### PR TITLE
fix(loki): upgrade v2.9.10 to v3.3.2 with config migration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -107,7 +107,7 @@ services:
     profiles: ["core"]
 
   loki:
-    image: grafana/loki:2.9.10
+    image: grafana/loki:3.3.2
     container_name: loki
     restart: unless-stopped
     command:

--- a/config/loki/loki.yaml
+++ b/config/loki/loki.yaml
@@ -32,7 +32,6 @@ storage_config:
   tsdb_shipper:
     active_index_directory: /loki/tsdb-index
     cache_location: /loki/tsdb-cache
-    shared_store: filesystem
   filesystem:
     directory: /loki/chunks
 
@@ -42,6 +41,7 @@ compactor:
   retention_enabled: true
   retention_delete_delay: 2h
   retention_delete_worker_count: 150
+  delete_request_store: filesystem
 
 limits_config:
   retention_period: 168h # 7 days
@@ -52,9 +52,6 @@ limits_config:
   per_stream_rate_limit: 5MB
   per_stream_rate_limit_burst: 15MB
   max_cache_freshness_per_query: 10m
-
-chunk_store_config:
-  max_look_back_period: 0s
 
 query_range:
   align_queries_with_step: true

--- a/tests/unit/test_compose_versions.py
+++ b/tests/unit/test_compose_versions.py
@@ -30,7 +30,7 @@ EXPECTED_VERSIONS: dict[str, str] = {
     "prometheus": "prom/prometheus:v2.55.1",
     "alertmanager": "prom/alertmanager:v0.28.0",
     "tempo": "grafana/tempo:2.10.5",
-    "loki": "grafana/loki:2.9.10",
+    "loki": "grafana/loki:3.3.2",
     "alloy": "grafana/alloy:v1.12.2",
     "grafana": "grafana/grafana:12.3.7",
 }

--- a/tests/unit/test_loki_schema.py
+++ b/tests/unit/test_loki_schema.py
@@ -112,3 +112,34 @@ class TestLokiSchema3x:
             "storage_config contains 'boltdb_shipper' key — "
             "remove it and use tsdb_shipper for Loki 3.x compatibility."
         )
+
+    def test_delete_request_store_configured(self, loki_config: dict) -> None:
+        """Assert compactor.delete-request-store is set when retention is enabled.
+
+        Loki 3.x requires delete-request-store when retention is enabled.
+        Missing this field causes a startup error.
+        """
+        compactor = loki_config.get("compactor")
+        assert compactor is not None, (
+            "loki.yaml is missing 'compactor' key"
+        )
+        retention_enabled = compactor.get("retention_enabled", False)
+        if retention_enabled:
+            delete_store = compactor.get("delete_request_store")
+            assert delete_store is not None, (
+                "compactor.retention_enabled is true but "
+                "compactor.delete_request_store is not set. "
+                "Loki 3.x requires delete-request-store when retention is enabled."
+            )
+
+    def test_no_shared_store_in_tsdb_shipper(self, loki_config: dict) -> None:
+        """Assert tsdb_shipper does not contain the removed shared_store field.
+
+        Loki 3.x removed the shared_store field from indexshipper.Config.
+        """
+        storage_config = loki_config.get("storage_config", {})
+        tsdb_shipper = storage_config.get("tsdb_shipper", {})
+        assert "shared_store" not in tsdb_shipper, (
+            "storage_config.tsdb_shipper contains 'shared_store' key — "
+            "this field was removed in Loki 3.x."
+        )


### PR DESCRIPTION
## Summary

fix(loki): upgrade v2.9.10 to v3.3.2 with config migration

### Changes

- Files changed: 4
- Lines added: 34
- Lines removed: 6

### Services affected

- compose.yaml
- config/loki/loki.yaml
- tests/unit/test_compose_versions.py
- tests/unit/test_loki_schema.py

### Run locally

```bash
pytest tests/unit/ -v
```

### Secrets check

No secrets, credentials, or environment variables committed.

---

**AI-Assisted Review Block:**
- What changed: fix(loki): upgrade v2.9.10 to v3.3.2 with config migration
- Services affected: See files changed
- Port or volume changes: None
- Secrets check: Confirmed nothing sensitive committed