### PR TITLE
fix(ci): add workflow_call trigger to ci-acceptance-smoke.yml

### DIFF
--- a/.github/workflows/ci-acceptance-smoke.yml
+++ b/.github/workflows/ci-acceptance-smoke.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION

## Fixes CI Failure on Main

**Root Cause:** `.github/workflows/ci-pipeline.yml` calls `ci-acceptance-smoke.yml` as a reusable workflow (line 76), but the called workflow was missing the required `on.workflow_call` trigger.

**Error:**
```
Invalid workflow file: .github/workflows/ci-pipeline.yml#L76
error parsing called workflow
-> "./.github/workflows/ci-acceptance-smoke.yml"
: workflow is not reusable as it is missing a `on.workflow_call` trigger
```

## Changes

- Added `workflow_call:` trigger to `.github/workflows/ci-acceptance-smoke.yml`
- Preserves existing triggers (`pull_request`, `push`, `workflow_dispatch`) for independent execution

## Validation

- Both workflow YAML files pass syntax validation
- No breaking changes — existing independent execution paths preserved

## AI-Assisted Review Block

**What does this PR do?**
Fixes a CI pipeline breakage on main by making `ci-acceptance-smoke.yml` callable as a reusable workflow.

**What could go wrong?**
Minimal risk — only adds a trigger, doesn't modify any job logic or permissions.

**What tests cover this change?**
N/A — workflow configuration change validated via YAML syntax check.

**Architecture check:**
- Layer: CI/CD pipeline configuration
- Cross-plane impact: None

**What I was NOT sure about:**
None — straightforward fix for reusable workflow requirement.
