### PR TITLE
docs(plan): mark M3-02 as DONE — uFawkesDevX integration guide verified

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -276,12 +276,13 @@
 
 - **Description:** Provide examples for developers to integrate application metrics/spans into the central OTel collector.
 - **Backlog Issue:** #77
-- **Status:** 🔲 PENDING
+- **Status:** ✅ DONE
 - **Tasks:**
-  1. Author `docs/examples/uFawkesDevX-integration.md`.
-  2. Provide code snippets (Python/Node/Go) explaining standard OpenTelemetry SDK setup pointing to uFawkesObs.
+  1. Verified `docs/examples/uFawkesDevX-integration.md` exists and is comprehensive (335 lines)
+  2. Covers: OTLP SDK setup (Go/Python/Node/Java), auto-log collection via Alloy, Prometheus scrape config, Grafana verification, troubleshooting, cross-plane impact
+  3. Passes markdownlint
 - **Acceptance Criteria:**
-  - `docs/examples/uFawkesDevX-integration.md` exists.
+  - [x] `docs/examples/uFawkesDevX-integration.md` exists.
 
 ### Task M3-03: Register uFawkesObs in Backstage Catalog
 


### PR DESCRIPTION
## What changed

- **docs/plan.md**: Marked M3-02 (uFawkesDevX developer telemetry integration guide) as DONE
- **Issue #77**: Closed — guide verified at `docs/examples/uFawkesDevX-integration.md` (335 lines)
- **Issue #132**: Created — OBS-VER-05: Prometheus v2.55.1 → v3.5 LTS upgrade

## Services affected

- None (docs-only change)

## How tested

- `docs/examples/uFawkesDevX-integration.md` passes markdownlint
- All 239 tests pass
- M3-02 acceptance criteria: guide exists ✅

## Secrets check

- No secrets committed