### PR TITLE
docs: integrate specification, design, and implementation plan

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,161 @@
+# uFawkesObs — Design
+
+**Version:** 1.0.0
+**Date:** 2026-06-28
+**Depends on:** docs/specification.md v1.0.0
+**Repo:** paruff/uFawkesObs
+
+---
+
+## 1. Architectural Principles
+
+uFawkesObs is built upon five design tenets:
+
+1. **Composition Over Compilations:** Service definitions, volumes, networks, and environment bindings are orchestrated via a centralized, decoupled `compose.yaml` file using explicit profiles (`core` and `apps`).
+2. **GitOps Reconciliation:** Changes made to `config/**`, `compose.yaml`, `.env.example`, and `dashboards/**` are auto-reconciled on target environments by GHA-triggered workflows over SSH.
+3. **Hot Configuration Reloading:** Config-only updates use native runtime signaling (such as Prometheus HTTP POST `/-/reload` or Alloy `SIGHUP`) to prevent container downtime.
+4. **Self-Monitoring:** Every telemetry service in the plane exposes a `/metrics` target scraped by Prometheus, ensuring the observability substrate is itself observable.
+5. **Reproducible Local Simulation:** All integration and unit tests are designed to run fully locally without external infrastructure or cluster dependencies.
+
+---
+
+## 2. Repository Structure
+
+The actual file layout is structured as follows:
+
+```
+uFawkesObs/
+├── compose.yaml                      # Service definitions, volumes, and networks
+├── .env.example                      # Reference template for localized configurations
+├── config/                           # Declarative configurations per service
+│   ├── alertmanager/
+│   │   └── alertmanager.yml          # Alert routing, deduplication, and receivers
+│   ├── alloy/
+│   │   └── config.river              # River DSL configuration for log tailing
+│   ├── grafana/
+│   │   ├── grafana.ini               # Security, authentication, and database settings
+│   │   └── provisioning/             # Pre-configured dashboards and datasources
+│   │       ├── dashboards/
+│   │       └── datasources/
+│   ├── loki/
+│   │   └── loki.yaml                 # Index, schema, and retention rules
+│   ├── otel/
+│   │   └── collector.yaml            # Ingestion pipelines (metrics, traces, logs)
+│   ├── prometheus/
+│   │   ├── alerts.yml                # Alert thresholds
+│   │   └── prometheus.yaml           # Global configuration and scrapers
+│   └── tempo/
+│       └── tempo.yaml                # Trace ingestion ports and storage configs
+├── dashboards/                       # Provisioned dashboard JSON configurations
+├── data/                             # Host directory mounts for persistent volumes (gitignored)
+├── apps/
+│   └── telemetry-generator/          # Demo application mimicking standard OTLP workloads
+├── scripts/                          # Administration helpers and health verification tools
+├── tests/
+│   ├── unit/                         # Local config syntax, version, and model validators
+│   ├── integration/                  # Active container test cases (Prometheus, Grafana, Loki, Tempo)
+│   └── acceptance/                   # In-pipeline E2E observability checks
+└── .github/
+    └── workflows/
+        └── ci-pipeline.yml           # Unified pipeline running preflight, lint, security, build, tests
+```
+
+---
+
+## 3. Component Topology
+
+All services are orchestrated on a dedicated bridge network named `observability` (mapped externally to `observability-lab`).
+
+```
+                              ┌──────────────────────────────────┐
+                              │     Telemetry Generator App      │
+                              │       (OTLP gRPC Client)         │
+                              └────────────────┬─────────────────┘
+                                               │ OTLP / gRPC
+                                               ▼
+┌─────────────────────────── observability Network ──────────────────────────┐
+│                                                                            │
+│  ┌───────────────────────┐             ┌────────────────────────────────┐  │
+│  │   Docker Engine logs  │             │     OpenTelemetry Collector    │  │
+│  └──────────┬────────────┘             │            (Port 4317)         │  │
+│             │ container logs           └─┬──────────────┬─────────────┬─┘  │
+│             ▼                            │ OTLP/metrics │ OTLP/traces │    │
+│  ┌───────────────────────┐               │              │             │    │
+│  │     Grafana Alloy     │               ▼              ▼             ▼    │
+│  │     (Port 12345)      │         ┌───────────┐  ┌───────────┐ ┌────────┐ │
+│  └──────────┬────────────┘         │Prometheus │  │   Tempo   │ │  Loki  │ │
+│             │ loki push            │ (Port 9090│  │ (Port 3200│ │(Port   │ │
+│             └─────────────────────▶│   / 8889) │  │  / 9095)  │ │  3100) │ │
+│                                    └─────┬─────┘  └─────┬─────┘ └────┬───┘ │
+│                                          │              │            │     │
+│                                          ▼              ▼            ▼     │
+│                                    ┌─────────────────────────────────┐     │
+│                                    │             Grafana             │     │
+│                                    │           (Port 3000)           │     │
+│                                    └─────────────────────────────────┘     │
+│                                                                            │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Key Configuration Specifications
+
+### 4.1 OpenTelemetry Ingestion Pipeline
+
+The OpenTelemetry Collector is configured via `config/otel/collector.yaml` with dedicated receiver, processor, and exporter chains.
+
+- **Receivers:**
+  - `otlp`: Listens on `0.0.0.0:4317` (gRPC) and `0.0.0.0:4318` (HTTP).
+- **Processors:**
+  - `batch`: Groups telemetry data to optimize transport efficiency and DB write load.
+- **Exporters:**
+  - `prometheus`: Exposes a scrapable HTTP endpoint at port `8889` for metric data.
+  - `otlp/tempo`: Forwards incoming tracing directly to Tempo gRPC endpoint at `tempo:9095`.
+  - `otlp/loki`: Forwards structured log records to Loki at `http://loki:3100/loki/api/v1/push`.
+
+### 4.2 Log Collection & Processing
+
+Grafana Alloy (replacing Promtail) acts as our container log harvester via `config/alloy/config.river`.
+
+- **Discovery:** Targets the host container log directory using the Docker engine API via a local mount of `/var/run/docker.sock`.
+- **Parsing:** Parses container log formats, extracts metadata (container name, image tag, compose project, service name), and structures them into Loki labels.
+- **Exporting:** Forwards batch writes to Loki using the HTTP push protocol.
+
+### 4.3 Data Source and Dashboard Provisioning
+
+Grafana automatically configures datasources and preloads dashboards upon container boot via provisioning scripts:
+
+- **Prometheus:** Configured as the default datasource on `http://prometheus:9090`.
+- **Loki:** Mounted pointing to the Loki container at `http://loki:3100`.
+- **Tempo:** Mounted on `http://tempo:3200` with direct traces-to-logs integration enabled (referencing the Loki datasource UID).
+- **Dashboard Provisioning:** Scans `config/grafana/provisioning/dashboards/` for manifest maps linking to JSON templates in `/var/lib/grafana/dashboards/`.
+
+---
+
+## 5. Secret Management & Hardening
+
+- **No Hardcoded Values:** Secrets like Grafana admin passwords and database credentials are never committed.
+- **Environment Variable Substitution:** The `compose.yaml` utilizes environment variable bindings (such as `${GF_SECURITY_ADMIN_PASSWORD}`) sourced from a localized `.env` file (gitignored).
+- **Network Isolation:** Only essential UI/ingestion ports are bound to external host interfaces. Intra-plane service-to-service communication is entirely contained within the bridge network.
+
+---
+
+## 6. Forward-Looking Feature Designs
+
+### 6.1 Milestone 4: DORA & DevLake Integration Design
+
+- **Architecture Additions:** Add Apache DevLake and MySQL container dependencies in `compose.yaml` under the `dora` profile.
+- **Recording Rules:** Add PromQL recording rules in `config/prometheus/alerts.yml` (e.g. `dora:deployment_frequency:rate30d`) to allow instantaneous visualization queries.
+- **DORA Dashboard:** Provision `/config/grafana/provisioning/dashboards/dora-metrics.json` presenting historical trend lines and classification bands.
+
+### 6.2 Milestone 5: Kubernetes & Helm Migration Design
+
+- **Helm chart structure:** An umbrella Helm chart `helm/ufawkes-obs` containing separate sub-charts:
+  - `prometheus-community/prometheus`
+  - `grafana/grafana`
+  - `grafana/loki`
+  - `grafana/tempo`
+  - `grafana/alloy`
+- **NetworkPolicies:** Standard Kubernetes network segregation enforcing `restricted` security context.
+- **Secret Integration:** Map External Secrets Operator (ESO) resources pointing to Vault paths rather than local Compose environment variable bindings.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,195 @@
+# uFawkesObs — Implementation Plan
+
+**Version:** 1.0.0
+**Date:** 2026-06-28
+**Repo:** paruff/uFawkesObs
+**Status:** Active
+
+---
+
+## Guide to Using This Plan
+
+- This implementation plan guides the development of the uFawkesObs platform.
+- Tasks are derived from the actual open issues backlog in `gh issue list`.
+- Do not start any task until all its **Dependencies** are fully completed.
+- Every task must be verified with automated test gates (such as `make test`) before being marked complete.
+
+---
+
+## Milestone 2 — Docs, Metadata & Repository Hardening
+
+*Theme: Establish stable development workflow, document architecture limits, and configure standard PR gates.*
+
+### Task M2-01: Create CONTRIBUTING.md, CODE_OF_CONDUCT.md, and Issue Templates
+
+- **Description:** Establish community guidelines and create standardized issue templates for bugs and features.
+- **Backlog Issue:** #71
+- **Tasks:**
+  1. Author a comprehensive `CONTRIBUTING.md` detailing pytest instructions, pre-commit configuration, commit formats, and compose rules. (Already complete)
+  2. Create standard issue templates in `.github/ISSUE_TEMPLATE/` for bug reports and feature requests.
+  3. Formulate `CODE_OF_CONDUCT.md` following the Contributor Covenant.
+- **Acceptance Criteria:**
+  - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` exist in the repo root.
+  - `.github/ISSUE_TEMPLATE/bug_report.md` exists.
+
+### Task M2-04: Publish and Verify Platform Documentation
+
+- **Description:** Document current platform metrics, limits, and service inter-dependencies.
+- **Backlog Issue:** #74
+- **Tasks:**
+  1. Author `docs/ARCHITECTURE.md` mapping OTel Collector pipelines, service ports, and container dependencies. (Already complete)
+  2. Document `docs/KNOWN_LIMITATIONS.md` noting storage limits, retention behaviors, and development setups.
+  3. Establish `docs/CHANGE_IMPACT_MAP.md` mapping cross-service effects.
+- **Acceptance Criteria:**
+  - `docs/ARCHITECTURE.md`, `docs/KNOWN_LIMITATIONS.md`, and `docs/CHANGE_IMPACT_MAP.md` are present and valid markdown.
+
+### Task M2-05: Add Repository Metadata, Topics, and CI Badge
+
+- **Description:** Harden repo landing pages with metadata, appropriate topics, and automated workflow badges.
+- **Backlog Issue:** #75
+- **Dependencies:** M2-04
+- **Tasks:**
+  1. Add a live GitHub Actions CI pipeline passing status badge to `README.md`.
+  2. Update repo description, landing page URLs, and tags (such as `opentelemetry`, `prometheus`, `grafana`, `docker-compose`, `gitops`).
+- **Acceptance Criteria:**
+  - `README.md` includes the GHA badge.
+  - GitHub topics updated.
+
+---
+
+## Milestone 3 — Cross-Plane Integration Guides
+
+*Theme: Provide guides enabling other planes (e.g. uFawkesPipe, uFawkesDevX) to join the observability subnet.*
+
+### Task M3-01: Add uFawkesPipe Telemetry Integration Guide
+
+- **Description:** Guide developer teams on how to stream pipeline lifecycle tracing to uFawkesObs Tempo.
+- **Backlog Issue:** #76
+- **Tasks:**
+  1. Author `docs/examples/uFawkesPipe-integration.md`.
+  2. Provide clear examples of export headers, OTLP endpoint parameters (`otel-collector:4317`), and trace visualization procedures in Grafana.
+- **Acceptance Criteria:**
+  - `docs/examples/uFawkesPipe-integration.md` exists.
+
+### Task M3-02: Add uFawkesDevX Developer Telemetry Integration Guide
+
+- **Description:** Provide examples for developers to integrate application metrics/spans into the central OTel collector.
+- **Backlog Issue:** #77
+- **Tasks:**
+  1. Author `docs/examples/uFawkesDevX-integration.md`.
+  2. Provide code snippets (Python/Node/Go) explaining standard OpenTelemetry SDK setup pointing to uFawkesObs.
+- **Acceptance Criteria:**
+  - `docs/examples/uFawkesDevX-integration.md` exists.
+
+### Task M3-03: Register uFawkesObs in Backstage Catalog
+
+- **Description:** Add uFawkesObs metadata in the central Backstage platform catalog.
+- **Backlog Issue:** #78
+- **Tasks:**
+  1. Verify and populate `catalog-info.yaml` with service owner, system plane, lifecycle, and component taxonomy details.
+- **Acceptance Criteria:**
+  - `catalog-info.yaml` parses correctly and conforms to Backstage schema models.
+
+### Task M3-04: Update Multi-Stack Integration Guide
+
+- **Description:** Document compose project joining patterns to connect developer services to the local observability network.
+- **Backlog Issue:** #79
+- **Dependencies:** M3-01, M3-02
+- **Tasks:**
+  1. Update `docs/multi-stack-integration.md` with explicit details on how external compose networks join the `observability-lab` bridge.
+- **Acceptance Criteria:**
+  - `docs/multi-stack-integration.md` contains networking section with `external: true` example.
+
+---
+
+## Milestone 4 — DORA Metrics & DevLake Integration
+
+*Theme: Formulate the DORA metrics contract, provision Apache DevLake, and render dashboards.*
+
+### Task M4-01: Define DORA Data Contract
+
+- **Description:** Define what counts as a deployment, incident, and restoration within uFawkesObs telemetry.
+- **Backlog Issue:** #80
+- **Tasks:**
+  1. Create `docs/adr/ADR-004-dora-metric-definitions.md` detailing metric mappings and semantics.
+- **Acceptance Criteria:**
+  - ADR-004 exists and is linked from docs.
+
+### Task M4-02: Add DevLake + MySQL to Compose Stack under DORA Profile
+
+- **Description:** Integrate Apache DevLake database and worker instances into the docker-compose orchestration.
+- **Backlog Issue:** #81, #51
+- **Dependencies:** M4-01
+- **Tasks:**
+  1. Define `devlake` and `mysql` services inside `compose.yaml` under the `dora` profile.
+  2. Pin exact semantic images and define volume paths for persistent storage.
+  3. Define custom healthchecks for DevLake.
+- **Acceptance Criteria:**
+  - `docker compose --profile dora config` succeeds with zero parsing warnings.
+
+### Task M4-03: Add DORA Recording Rules to Prometheus
+
+- **Description:** Configure Prometheus recording rules inside uFawkesObs for continuous calculation of DORA metrics.
+- **Backlog Issue:** #82, #53
+- **Dependencies:** M4-02
+- **Tasks:**
+  1. Formulate recording rules for `dora:deployment_frequency:rate30d`, `dora:lead_time_hours:p50_30d`, `dora:change_failure_rate:ratio30d`, and `dora:mttr_hours:p50_30d` inside `config/prometheus/alerts.yml` (or dedicated recording rule file).
+- **Acceptance Criteria:**
+  - Prometheus rules load and parse cleanly.
+
+### Task M4-04: Provision Grafana DORA Metrics Dashboard
+
+- **Description:** Pre-provision a dedicated DORA dashboard in Grafana showing real-time calculations.
+- **Backlog Issue:** #83, #52
+- **Dependencies:** M4-03
+- **Tasks:**
+  1. Create `config/grafana/dashboards/dora-metrics.json` containing panel models for the 4 DORA indicators.
+  2. Enforce standard DORA performance bands (Elite/High/Medium/Low) using color thresholds.
+- **Acceptance Criteria:**
+  - Dashboard JSON exists and is mapped inside `config/grafana/provisioning/dashboards/`.
+
+---
+
+## Milestone 5 — Kubernetes & Helm Deployment Strategy
+
+*Theme: Scale the observability substrate from Docker Compose to cloud-native Kubernetes environments.*
+
+### Task M5-01: Document Kubernetes Deployment Strategy
+
+- **Description:** Author an ADR specifying the K8s migration path and architectural requirements.
+- **Backlog Issue:** #84
+- **Tasks:**
+  1. Create `docs/adr/ADR-005-kubernetes-migration.md`.
+- **Acceptance Criteria:**
+  - ADR-005 exists.
+
+### Task M5-02: Create Helm Chart for uFawkesObs Core Stack
+
+- **Description:** Create an umbrella Helm chart to deploy OTel, Prometheus, Loki, Tempo, Alloy, and Grafana.
+- **Backlog Issue:** #85
+- **Dependencies:** M5-01
+- **Tasks:**
+  1. Scaffold umbrella chart in `helm/ufawkes-obs/`.
+  2. Compile core observability dependencies as pinned Helm sub-charts.
+- **Acceptance Criteria:**
+  - `helm lint helm/ufawkes-obs/` passes with 0 warnings.
+
+### Task M5-03: Create k3d Local Simulator and Makefile Targets
+
+- **Description:** Add Makefile helpers to quickly spin up a local cluster and deploy uFawkesObs.
+- **Backlog Issue:** #86
+- **Dependencies:** M5-02
+- **Tasks:**
+  1. Add `make k3d-up`, `make k3d-down`, and `make helm-deploy` targets.
+- **Acceptance Criteria:**
+  - Running `make k3d-up` correctly boots k3d and deploys the Helm chart.
+
+### Task M5-04: Create Kubernetes Acceptance Testing Workflow
+
+- **Description:** Configure GitHub Actions workflows to verify Helm installations in a simulated cluster.
+- **Backlog Issue:** #87
+- **Dependencies:** M5-03
+- **Tasks:**
+  1. Configure GHA pipeline to boot a KinD/k3d cluster, install the Helm chart, and run verification probes.
+- **Acceptance Criteria:**
+  - GitHub Action parses cleanly and tests pass.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,118 @@
+# uFawkesObs — Specification
+
+**Version:** 1.0.0
+**Date:** 2026-06-28
+**Repo:** paruff/uFawkesObs
+**Plane:** Observability
+**Status:** Approved
+
+---
+
+## 1. Purpose
+
+uFawkesObs is the self-hosted, GitOps-first **Observability Plane** for the entire uFawkes suite. It delivers a consolidated telemetry substrate (metrics, logs, traces, and alert routing) to all developer and delivery tools within the ecosystem.
+
+Rather than having each repository or plane provision its own isolated, custom telemetry stack, all uFawkes components instruments into and integrates with uFawkesObs. It provides unified ingestion endpoints and a single pane of glass for visualization.
+
+---
+
+## 2. Scope Boundaries
+
+### In Scope
+
+- **Metrics Collection & Storage:** Prometheus scrapes metrics from target hosts, exporter processes, and OTel endpoints.
+- **Log Aggregation:** Loki aggregates system and container-level logs shipped via Alloy.
+- **Trace Aggregation:** Tempo provides highly scalable distributed trace storage for OTLP spans.
+- **Unified Telemetry Ingestion:** OpenTelemetry Collector processes and routes OTLP metric, log, and trace streams.
+- **Container Log Discovery:** Grafana Alloy discovers and streams Docker container stdout/stderr log pipelines.
+- **Alert Ingestion & Routing:** Alertmanager handles alert deduplication and notification dispatch.
+- **Visualization & Provisioning:** Grafana pre-provisions dashboards, datasource definitions, and permissions.
+- **GitOps Reconciliation:** Auto-reconciliation of runtime configurations and stack deployment via SSH-triggered workflows.
+
+### Out of Scope — Forever
+
+- **CI/CD Orchestration:** uFawkesPipe owns all integration pipelines and workflow execution.
+- **Secret Management Substrate:** Vault/uFawkesSec manages root credentials and rotation. uFawkesObs only consumes secrets via `.env` injection.
+- **Platform Engineering CLI & Portal:** The centralized developer interface and portal (fawkes) embeds or queries uFawkesObs but does not replace it.
+
+---
+
+## 3. Versioned Milestones
+
+| Milestone | Theme | Scope | Status |
+|---|---|---|---|
+| **M1 (v1.0.0)** | Substrate Core | Core Docker Compose stack (OTel Collector, Prometheus, Alertmanager, Tempo, Loki, Alloy, Grafana) with automated local unit/integration test gates. | **Completed** |
+| **M2 (v1.1.0)** | Repo Hardening | Standardized CONTRIBUTING rules, issue templates, ARCHITECTURE mapping, KNOWN_LIMITATIONS documentation, and repo badges. | **Backlog** (M2-01 to M2-05) |
+| **M3 (v1.2.0)** | Cross-Plane Docs | Structured guides for joining uFawkesPipe, uFawkesDevX, and Backstage catalog registration. | **Backlog** (M3-01 to M3-04) |
+| **M4 (v1.3.0)** | DORA & DevLake | DevLake + MySQL profile addition, Prometheus DORA recording rules, and Grafana DORA metric dashboard. | **Backlog** (M4-01 to M4-04) |
+| **M5 (v2.0.0)** | Kubernetes Deploy | Kubernetes deployment ADR, Helm charts for the core stack, k3d local simulator, and k8s-based acceptance pipelines. | **Backlog** (M5-01 to M5-04) |
+
+---
+
+## 4. Functional Requirements
+
+### 4.1 M1 (v1.0.0) — Core Observability Substrate
+
+- **OBS-F01:** Expose an OpenTelemetry Collector OTLP endpoint (gRPC 4317 / HTTP 4318) for incoming trace, metric, and log streams.
+- **OBS-F02:** Automatically scrape container logs via Grafana Alloy using Docker socket monitoring and forward them structured to Loki.
+- **OBS-F03:** Scrape system/hardware metrics from target hosts via Prometheus Node Exporter.
+- **OBS-F04:** Provide pre-provisioned, declarative datasources in Grafana pointing to Prometheus, Loki, Tempo, and Alertmanager.
+- **OBS-F05:** Pre-load system performance dashboards for host system, container logs, and telemetry flow metrics.
+- **OBS-F06:** Run automated health checking of all stack services via Docker Compose healthchecks and local test automation.
+
+### 4.2 Backlog — Repository Hardening & Cross-Plane (M2 & M3)
+
+- **OBS-F10:** Document the precise network join patterns in `multi-stack-integration.md` to allow other planes (e.g., developerd, deliveryd) to join the `observability-lab` Docker bridge network.
+- **OBS-F11:** Register uFawkesObs into fawkes Backstage catalog-info.yaml metadata.
+- **OBS-F12:** Provide clear guide explaining how uFawkesPipe CI pipelines can export OTLP tracing to uFawkesObs Tempo.
+
+### 4.3 Backlog — DORA & DevLake Integration (M4)
+
+- **OBS-F20:** Add Apache DevLake and MySQL to `compose.yaml` under a configurable `dora` Docker Compose profile.
+- **OBS-F21:** Define the schema contract mapping of what counts as a deployment, incident, and lead-time event inside uFawkesObs.
+- **OBS-F22:** Implement Prometheus recording rules inside `config/prometheus/alerts.yml` (or dedicated rules file) computing Deployment Frequency, Lead Time for Changes, Change Failure Rate, and Mean Time to Restore (MTTR).
+- **OBS-F23:** Pre-provision a "DORA Metrics" Grafana dashboard showing historical stat panels and trendlines for all 4 DORA indicators.
+
+### 4.4 Backlog — Kubernetes & Helm Deployment (M5)
+
+- **OBS-F30:** Formulate an Architecture Decision Record (ADR-004) specifying the migration path from Docker Compose orchestration to native Kubernetes resources.
+- **OBS-F31:** Author a Helm umbrella chart (`helm/ufawkes-obs`) compiling Prometheus, Loki, Tempo, Grafana, Alloy, and OTel Collector as standard sub-charts.
+- **OBS-F32:** Provide a local k3d Kubernetes bootstrap script/Makefile command to run acceptance verification in-cluster.
+
+---
+
+## 5. Non-Functional Requirements
+
+- **OBS-N01 (Unit Tests):** Maintain a suite of unit test validators verifying configuration files (yaml parser syntax, correct ports, required sections) for Loki, Prometheus, OTel, and Grafana.
+- **OBS-N02 (Integration Tests):** Require integration test cases that run containerized against active compose services to verify end-to-end trace queries, log searches, and scrape targets.
+- **OBS-N03 (Scrape Frequency):** Default scrape interval set to `30s` for standard workloads, minimizing resource overhead while providing high resolution.
+- **OBS-N04 (Zero Secret Commits):** Absolutely zero credentials, API keys, or database passwords in source files or configuration manifests. Enforce via Gitleaks and Yelp detect-secrets pre-commit hooks.
+- **OBS-N05 (Pinned Versions):** All third-party images defined in `compose.yaml` must be explicitly pinned to precise semantic versions (no `latest` or floating tag versions allowed).
+
+---
+
+## 6. Interface Contracts
+
+| Interface | Direction | Protocol / Port | Purpose | Consumer |
+|---|---|---|---|---|
+| **OTLP Ingestion** | Inbound | gRPC 4317 / HTTP 4318 | Standardized telemetry stream ingestion (Metrics, Logs, Traces) | uFawkesPipe, uFawkesDevX, and custom apps |
+| **Log Collection** | Pull | Docker API Socket | Harvest host container logs via Alloy daemon | Local Docker Engine |
+| **Scrape Targets** | Pull | HTTP `/metrics` | Prometheus pulls performance indicators | OTel Collector, Alloy, Node Exporter, custom apps |
+| **Alert manager API** | Inbound | HTTP 9093 | Prometheus fires alerts on breach of rules | Prometheus, custom alerting proxies |
+| **Query Engine APIs** | Inbound | HTTP `/api/v1` | External services query Prometheus/Loki/Tempo databases | Grafana, uFawkesAI/measure, DevLake |
+| **Visualization portal** | Inbound | HTTP 3000 | Developer and platform monitoring dashboard | Platform engineers, developers |
+
+---
+
+## 7. Confirmed Stack
+
+| Component | Version | Role | Mount / Vol Data | Configuration File |
+|---|---|---|---|---|
+| **OpenTelemetry Collector** | `0.120.0` | Telemetry processing and fanout | None | `config/otel/collector.yaml` |
+| **Prometheus** | `v2.55.1` | Metrics TSDB & scrape engine | `./data/prometheus` | `config/prometheus/prometheus.yaml` |
+| **Alertmanager** | `v0.27.0` | Notification aggregator & router | `./data/alertmanager` | `config/alertmanager/alertmanager.yml` |
+| **Tempo** | `2.10.5` | Distributed trace database | `./data/tempo` | `config/tempo/tempo.yaml` |
+| **Loki** | `2.9.10` | Log indexer & backend | `./data/loki` | `config/loki/loki.yaml` |
+| **Alloy** | `v1.12.2` | Container log discovery & forwarding | `./data/alloy` | `config/alloy/config.river` |
+| **Grafana** | `10.4.5` | Metrics, logs, & trace dashboard UI | `./data/grafana` | `config/grafana/grafana.ini` |
+| **Node Exporter** | `v1.8.1` | Host system exporter | Host read mounts | None |


### PR DESCRIPTION
## Summary

Revise all three planning documents (`docs/specification.md`, `docs/design.md`, `docs/plan.md`) to align with the **actual** uFawkesObs codebase.

### Problem

The previous versions were written without repo access ("source transparency: uFawkesObs is a private repo not readable at time of writing"). They described a **Kubernetes/Helm/Python-daemon** architecture that does not match reality. The actual uFawkesObs is a **Docker Compose observability stack** with:

- OpenTelemetry Collector v0.120.0
- Prometheus v2.55.1 / Alertmanager v0.27.0
- Tempo 2.10.5 / Loki 2.9.10
- Grafana Alloy v1.12.2 (log collection)
- Grafana 10.4.5

### Changes

| Document | What Changed |
|---|---|
| **specification.md** | Rewrote scope boundaries (Alloy replaces Fluent Bit, no OTel Operator, no Postgres/MinIO deps). Defined milestones aligned with open GitHub issues (#71-#87). Corrected interface contracts and confirmed stack table with real versions. |
| **design.md** | Replaced Helm/daemon architecture with real Docker Compose topology. Added actual port map, network design, volume mounts, OTel Collector pipeline design, and Alloy River config. Forward designs for M4 (DevLake dora profile) and M5 (Helm umbrella chart). |
| **plan.md** | Restructured into milestones matching open GitHub issues (#71-#87). Each task references its backlog issue. Realistic sequencing: M2 (docs) → M3 (guides) → M4 (DORA) → M5 (K8s). Machine-verifiable acceptance criteria per task. |

### Verification

- [x] Pre-commit hooks pass (trailing-whitespace, markdownlint, Gitleaks, detect-secrets)
- [x] Three files created as new files (474 insertions, 0 deletions)
- [x] Contents verified against actual repo architecture via `docs/ARCHITECTURE.md`, `compose.yaml`, and `config/`