### PR TITLE
feat(dora): add rework rate as 5th DORA metric and rename MTTR to FDRT (DORA 2026)

### DIFF
--- a/.agents/skills/dora-metrics/SKILL.md
+++ b/.agents/skills/dora-metrics/SKILL.md
@@ -41,7 +41,7 @@ sum(rate(deployment_failed_total{environment="prod"}[7d]))
 sum(rate(deployment_completed_total{environment="prod"}[7d])) * 100
 ```
 
-### Failed Deployment Recovery Time (FDRT / MTTR)
+### Failed Deployment Recovery Time (FDRT)
 
 ```promql
 # Average recovery duration in seconds

--- a/config/prometheus/rules/ufawkesobs-dora-metrics.yml
+++ b/config/prometheus/rules/ufawkesobs-dora-metrics.yml
@@ -20,7 +20,7 @@
 # 1. Deployment Frequency
 # 2. Lead Time for Changes
 # 3. Change Failure Rate
-# 4. Mean Time to Restore (MTTR)
+# 4. Failed Deployment Recovery Time (FDRT)
 # 5. Rework Rate — fraction of AI output requiring rework (DORA 2026)
 
 groups:
@@ -57,9 +57,9 @@ groups:
           )
           or vector(0)
 
-      # Mean Time to Restore (MTTR): median hours to resolve incidents (30d)
+      # Failed Deployment Recovery Time (FDRT): median hours to resolve incidents (30d)
       # Uses dora_incident_duration_hours histogram from incident resolved events
-      - record: dora:mttr_hours:p50_30d
+      - record: dora:fdrt_hours:p50_30d
         expr: |
           histogram_quantile(0.50,
             sum(rate(dora_incident_duration_hours_bucket[30d]))
@@ -189,35 +189,36 @@ groups:
             Check CI/CD pipeline is emitting deployment status.
           runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#change-failure-rate-absent"
 
-      # MTTR High
-      - alert: DORAMTTRHigh
+      # FDRT High
+      - alert: DORAFDRTHigh
         expr: |
-          dora:mttr_hours:p50_30d > 4
+          dora:fdrt_hours:p50_30d > 4
         for: 7d
         labels:
           severity: warning
           category: dora
         annotations:
-          summary: "Mean time to restore exceeds 4 hours"
+          summary: "Failed deployment recovery time exceeds 4 hours"
           description: |
             Median time to restore service after incidents exceeds 4 hours.
             DORA 2025: Elite < 1h, High < 4h, Medium < 1d, Low > 1w.
             Review incident response procedures and on-call runbooks.
-          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#mttr-high"
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#fdrt-high"
 
-      - alert: DORAMTTRHighAbsent
+      - alert: DORAFDRTHighAbsent
         expr: |
-          absent(dora:mttr_hours:p50_30d)
+          absent(dora:fdrt_hours:p50_30d)
         for: 7d
         labels:
           severity: warning
           category: dora
         annotations:
-          summary: "MTTR metrics are missing"
+          summary: "FDRT metrics are missing"
           description: |
-            MTTR metric is absent. Incident duration metrics may not be flowing.
-            Check Alertmanager alerts are firing and resolving with duration_hours attribute.
-          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#mttr-absent"
+            Failed deployment recovery time metric is absent. Incident duration
+            metrics may not be flowing. Check Alertmanager alerts are firing
+            and resolving with duration_hours attribute.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#fdrt-absent"
 
       # Rework Rate High
       - alert: DORAReworkRateHigh

--- a/config/prometheus/rules/ufawkesobs-dora-metrics.yml
+++ b/config/prometheus/rules/ufawkesobs-dora-metrics.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-# DORA 2025 Metrics Recording Rules
-# Computed from uFawkesObs telemetry (deployment spans, incident alerts)
-# Consumed by uFawkesDORA for DORA 2025 dashboard and alerting
+# DORA 2025/2026 Metrics Recording Rules
+# Computed from uFawkesObs telemetry (deployment spans, incident alerts, AI SDK)
+# Consumed by uFawkesDORA for DORA dashboard and alerting
 #
 # Metric naming: Uses "dora:" namespace per ADR-006.
 # Source metrics from OTel Collector dora pipeline:
@@ -12,6 +12,16 @@
 #   - dora.incident.opened (counter)
 #   - dora.incident.resolved (counter)
 #   - dora.incident.duration_hours (histogram)
+# Source metrics from AI SDK:
+#   - gen_ai.suggestion.accepted (counter)
+#   - gen_ai.suggestion.total (counter)
+#
+# DORA 2025/2026 Five Key Metrics:
+# 1. Deployment Frequency
+# 2. Lead Time for Changes
+# 3. Change Failure Rate
+# 4. Mean Time to Restore (MTTR)
+# 5. Rework Rate — fraction of AI output requiring rework (DORA 2026)
 
 groups:
   # DORA recording rules
@@ -54,6 +64,18 @@ groups:
           histogram_quantile(0.50,
             sum(rate(dora_incident_duration_hours_bucket[30d]))
               by (le)
+          )
+          or vector(0)
+
+      # Rework Rate: fraction of AI output requiring rework (5th DORA metric, DORA 2026)
+      # Derived from AI suggestion acceptance rate: rework = 1 - acceptance_rate
+      # ai:suggestion_acceptance_rate:ratio is defined in config/prometheus/rules/ai-rules.yml
+      # DORA 2026 thresholds: Elite < 5%, High < 10%, Medium < 20%, Low >= 20%
+      - record: dora:rework_rate:ratio
+        expr: |
+          clamp_min(
+            1 - (ai:suggestion_acceptance_rate:ratio or vector(0)),
+            0
           )
           or vector(0)
 
@@ -196,3 +218,49 @@ groups:
             MTTR metric is absent. Incident duration metrics may not be flowing.
             Check Alertmanager alerts are firing and resolving with duration_hours attribute.
           runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#mttr-absent"
+
+      # Rework Rate High
+      - alert: DORAReworkRateHigh
+        expr: |
+          dora:rework_rate:ratio > 0.10
+        for: 7d
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "AI rework rate exceeds 10% — watch threshold"
+          description: |
+            Rework rate has exceeded 10% over the last 30 days.
+            DORA 2026: Elite < 5%, High < 10%, Medium < 20%, Low >= 20%.
+            Rising rework above 10% signals AI instructions may need attention.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#rework-rate-high"
+
+      - alert: DORAReworkRateCritical
+        expr: |
+          dora:rework_rate:ratio > 0.20
+        for: 7d
+        labels:
+          severity: critical
+          category: dora
+        annotations:
+          summary: "AI rework rate exceeds 20% — stop features, fix instructions"
+          description: |
+            Rework rate has exceeded 20% over the last 30 days.
+            DORA 2026: Low performance band. AI-generated code is creating more
+            problems than it solves. Review AGENTS.md and PROMPT_LIBRARY.md
+            before adding new features.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#rework-rate-critical"
+
+      - alert: DORAReworkRateHighAbsent
+        expr: |
+          absent(dora:rework_rate:ratio)
+        for: 7d
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "Rework rate metrics are missing"
+          description: |
+            AI rework rate metric is absent. AI SDK suggestion telemetry may not be
+            flowing or ai-rules.yml recording rules may not be configured.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#rework-rate-absent"

--- a/dashboards/platform/dora-metrics.json
+++ b/dashboards/platform/dora-metrics.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "DORA 2025 metrics dashboard — Deployment Frequency, Lead Time for Changes, Change Failure Rate, and Mean Time to Restore with performance band thresholds (Elite/High/Medium/Low). Data from Prometheus recording rules and uFawkesRes PostgreSQL snapshots.",
+  "description": "DORA 2025 metrics dashboard — Deployment Frequency, Lead Time for Changes, Change Failure Rate, and Failed Deployment Recovery Time (FDRT) with performance band thresholds (Elite/High/Medium/Low). Data from Prometheus recording rules and uFawkesRes PostgreSQL snapshots.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -216,13 +216,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "dora:mttr_hours:p50_30d",
+          "expr": "dora:fdrt_hours:p50_30d",
           "instant": true,
-          "legendFormat": "P50 MTTR (30d)",
+          "legendFormat": "P50 FDRT (30d)",
           "refId": "A"
         }
       ],
-      "title": "Mean Time to Restore",
+      "title": "Failed Deployment Recovery Time",
       "type": "stat"
     },
     {
@@ -462,12 +462,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "dora:mttr_hours:p50_30d",
-          "legendFormat": "P50 MTTR",
+          "expr": "dora:fdrt_hours:p50_30d",
+          "legendFormat": "P50 FDRT",
           "refId": "A"
         }
       ],
-      "title": "Mean Time to Restore Trend",
+      "title": "Failed Deployment Recovery Time Trend",
       "type": "timeseries"
     },
     {
@@ -610,7 +610,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "MTTR performance band: Elite (< 1h), High (< 4h), Medium (< 24h), Low (>= 168h)",
+      "description": "FDRT performance band: Elite (< 1h), High (< 4h), Medium (< 24h), Low (>= 168h)",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -642,13 +642,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "dora:mttr_hours:p50_30d",
+          "expr": "dora:fdrt_hours:p50_30d",
           "instant": true,
-          "legendFormat": "MTTR",
+          "legendFormat": "FDRT",
           "refId": "A"
         }
       ],
-      "title": "MTTR Band",
+      "title": "FDRT Band",
       "type": "stat"
     },
     {
@@ -756,9 +756,9 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "count(dora:mttr_hours:p50_30d) or vector(0)",
+          "expr": "count(dora:fdrt_hours:p50_30d) or vector(0)",
           "instant": true,
-          "legendFormat": "MTTR",
+          "legendFormat": "FDRT",
           "refId": "D"
         }
       ],

--- a/docs/adr/ADR-006-dora-metric-definitions.md
+++ b/docs/adr/ADR-006-dora-metric-definitions.md
@@ -14,7 +14,7 @@ uFawkesObs is the observability plane of the Fawkes IDP platform. It provides th
 1. **Deployment Frequency** — How often code is deployed to production
 2. **Lead Time for Changes** — Time from commit to production
 3. **Change Failure Rate** — Percentage of deployments causing failures
-4. **Mean Time to Restore (MTTR)** — Time to recover from a failure
+4. **Failed Deployment Recovery Time (FDRT)** — Time to recover from a failed deployment
 5. **Rework Rate** — Fraction of AI-generated code requiring rework (DORA 2026)
 
 uFawkesObs does not compute these metrics directly; it provides the raw telemetry (metrics, logs, traces) and derived recording rules that uFawkesDORA's ingestion API consumes. This ADR defines the data contract: what counts as a deployment, incident, and restoration within uFawkesObs telemetry, and the metric mappings uFawkesDORA expects.
@@ -69,7 +69,7 @@ An **incident** is identified by an **Alertmanager alert** that fires and maps t
 - An incident **closes** when the alert resolves (stops firing) and the `resolved` notification is received
 - Incident duration = `resolved_at` - `fired_at`
 
-**uFawkesDORA computes Change Failure Rate and MTTR** from incidents that:
+**uFawkesDORA computes Change Failure Rate and FDRT** from incidents that:
 - Have `environment="production"`
 - Have `severity` in `["critical", "warning"]`
 - Are linked to a deployment (via time correlation: incident opened within 24h of a deployment)
@@ -83,7 +83,7 @@ A **restoration** is the resolution of an incident, identified by the alert reso
 **Restoration event semantics:**
 - Triggered by Alertmanager `resolved` notification for a previously firing alert
 - Restoration time = alert resolution timestamp
-- MTTR = `restoration_time` - `incident_start_time`
+- FDRT = `restoration_time` - `incident_start_time`
 
 ---
 
@@ -96,7 +96,7 @@ uFawkesObs provides the following Prometheus recording rules that uFawkesDORA co
 | `dora:deployment_frequency:rate30d` | Gauge | Successful production deployments per 30 days | Deployment spans |
 | `dora:lead_time_hours:p50_30d` | Gauge | Median lead time (commit → production) over 30d | Deployment spans + commit timestamps |
 | `dora:change_failure_rate:ratio30d` | Gauge | Failed deployments / total deployments (30d) | Deployment spans + incidents |
-| `dora:mttr_hours:p50_30d` | Gauge | Median time to restore (hours) over 30d | Incident open/close times |
+| `dora:fdrt_hours:p50_30d` | Gauge | Median failed deployment recovery time (hours) over 30d | Incident open/close times |
 | `dora:rework_rate:ratio` | Gauge | Fraction of AI output requiring rework (30d) | AI SDK suggestion telemetry |
 
 **Rule file location:** `config/prometheus/rules/ufawkesobs-dora-metrics.yml`
@@ -141,7 +141,7 @@ uFawkesObs provides the following DORA-specific alert rules in `config/prometheu
 | `DORALeadTimeHigh` | warning | `dora:lead_time_hours:p50_30d > 24` | Median lead time > 24h |
 | `DORAChangeFailureRateHigh` | warning | `dora:change_failure_rate:ratio30d > 0.15` | Change failure rate > 15% |
 | `DORAChangeFailureRateCritical` | critical | `dora:change_failure_rate:ratio30d > 0.30` | Change failure rate > 30% |
-| `DORAMTTRHigh` | warning | `dora:mttr_hours:p50_30d > 4` | Median MTTR > 4 hours |
+| `DORAFDRTHigh` | warning | `dora:fdrt_hours:p50_30d > 4` | Median FDRT > 4 hours |
 | `DORAReworkRateHigh` | warning | `dora:rework_rate:ratio > 0.10` | Rework rate > 10% (watch threshold) |
 | `DORAReworkRateCritical` | critical | `dora:rework_rate:ratio > 0.20` | Rework rate > 20% (stop features) |
 

--- a/docs/adr/ADR-006-dora-metric-definitions.md
+++ b/docs/adr/ADR-006-dora-metric-definitions.md
@@ -9,12 +9,13 @@
 
 ## Context
 
-uFawkesObs is the observability plane of the Fawkes IDP platform. It provides the telemetry substrate (metrics, logs, traces) that feeds into uFawkesDORA — the DORA metrics compute plane. uFawkesDORA requires a well-defined data contract to calculate the four DORA 2025 key metrics:
+uFawkesObs is the observability plane of the Fawkes IDP platform. It provides the telemetry substrate (metrics, logs, traces) that feeds into uFawkesDORA — the DORA metrics compute plane. uFawkesDORA requires a well-defined data contract to calculate the five DORA 2025/2026 key metrics:
 
 1. **Deployment Frequency** — How often code is deployed to production
 2. **Lead Time for Changes** — Time from commit to production
 3. **Change Failure Rate** — Percentage of deployments causing failures
 4. **Mean Time to Restore (MTTR)** — Time to recover from a failure
+5. **Rework Rate** — Fraction of AI-generated code requiring rework (DORA 2026)
 
 uFawkesObs does not compute these metrics directly; it provides the raw telemetry (metrics, logs, traces) and derived recording rules that uFawkesDORA's ingestion API consumes. This ADR defines the data contract: what counts as a deployment, incident, and restoration within uFawkesObs telemetry, and the metric mappings uFawkesDORA expects.
 
@@ -91,11 +92,12 @@ A **restoration** is the resolution of an incident, identified by the alert reso
 uFawkesObs provides the following Prometheus recording rules that uFawkesDORA consumes:
 
 | Recording Rule | Type | Description | Source |
-|---|---|---|---|
+|---|---|---|---|---|
 | `dora:deployment_frequency:rate30d` | Gauge | Successful production deployments per 30 days | Deployment spans |
 | `dora:lead_time_hours:p50_30d` | Gauge | Median lead time (commit → production) over 30d | Deployment spans + commit timestamps |
 | `dora:change_failure_rate:ratio30d` | Gauge | Failed deployments / total deployments (30d) | Deployment spans + incidents |
 | `dora:mttr_hours:p50_30d` | Gauge | Median time to restore (hours) over 30d | Incident open/close times |
+| `dora:rework_rate:ratio` | Gauge | Fraction of AI output requiring rework (30d) | AI SDK suggestion telemetry |
 
 **Rule file location:** `config/prometheus/rules/ufawkesobs-dora-metrics.yml`
 
@@ -134,12 +136,14 @@ uFawkesObs forwards telemetry to uFawkesDORA via OTLP HTTP to the ingestion endp
 uFawkesObs provides the following DORA-specific alert rules in `config/prometheus/rules/ufawkesobs-dora-alerts.yml`:
 
 | Alert | Severity | Threshold | Description |
-|---|---|---|---|
+|---|---|---|---|---|
 | `DORADeploymentFrequencyLow` | warning | `dora:deployment_frequency:rate30d < 1` | Deployments per 30d below 1 |
 | `DORALeadTimeHigh` | warning | `dora:lead_time_hours:p50_30d > 24` | Median lead time > 24h |
 | `DORAChangeFailureRateHigh` | warning | `dora:change_failure_rate:ratio30d > 0.15` | Change failure rate > 15% |
 | `DORAChangeFailureRateCritical` | critical | `dora:change_failure_rate:ratio30d > 0.30` | Change failure rate > 30% |
 | `DORAMTTRHigh` | warning | `dora:mttr_hours:p50_30d > 4` | Median MTTR > 4 hours |
+| `DORAReworkRateHigh` | warning | `dora:rework_rate:ratio > 0.10` | Rework rate > 10% (watch threshold) |
+| `DORAReworkRateCritical` | critical | `dora:rework_rate:ratio > 0.20` | Rework rate > 20% (stop features) |
 
 All alerts carry `category: dora` label for routing.
 
@@ -152,7 +156,7 @@ The DORA metrics dashboard is provisioned at:
 - Grafana folder: `Platform`
 - Datasources: `Prometheus` (UID: `prometheus`), `PostgreSQL` (UID: `ufawkesres-postgres`)
 
-The dashboard shows the four DORA indicators with DORA 2025 performance bands (Elite/High/Medium/Low).
+The dashboard shows the five DORA indicators with DORA 2025/2026 performance bands (Elite/High/Medium/Low).
 
 ---
 
@@ -162,7 +166,7 @@ The dashboard shows the four DORA indicators with DORA 2025 performance bands (E
 
 2. **Contract enables cross-plane integration** — uFawkesDORA's ingestion API can rely on a stable schema. Changes to this contract require an ADR update.
 
-3. **DORA 2025 alignment** — The four metrics and their recording rules follow the DORA 2025 report definitions, with performance bands (Elite/High/Medium/Low) matching industry benchmarks.
+3. **DORA 2025/2026 alignment** — The five key metrics and their recording rules follow the DORA 2025 report and DORA 2026 AI Capabilities Model definitions, with performance bands (Elite/High/Medium/Low) matching industry benchmarks.
 
 4. **Separation of concerns** — uFawkesObs provides telemetry and recording rules; uFawkesDORA computes final metrics. This ADR defines the interface between them.
 
@@ -196,6 +200,8 @@ The dashboard shows the four DORA indicators with DORA 2025 performance bands (E
 ## References
 
 - DORA 2025 Report: <https://dora.dev/reports/2025/>
+- DORA 2025 AI Capabilities Model: <https://services.google.com/fh/files/misc/2025_dora_ai_capabilities_model.pdf>
+- DORA 2026 ROI of AI-Assisted Development: <https://services.google.com/fh/files/misc/dora-roi-of-ai-assisted-software-development-2026.pdf>
 - OTel Semantic Conventions for CI/CD: <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/ci-cd/README.md>
 - OTel Semantic Conventions for Alerts: <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/alert/README.md>
 - uFawkesDORA Ingestion API spec: `docs/specification.md` (M4 section)
@@ -205,13 +211,14 @@ The dashboard shows the four DORA indicators with DORA 2025 performance bands (E
 
 ## Implementation Tasks
 
-1. [ ] Create `docs/adr/ADR-006-dora-metric-definitions.md` (this file)
-2. [ ] Add row to `docs/adr/README.md` index
-3. [ ] Create `config/prometheus/rules/ufawkesobs-dora-metrics.yml` (recording rules)
-4. [ ] Create `config/prometheus/rules/ufawkesobs-dora-alerts.yml` (alert rules)
-5. [ ] Add `dora` profile to `compose.yaml` with OTel Collector exporter to uFawkesDORA
-6. [ ] Create `config/otel/collector-dora.yaml` for DORA profile
-7. [ ] Add Grafana Postgres datasource provisioning (`ufawkesres-postgres`)
+1. [x] Create `docs/adr/ADR-006-dora-metric-definitions.md` (this file)
+2. [x] Add row to `docs/adr/README.md` index
+3. [x] Create `config/prometheus/rules/ufawkesobs-dora-metrics.yml` (recording rules + alert rules)
+4. [ ] Create `config/prometheus/rules/ufawkesobs-dora-alerts.yml` (alert rules — consolidated into recording rules file)
+5. [x] Add `dora` profile to `compose.yaml` with OTel Collector exporter to uFawkesDORA
+6. [x] Create `config/otel/collector-dora.yaml` for DORA profile
+7. [x] Add Grafana Postgres datasource provisioning (`ufawkesres-postgres`)
 8. [ ] Create `dashboards/platform/dora-metrics.json`
-9. [ ] Update `docs/adr/README.md` index
-10. [ ] Add Alertmanager route for `category: dora` alerts
+9. [x] Update `docs/adr/README.md` index
+10. [x] Add Alertmanager route for `category: dora` alerts
+11. [x] Add `dora:rework_rate:ratio` recording rule for 5th DORA metric (DORA 2026)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -388,13 +388,30 @@
 - **Description:** Configure Prometheus recording rules inside uFawkesObs for continuous calculation of DORA metrics. Rules query Prometheus metrics scraped from OTel Collector; derived metrics pushed by uFawkesDORA compute job via pushgateway.
 - **Backlog Issue:** #82, #53
 - **Dependencies:** M4-02
-- **Status:** 🔲 PENDING
-- **Notes:** Use GPT-5.1-Codex per model routing table (PromQL rules)
+- **Status:** ✅ DONE (commit 3ad1661, extended with rework rate in this branch)
+- **Notes:** DORA 2026 now defines 5 key metrics — the classic 4 plus rework rate from the AI Capabilities Model.
+- **Details:**
+   - Created `config/prometheus/rules/ufawkesobs-dora-metrics.yml` with 5 DORA recording rules:
+     - `dora:deployment_frequency:rate30d` — successful production deployments per 30 days
+     - `dora:lead_time_hours:p50_30d` — median lead time from commit to production
+     - `dora:change_failure_rate:ratio30d` — failed / total deployments (30d)
+     - `dora:mttr_hours:p50_30d` — median time to restore (hours, 30d)
+     - `dora:rework_rate:ratio` — fraction of AI output requiring rework (1 - acceptance rate)
+   - All 5 rules guarded with `or vector(0)`
+   - 7 DORA alert rules with paired absent() guards:
+     - DORADeploymentFrequencyLow / Absent
+     - DORALeadTimeHigh / Absent
+     - DORAChangeFailureRateHigh / Critical / Absent
+     - DORAMTTRHigh / Absent
+     - DORAReworkRateHigh / Critical / Absent
+   - Prometheus config updated to load the rules file
+   - 3 paired rework rate alerts in `ai-rules.yml` (AI-specific context, category: ai-capability)
 - **Tasks:**
-  1. Formulate recording rules for `dora:deployment_frequency:rate30d`, `dora:lead_time_hours:p50_30d`, `dora:change_failure_rate:ratio30d`, and `dora:mttr_hours:p50_30d` inside dedicated rule file `config/prometheus/rules/ufawkesobs-dora-metrics.yml`.
+  1. Formulate recording rules for `dora:deployment_frequency:rate30d`, `dora:lead_time_hours:p50_30d`, `dora:change_failure_rate:ratio30d`, `dora:mttr_hours:p50_30d`, and `dora:rework_rate:ratio` inside dedicated rule file `config/prometheus/rules/ufawkesobs-dora-metrics.yml`.
 - **Acceptance Criteria:**
-  - Prometheus rules load and parse cleanly.
-  - All rules guarded with `or vector(0)`.
+  - [x] Prometheus rules load and parse cleanly.
+  - [x] All rules guarded with `or vector(0)`.
+  - [x] 5th DORA metric (rework rate) added for DORA 2026 alignment.
 
 ### Task M4-04: Provision Grafana DORA Metrics Dashboard
 
@@ -403,7 +420,7 @@
 - **Dependencies:** M4-03
 - **Status:** 🔲 PENDING
 - **Tasks:**
-  1. Create `config/grafana/dashboards/dora-metrics.json` containing panel models for the 4 DORA indicators.
+  1. Create `config/grafana/dashboards/dora-metrics.json` containing panel models for the 5 DORA indicators.
   2. Enforce standard DORA performance bands (Elite/High/Medium/Low) using color thresholds.
   3. Configure dashboard to use both Prometheus and Postgres datasources.
 - **Acceptance Criteria:**

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -395,19 +395,19 @@
      - `dora:deployment_frequency:rate30d` — successful production deployments per 30 days
      - `dora:lead_time_hours:p50_30d` — median lead time from commit to production
      - `dora:change_failure_rate:ratio30d` — failed / total deployments (30d)
-     - `dora:mttr_hours:p50_30d` — median time to restore (hours, 30d)
+     - `dora:fdrt_hours:p50_30d` — median failed deployment recovery time (hours, 30d)
      - `dora:rework_rate:ratio` — fraction of AI output requiring rework (1 - acceptance rate)
    - All 5 rules guarded with `or vector(0)`
    - 7 DORA alert rules with paired absent() guards:
      - DORADeploymentFrequencyLow / Absent
      - DORALeadTimeHigh / Absent
      - DORAChangeFailureRateHigh / Critical / Absent
-     - DORAMTTRHigh / Absent
+     - DORAFDRTHigh / Absent
      - DORAReworkRateHigh / Critical / Absent
    - Prometheus config updated to load the rules file
    - 3 paired rework rate alerts in `ai-rules.yml` (AI-specific context, category: ai-capability)
 - **Tasks:**
-  1. Formulate recording rules for `dora:deployment_frequency:rate30d`, `dora:lead_time_hours:p50_30d`, `dora:change_failure_rate:ratio30d`, `dora:mttr_hours:p50_30d`, and `dora:rework_rate:ratio` inside dedicated rule file `config/prometheus/rules/ufawkesobs-dora-metrics.yml`.
+  1. Formulate recording rules for `dora:deployment_frequency:rate30d`, `dora:lead_time_hours:p50_30d`, `dora:change_failure_rate:ratio30d`, `dora:fdrt_hours:p50_30d`, and `dora:rework_rate:ratio` inside dedicated rule file `config/prometheus/rules/ufawkesobs-dora-metrics.yml`.
 - **Acceptance Criteria:**
   - [x] Prometheus rules load and parse cleanly.
   - [x] All rules guarded with `or vector(0)`.
@@ -415,7 +415,7 @@
 
 ### Task M4-04: Provision Grafana DORA Metrics Dashboard
 
-- **Description:** Pre-provision a dedicated DORA dashboard in Grafana showing real-time calculations. Dashboard reads from Prometheus (time-series) and uFawkesRes PostgreSQL via Grafana Postgres datasource plugin (current snapshots).
+- **Description:** Pre-provision a dedicated DORA dashboard in Grafana showing real-time calculations. Dashboard reads from Prometheus (time-series) and uFawkesRes PostgreSQL via Grafana Postgres datasource plugin (current snapshots). Metrics: Deployment Frequency, Lead Time, Change Failure Rate, Failed Deployment Recovery Time (FDRT), and Rework Rate.
 - **Backlog Issue:** #83, #52
 - **Dependencies:** M4-03
 - **Status:** 🔲 PENDING


### PR DESCRIPTION
## Summary

Two DORA 2026 alignment changes:

### 1. New 5th DORA Metric: Rework Rate
Add rework rate as the 5th DORA metric. This extends the existing M4-03 implementation (commit 3ad1661) which previously only had the classic 4 DORA metrics.

### 2. MTTR → FDRT Rename
Renamed "Mean Time to Restore (MTTR)" to "Failed Deployment Recovery Time (FDRT)" per DORA 2025/2026 conventions.

---

### Changes

| File | Change |
|------|--------|
| `config/prometheus/rules/ufawkesobs-dora-metrics.yml` | Added `dora:rework_rate:ratio` recording rule + 3 alert rules; renamed `dora:mttr_hours:p50_30d` → `dora:fdrt_hours:p50_30d`; renamed `DORAMTTRHigh` → `DORAFDRTHigh` |
| `dashboards/platform/dora-metrics.json` | Updated all panel queries from `dora:mttr_hours:p50_30d` → `dora:fdrt_hours:p50_30d`; updated titles/legends from MTTR → FDRT |
| `docs/adr/ADR-006-dora-metric-definitions.md` | Added rework rate to 5 key metrics; renamed MTTR → FDRT throughout; added DORA 2026 references |
| `docs/plan.md` | Marked M4-03 ✅ DONE; updated metric names to include rework rate and FDRT |
| `.agents/skills/dora-metrics/SKILL.md` | Updated "FDRT / MTTR" → "FDRT" |

### DORA 2026 Final 5 Key Metrics

1. **Deployment Frequency** — `dora:deployment_frequency:rate30d`
2. **Lead Time for Changes** — `dora:lead_time_hours:p50_30d`
3. **Change Failure Rate** — `dora:change_failure_rate:ratio30d`
4. **Failed Deployment Recovery Time (FDRT)** — `dora:fdrt_hours:p50_30d`
5. **Rework Rate** — `dora:rework_rate:ratio`

### Validation
- ✅ Pre-commit: all 14 hooks pass
- ✅ YAML syntax: valid
- ✅ JSON syntax: valid
- ✅ Unit tests: 242/242 pass

## AI-Assisted Review Block

**What does this PR do?**
Adds rework rate as 5th DORA metric and renames MTTR to FDRT for DORA 2026 alignment.

**What could go wrong?**
- The `dora:fdrt_hours:p50_30d` rename is a breaking change for any dashboard/alert referencing `dora:mttr_hours:p50_30d` — all in-repo references have been updated
- The rework rate recording rule references `ai:suggestion_acceptance_rate:ratio` — cross-file dependency must remain stable
- When `ai:suggestion_acceptance_rate:ratio` returns `vector(0)` (placeholder), rework rate = 1.0 (100%). Alerts will fire until real AI SDK data flows

**What tests cover this change?**
All 242 unit tests pass. Dashboard JSON validates via pre-commit JSON syntax check.

**Architecture check:**
- What layer(s) were touched and are they correct per §4? — `config/prometheus/rules/` (recording rules), `dashboards/` (provisioned Grafana), `docs/` (ADR, plan), `.agents/` (skill)
- Any cross-plane impact? — Metric rename (`dora:fdrt_hours:p50_30d`) must be consumed by uFawkesDORA. The SQL column `mttr_hours` in uFawkesDORA PostgreSQL remains unchanged.

**What I was NOT sure about:**
- Whether to update the SQL column name `mttr_hours` in the dashboard query — this is uFawkesDORA database schema, not our Prometheus metric name, so left unchanged.
