### PR TITLE
fix(workflow): correct if condition syntax in deploy.yml trigger expressions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,8 +60,10 @@ jobs:
     needs: detect-changes
     # For workflow_run trigger, ensure acceptance-full passed
     if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      (github.event_name == 'push')
+      (
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'push')
+      ) &&
       needs.detect-changes.outputs.reload_changed == 'true' &&
       needs.detect-changes.outputs.compose_changed != 'true' &&
       needs.detect-changes.outputs.non_reloadable_config_changed != 'true'
@@ -195,10 +197,14 @@ jobs:
     name: Deploy (compose restart)
     needs: detect-changes
     if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      (github.event_name == 'push')
-      needs.detect-changes.outputs.compose_changed == 'true' ||
-      needs.detect-changes.outputs.non_reloadable_config_changed == 'true'
+      (
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'push')
+      ) &&
+      (
+        needs.detect-changes.outputs.compose_changed == 'true' ||
+        needs.detect-changes.outputs.non_reloadable_config_changed == 'true'
+      )
     runs-on: ubuntu-latest
     environment: compose-restart
     outputs:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,7 +127,7 @@
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "5d84388a65394db41cddc26d73ca689a9394a36f",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 81
       }
     ],
     "docs/loki-operations.md": [
@@ -158,5 +158,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-30T07:44:38Z"
+  "generated_at": "2026-07-01T09:09:59Z"
 }


### PR DESCRIPTION
## Summary

The `if:` conditions in two deploy jobs (`deploy-config-reload` and `deploy-compose-restart`) had syntax errors. The trigger condition `(github.event_name == "workflow_run" && ...) || (github.event_name == "push")` was followed by `needs.detect-changes.outputs.*` references without a logical operator (`&&`), causing GitHub Actions to fail to parse the workflow.

Root cause: The `||` on line 64 (and 201) was immediately followed by `needs.detect-changes...` on the next line without an explicit `&&` operator, producing invalid expression syntax like `...|| (github.event_name == "push") needs.detect-changes.outputs...`.

Fix: Wrapped the trigger condition in parentheses and connected it with `&&` to the `needs.*` conditions.

### Before
```yaml
if: |
  (github.event_name == "workflow_run" && github.event.workflow_run.conclusion == "success") ||
  (github.event_name == "push")
  needs.detect-changes.outputs.reload_changed == "true" &&
  ...
```

### After
```yaml
if: |
  (
    (github.event_name == "workflow_run" && github.event.workflow_run.conclusion == "success") ||
    (github.event_name == "push")
  ) &&
  needs.detect-changes.outputs.reload_changed == "true" &&
  ...
```

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parse OK
- `yamllint` — passed via pre-commit
- `pre-commit` — all 14 hooks passed

## AI-Assisted Review Block

**What does this PR do?**
Fixes two broken `if:` expressions in the GitOps Reconciliation Deploy workflow by wrapping trigger conditions in parentheses and properly chaining with `&&` operator.

**What could go wrong?**
- The `deploy-config-reload` job now correctly runs only when trigger fires AND reload_changed is true — previously the `needs.*` conditions were unreachable syntax. This should be correct behavior.
- The `deploy-compose-restart` job now correctly runs only when trigger fires AND (compose_changed OR non_reloadable_config_changed) is true.

**What tests cover this change?**
Pre-commit YAML validation passes. No unit tests for GitHub Actions syntax — verified via `yamllint` and Python YAML parser.

**Architecture check:**
- What layer(s) were touched and are they correct per §4? — CI/CD pipeline config (`.github/workflows/`), not restricted by §4
- Any cross-plane impact? — Fixes a failing deploy workflow on main

**What I was NOT sure about:**
None.
