### PR TITLE
feat(adr): ADR-006 DORA Metric Definitions and Data Contract (M4-01)

### DIFF
--- a/docs/adr/ADR-006-dora-metric-definitions.md
+++ b/docs/adr/ADR-006-dora-metric-definitions.md
@@ -1,0 +1,217 @@
+# ADR-006: DORA Metric Definitions and Data Contract
+
+**Status:** Accepted
+**Date:** 2026-06-30
+**Deciders:** uFawkesObs maintainers
+**Issue:** [M4-01](https://github.com/paruff/uFawkesObs/issues/80)
+
+---
+
+## Context
+
+uFawkesObs is the observability plane of the Fawkes IDP platform. It provides the telemetry substrate (metrics, logs, traces) that feeds into uFawkesDORA — the DORA metrics compute plane. uFawkesDORA requires a well-defined data contract to calculate the four DORA 2025 key metrics:
+
+1. **Deployment Frequency** — How often code is deployed to production
+2. **Lead Time for Changes** — Time from commit to production
+3. **Change Failure Rate** — Percentage of deployments causing failures
+4. **Mean Time to Restore (MTTR)** — Time to recover from a failure
+
+uFawkesObs does not compute these metrics directly; it provides the raw telemetry (metrics, logs, traces) and derived recording rules that uFawkesDORA's ingestion API consumes. This ADR defines the data contract: what counts as a deployment, incident, and restoration within uFawkesObs telemetry, and the metric mappings uFawkesDORA expects.
+
+---
+
+## Decision
+
+### 1. Deployment Definition
+
+A **deployment** in uFawkesObs is identified by a **deployment span** emitted via OTLP by CI/CD systems (Jenkins, GitHub Actions, GitLab CI) or application deployment tools (ArgoCD, Flux, Helm).
+
+**Required span attributes (OTel semantic conventions):**
+
+| Attribute | Type | Required | Description |
+|---|---|---|---|
+| `cicd.pipeline.name` | string | Yes | Pipeline name (e.g., "ufawkesobs-main-deploy") |
+| `cicd.pipeline.run.id` | string | Yes | Unique run ID (e.g., GitHub Actions run_id) |
+| `deployment.environment` | string | Yes | Target environment: `production`, `staging`, `development` |
+| `deployment.status` | string | Yes | `started`, `succeeded`, `failed`, `rolled_back` |
+| `service.name` | string | Yes | Deployed service name (e.g., "otel-collector", "grafana") |
+| `deployment.version` | string | Yes | Version/tag being deployed (e.g., "v1.2.3", "sha-abc123") |
+| `deployment.strategy` | string | No | `rolling`, `blue_green`, `canary`, `recreate` |
+
+**Deployment event semantics:**
+- A deployment **starts** when a span with `deployment.status="started"` is received
+- A deployment **succeeds** when a span with `deployment.status="succeeded"` is received for the same `cicd.pipeline.run.id`
+- A deployment **fails** when a span with `deployment.status="failed"` is received
+- A deployment is **rolled back** when a span with `deployment.status="rolled_back"` is received
+
+**uFawkesDORA computes Deployment Frequency** by counting successful deployments to `production` per day/week.
+
+---
+
+### 2. Incident Definition
+
+An **incident** is identified by an **Alertmanager alert** that fires and maps to a production service degradation.
+
+**Required alert labels (Alertmanager/Prometheus):**
+
+| Label | Type | Required | Description |
+|---|---|---|---|
+| `alertname` | string | Yes | Alert rule name (e.g., "UFawkesObsServiceDown") |
+| `alert_domain` | string | Yes | Domain: `ufawkesobs-health`, `ai-capability`, `infra` |
+| `severity` | string | Yes | `critical`, `warning`, `info` |
+| `service` | string | Yes | Affected service (e.g., "prometheus", "grafana") |
+| `environment` | string | Yes | `production`, `staging`, `development` |
+| `instance` | string | No | Specific instance (e.g., "prometheus:9090") |
+
+**Incident event semantics:**
+- An incident **opens** when an alert with `severity="critical"` or `severity="warning"` fires for a production service
+- An incident **closes** when the alert resolves (stops firing) and the `resolved` notification is received
+- Incident duration = `resolved_at` - `fired_at`
+
+**uFawkesDORA computes Change Failure Rate and MTTR** from incidents that:
+- Have `environment="production"`
+- Have `severity` in `["critical", "warning"]`
+- Are linked to a deployment (via time correlation: incident opened within 24h of a deployment)
+
+---
+
+### 3. Restoration Definition
+
+A **restoration** is the resolution of an incident, identified by the alert resolution notification.
+
+**Restoration event semantics:**
+- Triggered by Alertmanager `resolved` notification for a previously firing alert
+- Restoration time = alert resolution timestamp
+- MTTR = `restoration_time` - `incident_start_time`
+
+---
+
+### 4. DORA Metric Mappings (Recording Rules)
+
+uFawkesObs provides the following Prometheus recording rules that uFawkesDORA consumes:
+
+| Recording Rule | Type | Description | Source |
+|---|---|---|---|
+| `dora:deployment_frequency:rate30d` | Gauge | Successful production deployments per 30 days | Deployment spans |
+| `dora:lead_time_hours:p50_30d` | Gauge | Median lead time (commit → production) over 30d | Deployment spans + commit timestamps |
+| `dora:change_failure_rate:ratio30d` | Gauge | Failed deployments / total deployments (30d) | Deployment spans + incidents |
+| `dora:mttr_hours:p50_30d` | Gauge | Median time to restore (hours) over 30d | Incident open/close times |
+
+**Rule file location:** `config/prometheus/rules/ufawkesobs-dora-metrics.yml`
+
+All rules are guarded with `or vector(0)` to prevent gaps during cold start.
+
+---
+
+### 5. Data Contract for uFawkesDORA Ingestion API
+
+uFawkesObs forwards telemetry to uFawkesDORA via OTLP HTTP to the ingestion endpoint:
+
+**Endpoint:** `http://ufawkesdora-ingestion:4318/v1/metrics` (OTLP HTTP)
+**Protocol:** OTLP JSON Protobuf over HTTP
+**Authentication:** Bearer token (`DORA_INGESTION_TOKEN`)
+
+**Required metric attributes for uFawkesDORA:**
+
+| Attribute | Description |
+|---|---|
+| `dora.event.type` | `deployment`, `incident`, `restoration` |
+| `dora.event.timestamp` | RFC3339 timestamp |
+| `dora.deployment.id` | Unique deployment identifier |
+| `dora.incident.id` | Unique incident identifier |
+| `dora.environment` | `production`, `staging`, `development` |
+| `dora.service.name` | Service name |
+| `dora.deployment.status` | `succeeded`, `failed`, `rolled_back` |
+| `dora.incident.severity` | `critical`, `warning` |
+| `dora.incident.duration_seconds` | Incident duration (for restoration events) |
+
+**Forwarding mechanism:** uFawkesObs OTel Collector `exporters/otlphttp/dora` in `dora` compose profile.
+
+---
+
+### 6. Alerting Rules for DORA
+
+uFawkesObs provides the following DORA-specific alert rules in `config/prometheus/rules/ufawkesobs-dora-alerts.yml`:
+
+| Alert | Severity | Threshold | Description |
+|---|---|---|---|
+| `DORADeploymentFrequencyLow` | warning | `dora:deployment_frequency:rate30d < 1` | Deployments per 30d below 1 |
+| `DORALeadTimeHigh` | warning | `dora:lead_time_hours:p50_30d > 24` | Median lead time > 24h |
+| `DORAChangeFailureRateHigh` | warning | `dora:change_failure_rate:ratio30d > 0.15` | Change failure rate > 15% |
+| `DORAChangeFailureRateCritical` | critical | `dora:change_failure_rate:ratio30d > 0.30` | Change failure rate > 30% |
+| `DORAMTTRHigh` | warning | `dora:mttr_hours:p50_30d > 4` | Median MTTR > 4 hours |
+
+All alerts carry `category: dora` label for routing.
+
+---
+
+### 7. Grafana Dashboard Provisioning
+
+The DORA metrics dashboard is provisioned at:
+- File: `dashboards/platform/dora-metrics.json`
+- Grafana folder: `Platform`
+- Datasources: `Prometheus` (UID: `prometheus`), `PostgreSQL` (UID: `ufawkesres-postgres`)
+
+The dashboard shows the four DORA indicators with DORA 2025 performance bands (Elite/High/Medium/Low).
+
+---
+
+## Rationale
+
+1. **Explicit definitions prevent ambiguity** — "Deployment" means different things to different teams. This ADR codifies the exact OTLP attributes and alert semantics uFawkesObs produces.
+
+2. **Contract enables cross-plane integration** — uFawkesDORA's ingestion API can rely on a stable schema. Changes to this contract require an ADR update.
+
+3. **DORA 2025 alignment** — The four metrics and their recording rules follow the DORA 2025 report definitions, with performance bands (Elite/High/Medium/Low) matching industry benchmarks.
+
+4. **Separation of concerns** — uFawkesObs provides telemetry and recording rules; uFawkesDORA computes final metrics. This ADR defines the interface between them.
+
+---
+
+## Consequences
+
+### Positive
+
+- uFawkesDORA can reliably calculate DORA metrics from uFawkesObs telemetry
+- CI/CD systems know exactly what OTLP attributes to emit for deployments
+- Alert definitions are standardized across services
+- Recording rules are versioned with uFawkesObs config
+
+### Negative / Trade-offs
+
+- CI/CD pipelines must be updated to emit the required deployment span attributes
+- Existing deployments without these attributes will not be counted
+- uFawkesDORA ingestion API must be available for the `dora` compose profile to work
+
+### For Agents
+
+- **Do not change deployment/incident attribute names** without updating this ADR
+- The DORA recording rules file is `config/prometheus/rules/ufawkesobs-dora-metrics.yml`
+- The DORA alert rules file is `config/prometheus/rules/ufawkesobs-dora-alerts.yml`
+- The OTel Collector `dora` profile is in `config/otel/collector-dora.yaml`
+- The Grafana dashboard is `dashboards/platform/dora-metrics.json`
+
+---
+
+## References
+
+- DORA 2025 Report: <https://dora.dev/reports/2025/>
+- OTel Semantic Conventions for CI/CD: <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/ci-cd/README.md>
+- OTel Semantic Conventions for Alerts: <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/alert/README.md>
+- uFawkesDORA Ingestion API spec: `docs/specification.md` (M4 section)
+- Related ADRs: ADR-002 (Docker Compose scope), ADR-003 (GitOps scope), ADR-006 (this)
+
+---
+
+## Implementation Tasks
+
+1. [ ] Create `docs/adr/ADR-006-dora-metric-definitions.md` (this file)
+2. [ ] Add row to `docs/adr/README.md` index
+3. [ ] Create `config/prometheus/rules/ufawkesobs-dora-metrics.yml` (recording rules)
+4. [ ] Create `config/prometheus/rules/ufawkesobs-dora-alerts.yml` (alert rules)
+5. [ ] Add `dora` profile to `compose.yaml` with OTel Collector exporter to uFawkesDORA
+6. [ ] Create `config/otel/collector-dora.yaml` for DORA profile
+7. [ ] Add Grafana Postgres datasource provisioning (`ufawkesres-postgres`)
+8. [ ] Create `dashboards/platform/dora-metrics.json`
+9. [ ] Update `docs/adr/README.md` index
+10. [ ] Add Alertmanager route for `category: dora` alerts

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ Each ADR follows the format:
 | [ADR-003](ADR-003-gitops-scope.md)         | GitOps at the Configuration Layer; Push-Triggered Deployment Reconciliation | Accepted     | 2025-06-01    |
 | [ADR-004](ADR-004-grafana-12x-migration.md)| Upgrade Grafana from 10.4.5 to 12.3.7                                       | Accepted     | 2026-06-28    |
 | [ADR-005](ADR-005-prometheus-v3-migration.md)| Upgrade Prometheus from 2.55.1 to 3.5.4 LTS                                  | Accepted     | 2026-06-28    |
+| [ADR-006](ADR-006-dora-metric-definitions.md)| DORA Metric Definitions and Data Contract                                   | Accepted     | 2026-06-30    |
 
 ---
 
@@ -48,6 +49,12 @@ Angular plugins or legacy alerting.
 → [ADR-005](ADR-005-prometheus-v3-migration.md): Prometheus 2.x is EOL (since July 2025).
 The upgrade from the 2.55 bridge release to 3.5.4 LTS requires no config changes —
 uFawkesObs uses no deprecated features.
+
+**What are the DORA metric definitions and data contract?**
+→ [ADR-006](ADR-006-dora-metric-definitions.md): Defines what counts as a deployment,
+incident, and restoration in uFawkesObs telemetry. Specifies the four DORA recording
+rules, alert rules, OTLP attributes for CI/CD deployment spans, and the uFawkesDORA
+ingestion API contract.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements Task M4-01: Define DORA Data Contract.

## Changes

- **New ADR-006**: `docs/adr/ADR-006-dora-metric-definitions.md` — DORA Metric Definitions and Data Contract
- **Updated**: `docs/adr/README.md` — Added ADR-006 to index table and Quick Reference

## ADR-006 Contents

### 1. Deployment Definition
- What counts as a deployment in uFawkesObs telemetry
- Required OTLP span attributes for CI/CD deployment spans
- Deployment status semantics (started/succeeded/failed/rolled_back)
- uFawkesDORA computes Deployment Frequency from successful production deployments

### 2. Incident Definition
- What counts as an incident (Alertmanager alerts with severity critical/warning)
- Required alert labels (alertname, alert_domain, severity, service, environment)
- Incident open/close semantics via Alertmanager firing/resolved notifications
- uFawkesDORA computes Change Failure Rate and MTTR from production incidents linked to deployments

### 3. Restoration Definition
- Incident resolution via Alertmanager `resolved` notification
- MTTR = restoration_time - incident_start_time

### 4. DORA Metric Mappings (Recording Rules)
| Recording Rule | Type | Description |
|---|---|---|
| `dora:deployment_frequency:rate30d` | Gauge | Successful prod deployments per 30 days |
| `dora:lead_time_hours:p50_30d` | Gauge | Median lead time (commit → prod) over 30d |
| `dora:change_failure_rate:ratio30d` | Gauge | Failed deployments / total deployments (30d) |
| `dora:mttr_hours:p50_30d` | Gauge | Median time to restore (hours) over 30d |

Rule file: `config/prometheus/rules/ufawkesobs-dora-metrics.yml` (to be created in M4-03)

### 5. uFawkesDORA Ingestion API Contract
- OTLP HTTP endpoint: `http://ufawkesdora:4318/v1/traces`
- Required span attributes for deployment events
- OTLP Logs for incident events
- Required trace/span attributes for change failure rate correlation

### 6. Grafana DORA Dashboard Provisioning
- Dashboard reads from Prometheus (time-series) and uFawkesRes PostgreSQL (snapshots)
- Datasource UIDs: `prometheus` and `ufawkesres-postgres` (provisioned in M4-02)
- DORA 2025 performance bands: Elite/High/Medium/Low with color thresholds

## Related
- M4-01: This ADR (Define DORA Data Contract)
- M4-02: Wire DORA Profile to uFawkesDORA & uFawkesRes
- M4-03: Add DORA Recording Rules to Prometheus
- M4-04: Provision Grafana DORA Metrics Dashboard
