### PR TITLE
fix(ci): add actions/checks permissions for reusable workflow calls

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -12,6 +12,8 @@ permissions:
   pull-requests: write
   issues: write
   security-events: write
+  actions: write
+  checks: write
 
 concurrency:
   group: pipeline-${{ github.ref }}


### PR DESCRIPTION
## What does this PR do?
Fixes CI pipeline failure by adding required `actions: write` and `checks: write` permissions to `.github/workflows/ci-pipeline.yml`.

## Root Cause
The `ci-pipeline.yml` calls `.github/workflows/ci-acceptance-smoke.yml` as a reusable workflow. The called workflow requires:
- `actions: write` (for uploading artifacts)
- `checks: write` (for creating check runs)

But the calling workflow only had:
- `contents: read`
- `pull-requests: write`
- `issues: write`
- `security-events: write`

When a workflow calls another as reusable, the caller's permissions must include all permissions needed by the callee.

## Fix
Added `actions: write` and `checks: write` to the caller's permissions.

## Testing
- YAML syntax validated
- Pre-commit hooks pass