### PR TITLE
docs(product): bring discovery/spec/design revision to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md — uFawkesObs
+
+@AGENTS.md

--- a/docs/product/design.md
+++ b/docs/product/design.md
@@ -1,8 +1,8 @@
 # uFawkesObs — Design
 
-**Version:** 1.0.0
-**Date:** 2026-06-28
-**Depends on:** docs/product/spec.md v1.0.0
+**Version:** 1.1.0
+**Date:** 2026-07-27
+**Depends on:** docs/product/spec.md v1.1.0
 **Repo:** paruff/uFawkesObs
 
 ---
@@ -40,13 +40,16 @@ uFawkesObs/
 │   ├── loki/
 │   │   └── loki.yaml                 # Index, schema, and retention rules
 │   ├── otel/
-│   │   └── collector.yaml            # Ingestion pipelines (metrics, traces, logs)
+│   │   ├── collector.yaml            # Core ingestion pipeline (metrics, traces, logs)
+│   │   └── collector-dora.yaml       # DORA-profile collector, forwards to uFawkesDORA ingestion
 │   ├── prometheus/
 │   │   ├── alerts.yml                # Alert thresholds
-│   │   └── prometheus.yaml           # Global configuration and scrapers
+│   │   ├── prometheus.yaml           # Global configuration and scrapers
+│   │   └── rules/                    # Recording/alerting rules (AI capability, DORA, self-monitoring)
 │   └── tempo/
 │       └── tempo.yaml                # Trace ingestion ports and storage configs
 ├── dashboards/                       # Provisioned dashboard JSON configurations
+│   └── platform/                     # DORA, AI-capability, and per-component health dashboards
 ├── data/                             # Host directory mounts for persistent volumes (gitignored)
 ├── apps/
 │   └── telemetry-generator/          # Demo application mimicking standard OTLP workloads
@@ -54,10 +57,24 @@ uFawkesObs/
 ├── tests/
 │   ├── unit/                         # Local config syntax, version, and model validators
 │   ├── integration/                  # Active container test cases (Prometheus, Grafana, Loki, Tempo)
-│   └── acceptance/                   # In-pipeline E2E observability checks
+│   └── acceptance/                   # In-pipeline E2E observability checks, incl. chaos_report.py
+│       ├── features/                 # Gherkin features (e.g. chaos_resilience.feature)
+│       └── steps/                    # Step implementations (e.g. chaos_steps.py)
+├── reports/
+│   └── chaos-evidence/               # Generated evidence artifacts from chaos test runs
+├── docs/
+│   ├── product/                      # Whole-repo product artifacts: discovery-draft.md, spec.md,
+│   │                                 #   design.md, tasks.json (this document lives here)
+│   └── features/                     # Per-feature discovery/spec/design/tasks, kept after ship
+│       └── chaos-failure-injection/  # Example: chaos/failure-injection feature's pipeline output
 └── .github/
     └── workflows/
-        └── ci-pipeline.yml           # Unified pipeline running preflight, lint, security, build, tests
+        ├── ci-pipeline.yml           # Unified pipeline running preflight, lint, security, build, tests
+        ├── ci-acceptance-smoke.yml   # Fast acceptance gate on PRs
+        ├── ci-acceptance-full.yml    # Full acceptance suite
+        ├── ci-chaos-nightly.yml      # Scheduled chaos/failure-injection gate
+        ├── main-ci-guard.yml         # Branch-protection guard for main
+        └── deploy.yml                # GitOps reconciliation (SSH-triggered) to target environments
 ```
 
 ---
@@ -141,27 +158,29 @@ Grafana automatically configures datasources and preloads dashboards upon contai
 
 ---
 
-## 6. Forward-Looking Feature Designs
+## 6. Milestone Designs
 
-### 6.1 Milestone 4: DORA & Ecosystem Integration Design
+### 6.1 Milestone 4: DORA & Ecosystem Integration Design (Implemented)
 
-uFawkesObs is the observability substrate for DORA metrics. The DORA data pipeline spans three planes:
+uFawkesObs is the observability substrate for DORA metrics. This section previously described a forward-looking design; M4-01 through M4-04 shipped (PRs #147, #148, plus recording-rule and dashboard work) and the design below reflects what is actually running, not a plan. The DORA data pipeline spans three planes:
 
 - **uFawkesDORA (Compute Plane):** Ingestion API → Event Queue (Postgres) → Processor → Metric Compute Job. Owns DevLake as optional complementary visualization.
 - **uFawkesRes (Resource Plane):** Shared PostgreSQL 17 + TimescaleDB on `fawkes-backbone-net`. Hosts `dora_metrics` database (schemas: `event_queue`, `raw_events`, `dora_snapshots`, `archetype_history`, `wellbeing_surveys`, `vsi_stage_breakdown`).
-- **uFawkesObs (Observability Plane):** Prometheus (recording rules, alerting, time-series), Grafana (dashboards reading Prometheus + Postgres), Loki (raw event logs), OTel Collector (ingestion from uFawkesDORA).
+- **uFawkesObs (Observability Plane):** Prometheus (recording rules, alerting, time-series), Grafana (dashboards reading Prometheus + Postgres), Loki (raw event logs), a dedicated `otel-collector-dora` instance (ingestion from/to uFawkesDORA).
 
-**Architecture Additions in uFawkesObs:**
-- **Recording Rules:** PromQL rules in `config/prometheus/rules/dora-metrics.yml` for continuous calculation of `dora:deployment_frequency:rate30d`, `dora:lead_time_hours:p50_30d`, `dora:fdrt_hours:p50_30d`, `dora:change_failure_rate:ratio30d`, `dora:rework_rate:ratio30d`.
-- **DORA Dashboard:** Provision `config/grafana/provisioning/dashboards/dora-metrics.json` with panels reading from Prometheus (trend lines) and PostgreSQL via Postgres datasource plugin (current snapshots, archetype profile).
-- **Network Attachment:** uFawkesObs joins `fawkes-backbone-net` (external name: `ufawkes-resources_fawkes-backbone-net`) to query uFawkesRes PostgreSQL for DORA snapshots.
-- **Alertmanager Routing:** Add `dora_regression` and `leading_indicator` routes to Alertmanager config pointing to `DORA_SLACK_WEBHOOK_URL`.
+**Architecture in uFawkesObs (as built):**
+- **Second OTel Collector:** `otel-collector-dora` compose service, gated behind the `dora` profile, configured via `config/otel/collector-dora.yaml`, connecting to `${DORA_OTEL_ENDPOINT:-http://ufawkesdora-ingestion:4318}`.
+- **Recording Rules:** PromQL rules in `config/prometheus/rules/ufawkesobs-dora-metrics.yml` computing `dora:deployment_frequency:rate30d`, `dora:lead_time_hours:p50_30d`, `dora:fdrt_hours:p50_30d`, `dora:change_failure_rate:ratio30d`, `dora:rework_rate:ratio30d`.
+- **DORA Dashboard:** Provisioned at `dashboards/platform/dora-metrics.json`, documented in `docs/adr/ADR-006-dora-metric-definitions.md`, with panels reading from Prometheus (trend lines) and PostgreSQL via the Postgres datasource plugin (current snapshots, archetype profile).
+- **Network Attachment:** uFawkesObs joins `fawkes-backbone-net` (external name: `ufawkes-resources_fawkes-backbone-net`) to query uFawkesRes PostgreSQL for DORA snapshots. The `otel-collector-dora` service requires `DORA_POSTGRES_URL` as a fail-closed environment variable (no hardcoded fallback) — see §5.
+- **Alertmanager Routing:** `dora_regression` and `leading_indicator` routes point to `DORA_SLACK_WEBHOOK_URL`.
+- **Runtime-deployed status:** Deployed and running under the `dora` compose profile; exercised by the acceptance suite's DORA-dashboard checks (not yet by a dedicated live-system AC in the product discovery brief — see [`discovery-draft.md`](discovery-draft.md), whose current acceptance criterion covers the `core` profile only).
 
 **What moved to other planes (no longer in uFawkesObs scope):**
 - Apache DevLake → uFawkesDORA (optional, complementary to native ingestion)
 - MySQL database → removed; DevLake uses uFawkesRes PostgreSQL
 
-### 6.2 Milestone 5: Kubernetes & Helm Migration Design
+### 6.2 Milestone 5: Kubernetes & Helm Migration Design (Forward-Looking, Backlog)
 
 - **Helm chart structure:** An umbrella Helm chart `helm/ufawkes-obs` containing separate sub-charts:
   - `prometheus-community/prometheus`

--- a/docs/product/discovery-draft.md
+++ b/docs/product/discovery-draft.md
@@ -1,17 +1,179 @@
-# uFawkesObs — Discovery Draft
+---
+date: 2026-07-27
+persona: solo-entrepreneur
+jtbd: "When I run a small (3-15 person) engineering team shipping on Docker Compose, I want a self-hosted stack that gives me production-grade metrics, logs, traces, and alerting out of the box, so I can catch and diagnose incidents without paying a SaaS observability bill or building my own telemetry stack from scratch."
+riskiest_assumption: "We assume a 3-15 person team will accept operating its own observability infrastructure (upgrades, disk growth, backup, on-call for the stack itself) in exchange for not paying a SaaS bill — if that operational burden exceeds what the team can absorb alongside their actual product, they'll churn to a managed SaaS regardless of cost."
+acceptance_criterion: "Given a fresh clone of uFawkesObs on a machine with Docker installed, when `make up` (or `docker compose --profile core up -d`) is run, then Grafana is reachable at localhost:3000 within 2 minutes with Prometheus, Loki, Tempo, and Alertmanager already wired as datasources and at least one pre-provisioned dashboard showing live data."
+test_type: live-system
+test_type_reasoning: "\"Ready to use within 2 minutes\" is a claim about the real compose stack converging to healthy and dashboards resolving live queries — no mock or unit test can stand in for actually starting the containers and observing Grafana render data."
+dora_ai_capability: null
+dora_core_capability: "Monitoring and Observability"
+metric: "time_to_first_signal_minutes"
+measurement_source: "manual (timed via scripts/smoke-test.sh against a fresh clone)"
+baseline: "not yet measured — establish baseline by timing scripts/smoke-test.sh from a clean checkout"
+prior_art: "Grafana Cloud free tier, Datadog, SigNoz, OpenObserve — all viable alternatives for a small team. uFawkesObs's answer isn't a new telemetry backend, it's composing the same OSS components (Prometheus, Loki, Tempo, Grafana, OTel Collector, Alertmanager) that those vendors already build on, pre-wired and pre-provisioned, so a small team gets the vendor's default experience without the vendor's invoice."
+status: ready-for-spec
+retrospective: true
+assumption_validated: false
+---
 
-**Status:** Not yet populated.
+# Discovery Brief: uFawkesObs (Product-Level)
 
-No product-level discovery document existed anywhere in this repo as of
-2026-07-27 — this file is a placeholder created when `docs/product/` was
-established as the home for product-level pipeline artifacts (per AGENTS.md
-§2's `discover → spec → design → plan` pipeline).
+> **Note on scope, stated plainly:** this brief was written after M2–M4 were
+> already built, shipped, and merged. That inverts the entire point of a
+> discovery gate — discovery is supposed to de-risk a decision *before*
+> resources are committed, and nothing here changed a build decision, because
+> the decisions were already made. Calling this "discovery" is generous; it is
+> more accurately a **retrospective risk audit**: an attempt to make the user
+> need and riskiest assumption behind the *already-existing* spec/design
+> explicit and falsifiable, so that (a) M5 and future milestones get checked
+> against a real JTBD instead of an assumed one, and (b) the gap this brief
+> exposes — that the assumption below has never actually been tested — is
+> visible instead of quietly absent. See "Honest Limitations of This Brief"
+> below for what this document does *not* establish. Feature-level discovery
+> briefs for individual increments belong in
+> `docs/features/<feature-slug>/discovery-draft.md`, and for those, discovery
+> should run *before* build — this repo already violates that order once;
+> it shouldn't again.
 
-When a `discover`-flow run produces product-level discovery output (problem
-framing, user/stakeholder findings, constraints, alternatives considered),
-it belongs here. Feature-level discovery notes belong in the corresponding
-`docs/features/<feature-slug>/` directory instead.
+## Job to Be Done
 
-See [`docs/product/spec.md`](spec.md) and [`docs/product/design.md`](design.md)
-for the existing product-level specification and design, which this
-discovery draft would normally precede.
+When I run a small (3-15 person) engineering team shipping on Docker Compose,
+I want a self-hosted stack that gives me production-grade metrics, logs,
+traces, and alerting out of the box, so I can catch and diagnose incidents
+without paying a SaaS observability bill or building my own telemetry stack
+from scratch.
+
+This matches `README.md`'s stated audience directly: *"uFawkesObs is for
+small-to-medium engineering teams (3–15 people) running Docker Compose
+workloads who want production-grade metrics, logs, and traces without a SaaS
+observability bill."*
+
+## Riskiest Assumption
+
+We assume a 3-15 person team will accept operating its own observability
+infrastructure (upgrades, disk growth, backup, on-call for the stack itself)
+in exchange for not paying a SaaS bill. If that operational burden exceeds
+what the team can absorb alongside their actual product, they'll churn to a
+managed SaaS regardless of cost — no amount of pre-provisioned dashboards
+fixes an assumption that's wrong at the root.
+
+This is the same risk `README.md`'s "What This Is Not" section already
+gestures at ("Not horizontally scalable in this release — single-instance
+only... Not multi-tenant") but doesn't state as a testable assumption. It's
+also the reason `docs/KNOWN_LIMITATIONS.md` exists — every limitation listed
+there is a place this assumption could break first.
+
+## Acceptance Criterion
+
+Given a fresh clone of uFawkesObs on a machine with Docker installed, when
+`make up` (or `docker compose --profile core up -d`) is run, then Grafana is
+reachable at `localhost:3000` within 2 minutes with Prometheus, Loki, Tempo,
+and Alertmanager already wired as datasources and at least one pre-provisioned
+dashboard showing live data.
+
+`test_type: live-system` — "ready to use within 2 minutes" is a claim about
+the real compose stack converging to healthy and dashboards resolving live
+queries; no mock or unit test can stand in for actually starting the
+containers and observing Grafana render data.
+
+## DORA Outcome Target
+
+- Capability: Monitoring and Observability (DORA Core Capability) — uFawkesObs
+  is the substrate other planes (uFawkesPipe, uFawkesDevX, uFawkesDORA) build
+  their own DORA Core Capability 6 (User-Centric Focus) and delivery metrics
+  on top of; it doesn't measure its own AI capability directly.
+- Metric: `time_to_first_signal_minutes` — wall-clock time from a fresh clone
+  to a live, data-populated Grafana dashboard.
+- Current baseline: not yet measured — establish it by timing
+  `scripts/smoke-test.sh` from a clean checkout.
+- Target: < 2 minutes (matches the acceptance criterion above).
+- Measurement: manual timing today; a candidate future improvement is having
+  `scripts/smoke-test.sh` emit its own duration so this becomes
+  self-measuring rather than a manual stopwatch exercise.
+
+## Prior Art
+
+Grafana Cloud's free tier, Datadog, SigNoz, and OpenObserve all solve some
+version of this problem already. uFawkesObs's answer isn't a new telemetry
+backend — it composes the same OSS components those vendors build on
+(Prometheus, Loki, Tempo, Grafana, OpenTelemetry Collector, Alertmanager),
+pre-wired and pre-provisioned via Docker Compose, so a small team gets close
+to the vendor's default experience without the vendor's invoice or the
+multi-week integration effort of standing up each component by hand.
+
+## Honest Limitations of This Brief
+
+A candid read of this document, not a flattering one:
+
+- **Retroactive, not gating.** This was written after M2–M4 shipped and
+  merged. Real discovery would have run before that work started and could
+  have changed its scope; this brief could not and did not. Treat it as an
+  audit of the assumption already baked into the existing spec/design, not
+  as evidence the assumption was validated before building on it.
+- **The persona was inferred, not researched.** "solo-entrepreneur" (with
+  `platform-engineer` as secondary) was derived from one sentence in
+  `README.md`, not from user interviews, support tickets, GitHub issue
+  patterns, or usage telemetry — because none of those currently exist for
+  this repo. It's a reasonable placeholder read from the closest available
+  evidence, not a researched finding. Don't cite it as if real users were
+  consulted.
+- **The riskiest assumption is named, not tested.** Stating "we assume a
+  3-15 person team will accept the ops burden" is the easy half of
+  discovery. No experiment has run to falsify it — there's no interview
+  data, no churn signal, no adoption-vs-abandonment comparison. Until one of
+  the experiments below runs, this assumption is a hypothesis, not a
+  validated (or invalidated) finding.
+- **The DORA-outcome mapping is a template fit, not a natural fit.**
+  `time_to_first_signal_minutes` is an onboarding-friction metric. Mapping
+  it to the DORA "Monitoring and Observability" core capability satisfies
+  the discovery skill's required schema field, but this product's actual
+  users (small teams evaluating whether to self-host observability) don't
+  care about DORA taxonomy — they care about "will this work with minimal
+  effort." Read the DORA mapping as bookkeeping for pipeline consistency
+  across the uFawkes suite, not as a claim that DORA outcomes are what this
+  particular decision turns on.
+
+## Next Actual Discovery Experiment
+
+What would make the riskiest assumption stop being a guess, ranked cheapest
+first:
+
+1. **Measure the acceptance criterion for real, now.** Time
+   `scripts/smoke-test.sh` against a genuinely fresh clone and record the
+   actual `time_to_first_signal_minutes` baseline. This is achievable
+   immediately, with no user contact required, and turns "not yet measured"
+   into a real number.
+2. **Mine existing low-cost signal before running new experiments.** Check
+   GitHub repo Insights (clone/traffic trends vs. stars, return-visitor
+   rate) and scan open/closed issues for operational-burden complaints
+   (disk growth, upgrade pain, "how do I back this up" questions). This is
+   free, uses data that already exists, and would show early churn signal
+   without needing to design a survey.
+3. **If (1) and (2) don't settle it, ask directly.** Post a short
+   discussion/issue template aimed at anyone who starred or forked the repo
+   but never adopted it: "what stopped you?" A handful of real responses
+   would outweigh everything in this brief.
+4. Whichever of the above runs first should update `baseline` in this
+   file's frontmatter and flip the riskiest assumption from "asserted" to
+   either "supported" or "falsified" — don't let this brief go stale as a
+   permanent hypothesis.
+
+## Notes
+
+- Secondary persona: the person actually running `make up` day-to-day is
+  often closer to the `platform-engineer` persona (from the `discovery`
+  skill's persona reference table) than a "solo-entrepreneur" in the
+  literal sense — a designated platform/ops-minded engineer inside a
+  3-15 person team, not necessarily its founder. The JTBD and acceptance
+  criterion above hold either way; only the framing of "why this matters to
+  the business" differs.
+- This brief does not re-derive the full functional scope — that's
+  `docs/product/spec.md` §4. It exists to answer *why* that scope was chosen,
+  which the spec alone doesn't state.
+- Known limitations that bear directly on the riskiest assumption (single-
+  instance, no multi-tenancy, local filesystem storage only, no TLS between
+  internal services) are already tracked in `docs/KNOWN_LIMITATIONS.md` —
+  treat that file as the running list of ways this assumption could fail in
+  practice, and revisit this brief if any of them get worse rather than
+  better in a small-team deployment.

--- a/docs/product/spec.md
+++ b/docs/product/spec.md
@@ -1,10 +1,11 @@
 # uFawkesObs — Specification
 
-**Version:** 1.0.0
-**Date:** 2026-06-28
+**Version:** 1.1.0
+**Date:** 2026-07-27
 **Repo:** paruff/uFawkesObs
 **Plane:** Observability
 **Status:** Approved
+**Discovery:** [`docs/product/discovery-draft.md`](discovery-draft.md)
 
 ---
 
@@ -42,9 +43,9 @@ Rather than having each repository or plane provision its own isolated, custom t
 | Milestone | Theme | Scope | Status |
 |---|---|---|---|
 | **M1 (v1.0.0)** | Substrate Core | Core Docker Compose stack (OTel Collector, Prometheus, Alertmanager, Tempo, Loki, Alloy, Grafana) with automated local unit/integration test gates. | **Completed** |
-| **M2 (v1.1.0)** | Repo Hardening | Standardized CONTRIBUTING rules, issue templates, ARCHITECTURE mapping, KNOWN_LIMITATIONS documentation, and repo badges. | **Backlog** (M2-01 to M2-05) |
-| **M3 (v1.2.0)** | Cross-Plane Docs | Structured guides for joining uFawkesPipe, uFawkesDevX, and Backstage catalog registration. | **Backlog** (M3-01 to M3-04) |
-| **M4 (v1.3.0)** | DORA & Ecosystem | Wire uFawkesObs to uFawkesDORA compute plane and uFawkesRes shared PostgreSQL, implement Prometheus DORA recording rules, and provision Grafana DORA dashboards. | **Backlog** (M4-01 to M4-04) |
+| **M2 (v1.1.0)** | Repo Hardening | Standardized CONTRIBUTING rules, issue templates, ARCHITECTURE mapping, KNOWN_LIMITATIONS documentation, and repo badges. | **Completed** (M2-01 to M2-04) |
+| **M3 (v1.2.0)** | Cross-Plane Docs | Structured guides for joining uFawkesPipe, uFawkesDevX, and Backstage catalog registration. | **Completed** (M3-01 to M3-04; M3-05 shipped under a narrowed scope, PR #138) |
+| **M4 (v1.3.0)** | DORA & Ecosystem | Wire uFawkesObs to uFawkesDORA compute plane and uFawkesRes shared PostgreSQL, implement Prometheus DORA recording rules, and provision Grafana DORA dashboards. | **Completed** (M4-01 to M4-04) |
 | **M5 (v2.0.0)** | Kubernetes Deploy | Kubernetes deployment ADR, Helm charts for the core stack, k3d local simulator, and k8s-based acceptance pipelines. | **Backlog** (M5-01 to M5-04) |
 
 ---
@@ -60,13 +61,13 @@ Rather than having each repository or plane provision its own isolated, custom t
 - **OBS-F05:** Pre-load system performance dashboards for host system, container logs, and telemetry flow metrics.
 - **OBS-F06:** Run automated health checking of all stack services via Docker Compose healthchecks and local test automation.
 
-### 4.2 Backlog — Repository Hardening & Cross-Plane (M2 & M3)
+### 4.2 Completed — Repository Hardening & Cross-Plane (M2 & M3)
 
 - **OBS-F10:** Document the precise network join patterns in `multi-stack-integration.md` to allow other planes (e.g., developerd, deliveryd) to join the `observability-lab` Docker bridge network.
 - **OBS-F11:** Register uFawkesObs into fawkes Backstage catalog-info.yaml metadata.
 - **OBS-F12:** Provide clear guide explaining how uFawkesPipe CI pipelines can export OTLP tracing to uFawkesObs Tempo.
 
-### 4.3 Backlog — DORA & Ecosystem Integration (M4)
+### 4.3 Completed — DORA & Ecosystem Integration (M4)
 
 - **OBS-F20:** Define the DORA data contract mapping of what counts as a deployment, incident, and lead-time event inside uFawkesObs telemetry. This contract is consumed by uFawkesDORA's ingestion API.
 - **OBS-F21:** Implement Prometheus recording rules inside `config/prometheus/rules/` computing Deployment Frequency, Lead Time for Changes, Change Failure Rate, and Failed Deployment Recovery Time (FDRT).
@@ -113,10 +114,12 @@ Rather than having each repository or plane provision its own isolated, custom t
 | Component | Version | Role | Mount / Vol Data | Configuration File |
 |---|---|---|---|---|
 | **OpenTelemetry Collector** | `0.120.0` | Telemetry processing and fanout | None | `config/otel/collector.yaml` |
-| **Prometheus** | `v2.55.1` | Metrics TSDB & scrape engine | `./data/prometheus` | `config/prometheus/prometheus.yaml` |
-| **Alertmanager** | `v0.27.0` | Notification aggregator & router | `./data/alertmanager` | `config/alertmanager/alertmanager.yml` |
+| **OpenTelemetry Collector (DORA)** | `0.120.0` | Second collector instance, `dora` profile only, forwards to uFawkesDORA ingestion | None | `config/otel/collector-dora.yaml` |
+| **Prometheus** | `v3.5.4` | Metrics TSDB & scrape engine | `./data/prometheus` | `config/prometheus/prometheus.yaml` |
+| **Alertmanager** | `v0.28.0` | Notification aggregator & router | `./data/alertmanager` | `config/alertmanager/alertmanager.yml` |
 | **Tempo** | `2.10.5` | Distributed trace database | `./data/tempo` | `config/tempo/tempo.yaml` |
-| **Loki** | `2.9.10` | Log indexer & backend | `./data/loki` | `config/loki/loki.yaml` |
+| **Loki** | `3.3.2` | Log indexer & backend | `./data/loki` | `config/loki/loki.yaml` |
 | **Alloy** | `v1.12.2` | Container log discovery & forwarding | `./data/alloy` | `config/alloy/config.river` |
-| **Grafana** | `10.4.5` | Metrics, logs, & trace dashboard UI | `./data/grafana` | `config/grafana/grafana.ini` |
+| **Grafana** | `12.3.7` | Metrics, logs, & trace dashboard UI | `./data/grafana` | `config/grafana/grafana.ini` |
 | **Node Exporter** | `v1.8.1` | Host system exporter | Host read mounts | None |
+| **telemetry-generator** | n/a (in-repo Go app) | Demo instrumented app; emits OTLP metrics/logs/traces for stack verification | None | `apps/telemetry-generator/` |


### PR DESCRIPTION
## Summary
- Cherry-picks commit `7cf0b60` (originally landed via #173) onto `main`.
- That commit merged into `chore/audit-remediation-p0-p1` via #173 *after* #172 had already merged that same branch into `main`, so it never actually reached `main` — this PR closes that gap.
- Populates `docs/product/discovery-draft.md` with a full, honest retrospective discovery brief (explicitly flags it was written after M2–M4 shipped, persona inferred not researched, includes a "Next Actual Discovery Experiment" section).
- Syncs `docs/product/spec.md` (M2/M3/M4 status Backlog → Completed, corrected stack versions) and `docs/product/design.md` (expanded repo structure, DORA section reframed from forward-looking to as-built) to match current repo state.
- Adds root `CLAUDE.md` importing `AGENTS.md` via `@AGENTS.md`.
- `docs/product/tasks.json` is unaffected — it wasn't touched by the original commit and already matches on `main`.

## Test plan
- [x] Clean cherry-pick, no conflicts
- [ ] CI green on this PR