### PR TITLE
test(unit): add schema and version assertion tests

### DIFF
--- a/tests/unit/test_compose_versions.py
+++ b/tests/unit/test_compose_versions.py
@@ -1,0 +1,124 @@
+"""
+Unit tests that assert Docker Compose image versions match expected targets.
+
+These tests catch accidental drift — e.g. someone changing a version string
+during an unrelated PR. Must pass before any version upgrade PR is merged.
+
+Run:  pytest tests/unit/test_compose_versions.py -v
+      (no running stack required — reads compose.yaml statically)
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Path to compose.yaml relative to this file's directory
+# ---------------------------------------------------------------------------
+COMPOSE_PATH = pathlib.Path(__file__).resolve().parents[2] / "compose.yaml"
+
+# ---------------------------------------------------------------------------
+# Expected image strings — update these ONLY when upgrading a service.
+# The key is the Docker Compose service name; the value is the full
+# registry/repo:tag string that must appear in compose.yaml.
+# ---------------------------------------------------------------------------
+EXPECTED_VERSIONS: dict[str, str] = {
+    "otel-collector": "otel/opentelemetry-collector-contrib:0.120.0",
+    "prometheus": "prom/prometheus:v2.55.1",
+    "alertmanager": "prom/alertmanager:v0.27.0",
+    "tempo": "grafana/tempo:2.10.5",
+    "loki": "grafana/loki:2.9.10",
+    "alloy": "grafana/alloy:v1.12.2",
+    "grafana": "grafana/grafana:10.4.5",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def compose_data() -> dict:
+    """Load and return the parsed compose.yaml as a dict."""
+    if not COMPOSE_PATH.exists():
+        pytest.fail(f"compose.yaml not found at {COMPOSE_PATH}")
+    with open(COMPOSE_PATH, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    assert isinstance(data, dict), "compose.yaml must parse to a mapping"
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestComposeImageVersions:
+    """Verify every tracked service has the exact expected image tag."""
+
+    @pytest.mark.parametrize(
+        "service,expected_image",
+        list(EXPECTED_VERSIONS.items()),
+        ids=list(EXPECTED_VERSIONS.keys()),
+    )
+    def test_image_version_matches(
+        self, compose_data: dict, service: str, expected_image: str
+    ) -> None:
+        """Assert the service exists and its image string matches exactly."""
+        services = compose_data.get("services")
+        assert services is not None, "compose.yaml has no 'services' key"
+        assert service in services, (
+            f"Service '{service}' is missing from compose.yaml — "
+            f"cannot verify image version"
+        )
+
+        actual_image = services[service].get("image")
+        assert actual_image is not None, (
+            f"Service '{service}' has no 'image' field in compose.yaml"
+        )
+        assert actual_image == expected_image, (
+            f"Service '{service}' image mismatch:\n"
+            f"  expected: {expected_image}\n"
+            f"  actual:   {actual_image}"
+        )
+
+    @pytest.mark.parametrize(
+        "service,expected_image",
+        list(EXPECTED_VERSIONS.items()),
+        ids=list(EXPECTED_VERSIONS.keys()),
+    )
+    def test_image_not_latest(
+        self, compose_data: dict, service: str, expected_image: str
+    ) -> None:
+        """Guard against accidental use of the 'latest' tag."""
+        services = compose_data.get("services", {})
+        if service not in services:
+            pytest.skip(f"Service '{service}' not present — covered by other test")
+        actual_image = services[service].get("image", "")
+        tag = actual_image.split(":")[-1] if ":" in actual_image else ""
+        assert tag != "latest", (
+            f"Service '{service}' uses ':latest' tag — pin to a specific version"
+        )
+
+    @pytest.mark.parametrize(
+        "service,expected_image",
+        list(EXPECTED_VERSIONS.items()),
+        ids=list(EXPECTED_VERSIONS.keys()),
+    )
+    def test_image_tag_not_empty(
+        self, compose_data: dict, service: str, expected_image: str
+    ) -> None:
+        """Guard against an empty or missing tag."""
+        services = compose_data.get("services", {})
+        if service not in services:
+            pytest.skip(f"Service '{service}' not present — covered by other test")
+        actual_image = services[service].get("image", "")
+        assert ":" in actual_image, (
+            f"Service '{service}' image '{actual_image}' has no tag — "
+            f"expected '{expected_image}'"
+        )
+        tag = actual_image.split(":")[-1]
+        assert tag != "", (
+            f"Service '{service}' image has an empty tag — "
+            f"expected '{expected_image}'"
+        )

--- a/tests/unit/test_grafana_dashboards.py
+++ b/tests/unit/test_grafana_dashboards.py
@@ -1,0 +1,152 @@
+"""
+Unit tests that validate Grafana dashboard JSON conventions.
+
+Checks:
+  - Top-level uid is present and uses an allowed prefix
+  - No numeric datasource IDs (deprecated in Grafana 12.x, removed in 13.x)
+  - schemaVersion is present
+
+Run:  pytest tests/unit/test_grafana_dashboards.py -v
+      (no running Grafana required — reads JSON files statically)
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+DASHBOARDS_DIR = pathlib.Path(__file__).resolve().parents[2] / "dashboards"
+
+# ---------------------------------------------------------------------------
+# Allowed UID prefixes — add new prefixes here, not in test logic
+# ---------------------------------------------------------------------------
+ALLOWED_UID_PREFIXES = ("ufawkesobs-", "platform-")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _find_dashboard_files() -> list[pathlib.Path]:
+    """Recursively find all *.json files under dashboards/."""
+    if not DASHBOARDS_DIR.is_dir():
+        return []
+    return sorted(DASHBOARDS_DIR.rglob("*.json"))
+
+
+def _load_dashboard(path: pathlib.Path) -> dict:
+    """Load and parse a dashboard JSON file."""
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert isinstance(data, dict), f"{path.name}: top-level JSON must be a mapping"
+    return data
+
+
+def _has_numeric_datasource_id(obj: object, path: str = "") -> list[str]:
+    """Recursively find datasource fields that use numeric IDs.
+
+    Grafana 12.x deprecates {"id": N, "type": "..."} datasource refs.
+    Grafana 13.x removes them entirely. Use {"uid": "...", "type": "..."} instead.
+
+    Returns a list of paths where numeric datasource IDs were found.
+    """
+    hits: list[str] = []
+    if isinstance(obj, dict):
+        # Only check 'datasource' keys — panel "id" fields are fine
+        if "datasource" in obj:
+            ds = obj["datasource"]
+            if isinstance(ds, dict) and "id" in ds and isinstance(ds["id"], (int, float)):
+                hits.append(f"{path}.datasource")
+        for k, v in obj.items():
+            hits.extend(_has_numeric_datasource_id(v, f"{path}.{k}"))
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            hits.extend(_has_numeric_datasource_id(item, f"{path}[{i}]"))
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Parametrize over discovered dashboard files
+# ---------------------------------------------------------------------------
+_dashboard_files = _find_dashboard_files()
+_dashboard_ids = [str(p.relative_to(DASHBOARDS_DIR)) for p in _dashboard_files]
+
+
+@pytest.fixture(scope="module")
+def dashboards() -> list[tuple[str, dict]]:
+    """Load all dashboards as (relative_path, parsed_json) pairs."""
+    return [(fid, _load_dashboard(fpath)) for fid, fpath in zip(_dashboard_ids, _dashboard_files)]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestGrafanaDashboardConventions:
+    """Validate dashboard JSON conventions for Grafana 12.x+ compatibility."""
+
+    @pytest.mark.parametrize("dashboard_id", _dashboard_ids, ids=_dashboard_ids)
+    def test_uid_present_and_valid_prefix(
+        self, dashboards: list[tuple[str, dict]], dashboard_id: str
+    ) -> None:
+        """Assert uid exists and starts with an allowed prefix."""
+        data = dict(dashboards).get(dashboard_id)
+        assert data is not None, f"Dashboard '{dashboard_id}' not loaded"
+
+        uid = data.get("uid")
+        assert uid is not None, (
+            f"Dashboard '{dashboard_id}' is missing top-level 'uid' field"
+        )
+        assert isinstance(uid, str) and len(uid) > 0, (
+            f"Dashboard '{dashboard_id}' has empty 'uid'"
+        )
+        assert uid.startswith(ALLOWED_UID_PREFIXES), (
+            f"Dashboard '{dashboard_id}' uid '{uid}' does not start with "
+            f"an allowed prefix {ALLOWED_UID_PREFIXES}"
+        )
+
+    @pytest.mark.parametrize("dashboard_id", _dashboard_ids, ids=_dashboard_ids)
+    def test_no_numeric_datasource_id(
+        self, dashboards: list[tuple[str, dict]], dashboard_id: str
+    ) -> None:
+        """Assert no panel or target uses the deprecated numeric datasource ID pattern.
+
+        Grafana 12.x deprecates {"id": N, "type": "..."} datasource refs.
+        Grafana 13.x removes them entirely. Use uid-based refs instead.
+        """
+        data = dict(dashboards).get(dashboard_id)
+        assert data is not None, f"Dashboard '{dashboard_id}' not loaded"
+
+        hits = _has_numeric_datasource_id(data)
+        assert not hits, (
+            f"Dashboard '{dashboard_id}' contains {len(hits)} numeric datasource ID "
+            f"reference(s) at: {', '.join(hits[:5])}. "
+            f"Replace with uid-based datasource references."
+        )
+
+    @pytest.mark.parametrize("dashboard_id", _dashboard_ids, ids=_dashboard_ids)
+    def test_schema_version_present(
+        self, dashboards: list[tuple[str, dict]], dashboard_id: str
+    ) -> None:
+        """Assert schemaVersion is present in the dashboard JSON."""
+        data = dict(dashboards).get(dashboard_id)
+        assert data is not None, f"Dashboard '{dashboard_id}' not loaded"
+
+        sv = data.get("schemaVersion")
+        assert sv is not None, (
+            f"Dashboard '{dashboard_id}' is missing 'schemaVersion' field"
+        )
+        assert isinstance(sv, (int, float)), (
+            f"Dashboard '{dashboard_id}' schemaVersion must be a number, "
+            f"got {type(sv).__name__}"
+        )
+
+    def test_dashboards_directory_graceful_skip(self) -> None:
+        """If dashboards/ has no JSON files, report 0 collected (not error)."""
+        count = len(_dashboard_files)
+        # This test always passes — it documents the graceful-skip behavior.
+        # The parametrized tests above will have 0 items if no files exist.
+        assert count >= 0, "Sanity check: count cannot be negative"

--- a/tests/unit/test_loki_schema.py
+++ b/tests/unit/test_loki_schema.py
@@ -1,0 +1,114 @@
+"""
+Unit tests that validate Loki config is compatible with Loki 3.x.
+
+Loki 3.x removed BoltDB entirely. These tests assert the config uses
+the tsdb storage schema and contains no BoltDB references.
+
+Run:  pytest tests/unit/test_loki_schema.py -v
+      (no running Loki required — reads config/loki/loki.yaml statically)
+
+Expected behavior:
+  - If loki.yaml uses boltdb: tests FAIL with clear messages (correct)
+  - If loki.yaml uses tsdb: tests PASS (correct)
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Path to loki.yaml relative to this file's directory
+# ---------------------------------------------------------------------------
+LOKI_CONFIG_PATH = pathlib.Path(__file__).resolve().parents[2] / "config" / "loki" / "loki.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def loki_config_raw() -> str:
+    """Return the raw text content of loki.yaml (for string searches)."""
+    if not LOKI_CONFIG_PATH.exists():
+        pytest.fail(f"loki.yaml not found at {LOKI_CONFIG_PATH}")
+    return LOKI_CONFIG_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def loki_config() -> dict:
+    """Load and return the parsed loki.yaml as a dict."""
+    if not LOKI_CONFIG_PATH.exists():
+        pytest.fail(f"loki.yaml not found at {LOKI_CONFIG_PATH}")
+    with open(LOKI_CONFIG_PATH, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    assert isinstance(data, dict), "loki.yaml must parse to a mapping"
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestLokiSchema3x:
+    """Validate Loki config is 3.x-compatible (no BoltDB, uses tsdb)."""
+
+    def test_no_boltdb_references(self, loki_config_raw: str) -> None:
+        """Assert the file contains NO references to boltdb or boltdb-shipper.
+
+        Loki 3.x removed BoltDB entirely. Any reference means the config
+        is incompatible and must be updated before upgrading.
+        """
+        lower = loki_config_raw.lower()
+        violations = []
+        if "boltdb-shipper" in lower:
+            violations.append("boltdb-shipper")
+        if "boltdb" in lower:
+            violations.append("boltdb")
+        assert not violations, (
+            f"loki.yaml contains BoltDB references: {', '.join(violations)}. "
+            f"Loki 3.x removed BoltDB entirely — migrate to tsdb storage schema."
+        )
+
+    def test_schema_config_exists(self, loki_config: dict) -> None:
+        """Assert schema_config.configs exists and is a non-empty list."""
+        schema_config = loki_config.get("schema_config")
+        assert schema_config is not None, (
+            "loki.yaml is missing 'schema_config' key"
+        )
+        configs = schema_config.get("configs")
+        assert configs is not None, (
+            "loki.yaml is missing 'schema_config.configs'"
+        )
+        assert isinstance(configs, list), (
+            f"schema_config.configs must be a list, got {type(configs).__name__}"
+        )
+        assert len(configs) > 0, (
+            "schema_config.configs is empty — at least one schema entry is required"
+        )
+
+    def test_all_schemas_use_tsdb(self, loki_config: dict) -> None:
+        """Assert every entry in schema_config.configs uses store: tsdb.
+
+        Loki 3.x only supports tsdb. BoltDB entries must be removed.
+        """
+        configs = loki_config.get("schema_config", {}).get("configs", [])
+        assert len(configs) > 0, "No schema configs to check"
+
+        for i, entry in enumerate(configs):
+            store = entry.get("store")
+            assert store == "tsdb", (
+                f"schema_config.configs[{i}] has store: '{store}' — "
+                f"expected 'tsdb'. Loki 3.x requires tsdb storage schema."
+            )
+
+    def test_no_boltdb_shipper_in_storage_config(self, loki_config: dict) -> None:
+        """Assert storage_config does not contain a boltdb_shipper key."""
+        storage_config = loki_config.get("storage_config")
+        assert storage_config is not None, (
+            "loki.yaml is missing 'storage_config' key"
+        )
+        assert "boltdb_shipper" not in storage_config, (
+            "storage_config contains 'boltdb_shipper' key — "
+            "remove it and use tsdb_shipper for Loki 3.x compatibility."
+        )


### PR DESCRIPTION
## Summary

Adds unit tests that guard against version drift and schema incompatibilities before upgrade PRs.

### Tests added (74 total)

| File | Tests | What it guards |
|------|-------|----------------|
|  | 21 | Pinned image versions in  — exact match, no `:latest`, no empty tags |
|  | 49 | Dashboard JSON conventions — uid prefix, no numeric datasource IDs, schemaVersion present |
|  | 4 | Loki 3.x config compatibility — no BoltDB refs, tsdb schema, no boltdb\_shipper |

### Services affected

- **compose.yaml** — tested but not modified
- **dashboards/** — tested but not modified  
- **config/loki/loki.yaml** — tested but not modified

### Run locally

```bash
pytest tests/unit/test_compose_versions.py tests/unit/test_grafana_dashboards.py tests/unit/test_loki_schema.py -v
```

### Secrets check

No secrets, credentials, or environment variables committed.

---

**AI-Assisted Review Block:**
- What changed: Three new test files for version and schema assertions
- Services affected: None modified — tests only read config/compose/dashboard files
- Port or volume changes: None
- Secrets check: Confirmed nothing sensitive committed