### PR TITLE
fix(alertmanager): upgrade v0.27.0 → v0.28.0 for CVE fixes

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -278,7 +278,7 @@ services:
     profiles: ["core"]
 
   alertmanager:
-    image: prom/alertmanager:v0.27.0
+    image: prom/alertmanager:v0.28.0
     container_name: alertmanager
     restart: unless-stopped
     command:

--- a/tests/unit/test_compose_versions.py
+++ b/tests/unit/test_compose_versions.py
@@ -28,7 +28,7 @@ COMPOSE_PATH = pathlib.Path(__file__).resolve().parents[2] / "compose.yaml"
 EXPECTED_VERSIONS: dict[str, str] = {
     "otel-collector": "otel/opentelemetry-collector-contrib:0.120.0",
     "prometheus": "prom/prometheus:v2.55.1",
-    "alertmanager": "prom/alertmanager:v0.27.0",
+    "alertmanager": "prom/alertmanager:v0.28.0",
     "tempo": "grafana/tempo:2.10.5",
     "loki": "grafana/loki:2.9.10",
     "alloy": "grafana/alloy:v1.12.2",


### PR DESCRIPTION
## Summary

fix(alertmanager): upgrade v0.27.0 → v0.28.0 for CVE fixes

### Changes

- Files changed: 2
- Lines added: 2
- Lines removed: 2

### Services affected

- compose.yaml
- tests/unit/test_compose_versions.py

### Run locally

```bash
pytest tests/unit/ -v
```

### Secrets check

No secrets, credentials, or environment variables committed.

---

**AI-Assisted Review Block:**
- What changed: fix(alertmanager): upgrade v0.27.0 → v0.28.0 for CVE fixes
- Services affected: See files changed
- Port or volume changes: None
- Secrets check: Confirmed nothing sensitive committed