### PR TITLE
fix(ci): correct telemetry-generator health check endpoint in acceptance-full workflow

### DIFF
--- a/.github/workflows/ci-acceptance-full.yml
+++ b/.github/workflows/ci-acceptance-full.yml
@@ -60,7 +60,7 @@ jobs:
             ('Grafana', 'http://localhost:3000/api/health'),
             ('OTel Collector', 'http://localhost:8888/metrics'),
             ('Alloy', 'http://localhost:12345/-/ready'),
-            ('Telemetry Generator', 'http://localhost:5001/health'),
+            ('Telemetry Generator', 'http://localhost:5001/'),
           ]
           for name, url in services:
             for i in range(60):


### PR DESCRIPTION
## What does this PR do?
Fixes the "Acceptance Full (Post-Merge)" CI workflow by correcting the telemetry-generator health check endpoint. The workflow was checking `http://localhost:5001/health` but the telemetry-generator Flask app only exposes `/` as the health endpoint.

## Root Cause
The telemetry generator app at `apps/telemetry-generator/app.py` only has a `/` route acting as its health check (returns `{"status": "healthy"}`). It does not have a `/health` endpoint. The workflow was using the wrong URL path.

## Fix
Changed health check URL from `http://localhost:5001/health` to `http://localhost:5001/` in `.github/workflows/ci-acceptance-full.yml`.

## Validation
- YAML syntax validated
- Pre-commit hooks pass

## AI-Assisted Review Block

**What does this PR do?**
Fixes a broken health check URL in the Acceptance Full CI workflow.

**What could go wrong?**
Nothing — the `/` endpoint returns a 200 with `{"status": "healthy"}` which satisfies the health check requirement.

**What tests cover this change?**
N/A — CI config change. Validate by running the workflow on main after merge.

**Architecture check:**
- Layer: CI/CD pipeline configuration
- Cross-plane impact: None — only affects the acceptance test CI workflow

**What I was NOT sure about:**
None — straightforward URL correction verified against the source code.