### PR TITLE
fix(grafana): repair Platform/Services dashboard variable plumbing

### DIFF
--- a/dashboards/platform/alertmanager-overview.json
+++ b/dashboards/platform/alertmanager-overview.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(alertmanager_alerts{cluster=~\"$cluster\",namespace=~\"$namespace\",state=\"active\"})",
+          "expr": "sum(alertmanager_alerts{state=\"active\"})",
           "refId": "A"
         }
       ],
@@ -140,7 +142,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -153,7 +157,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(alertmanager_alerts{cluster=~\"$cluster\",namespace=~\"$namespace\",state=\"suppressed\"})",
+          "expr": "sum(alertmanager_alerts{state=\"suppressed\"})",
           "refId": "A"
         }
       ],
@@ -206,7 +210,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -219,7 +225,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(alertmanager_silences{cluster=~\"$cluster\",namespace=~\"$namespace\",state=\"active\"})",
+          "expr": "sum(alertmanager_silences{state=\"active\"})",
           "refId": "A"
         }
       ],
@@ -264,7 +270,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -277,7 +285,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(alertmanager_alert_groups{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(alertmanager_alert_groups)",
           "refId": "A"
         }
       ],
@@ -363,7 +371,9 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -380,7 +390,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(alertmanager_alerts_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (pod)",
+          "expr": "sum(rate(alertmanager_alerts_received_total[5m])) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -454,7 +464,9 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -471,7 +483,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(alertmanager_alerts_invalid_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (pod)",
+          "expr": "sum(rate(alertmanager_alerts_invalid_total[5m])) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -558,7 +570,9 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -575,7 +589,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(alertmanager_notifications_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (integration)",
+          "expr": "sum(rate(alertmanager_notifications_total[5m])) by (integration)",
           "legendFormat": "{{integration}}",
           "refId": "A"
         }
@@ -649,7 +663,9 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -666,7 +682,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(alertmanager_notifications_failed_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (integration)",
+          "expr": "sum(rate(alertmanager_notifications_failed_total[5m])) by (integration)",
           "legendFormat": "{{integration}}",
           "refId": "A"
         }
@@ -753,7 +769,9 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -770,7 +788,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(alertmanager_notification_latency_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le, integration))",
+          "expr": "histogram_quantile(0.99, sum(rate(alertmanager_notification_latency_seconds_bucket[5m])) by (le, integration))",
           "legendFormat": "{{integration}} p99",
           "refId": "A"
         },
@@ -779,7 +797,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(alertmanager_notification_latency_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le, integration))",
+          "expr": "histogram_quantile(0.50, sum(rate(alertmanager_notification_latency_seconds_bucket[5m])) by (le, integration))",
           "legendFormat": "{{integration}} p50",
           "refId": "B"
         }
@@ -853,7 +871,9 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -870,7 +890,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(alertmanager_nflog_query_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(alertmanager_nflog_query_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
@@ -879,7 +899,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(alertmanager_nflog_query_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(alertmanager_nflog_query_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "B"
         }
@@ -890,7 +910,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["platform", "alertmanager", "alerts"],
+  "tags": [
+    "platform",
+    "alertmanager",
+    "alerts"
+  ],
   "templating": {
     "list": [
       {
@@ -910,81 +934,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
       }
     ]
   },

--- a/dashboards/platform/alloy-overview.json
+++ b/dashboards/platform/alloy-overview.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_receiver_accepted_spans{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_receiver_accepted_spans[5m]))",
           "refId": "A"
         }
       ],
@@ -148,7 +150,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -161,7 +165,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_receiver_accepted_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_receiver_accepted_metric_points[5m]))",
           "refId": "A"
         }
       ],
@@ -214,7 +218,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -227,7 +233,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_receiver_accepted_log_records{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_receiver_accepted_log_records[5m]))",
           "refId": "A"
         }
       ],
@@ -280,7 +286,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -293,7 +301,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max(process_uptime_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\".*otel.*\"})",
+          "expr": "max(process_uptime_seconds{job=~\".*otel.*\"})",
           "refId": "A"
         }
       ],
@@ -379,7 +387,9 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -396,7 +406,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_processor_dropped_spans{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (processor)",
+          "expr": "sum(rate(otelcol_processor_dropped_spans[5m])) by (processor)",
           "legendFormat": "{{processor}}",
           "refId": "A"
         }
@@ -470,7 +480,9 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -487,7 +499,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_processor_dropped_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (processor)",
+          "expr": "sum(rate(otelcol_processor_dropped_metric_points[5m])) by (processor)",
           "legendFormat": "{{processor}}",
           "refId": "A"
         }
@@ -574,7 +586,9 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -591,7 +605,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_exporter_send_failed_spans{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (exporter)",
+          "expr": "sum(rate(otelcol_exporter_send_failed_spans[5m])) by (exporter)",
           "legendFormat": "{{exporter}}",
           "refId": "A"
         }
@@ -665,7 +679,9 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -682,7 +698,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_exporter_send_failed_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (exporter)",
+          "expr": "sum(rate(otelcol_exporter_send_failed_metric_points[5m])) by (exporter)",
           "legendFormat": "{{exporter}}",
           "refId": "A"
         }
@@ -769,7 +785,10 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "max"],
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -786,7 +805,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "otelcol_exporter_queue_size{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "otelcol_exporter_queue_size",
           "legendFormat": "{{exporter}}",
           "refId": "A"
         }
@@ -860,7 +879,9 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -877,7 +898,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "otelcol_exporter_queue_capacity{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "otelcol_exporter_queue_capacity",
           "legendFormat": "{{exporter}}",
           "refId": "A"
         }
@@ -964,7 +985,10 @@
       "id": 11,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "max"],
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -981,7 +1005,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\".*otel.*\"}[5m])",
+          "expr": "rate(process_cpu_seconds_total{job=~\".*otel.*\"}[5m])",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1055,7 +1079,10 @@
       "id": 12,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "max"],
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -1072,7 +1099,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\".*otel.*\"}",
+          "expr": "process_resident_memory_bytes{job=~\".*otel.*\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1083,7 +1110,12 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["platform", "alloy", "otel", "collector"],
+  "tags": [
+    "platform",
+    "alloy",
+    "otel",
+    "collector"
+  ],
   "templating": {
     "list": [
       {
@@ -1103,81 +1135,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
       }
     ]
   },

--- a/dashboards/platform/global-health.json
+++ b/dashboards/platform/global-health.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(ALERTS{alertstate=\"firing\",cluster=~\"$cluster\"})",
+          "expr": "sum(ALERTS{alertstate=\"firing\"})",
           "refId": "A"
         }
       ],
@@ -144,7 +146,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -157,7 +161,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(ALERTS{alertstate=\"firing\",severity=\"critical\",cluster=~\"$cluster\"})",
+          "expr": "sum(ALERTS{alertstate=\"firing\",severity=\"critical\"})",
           "refId": "A"
         }
       ],
@@ -245,7 +249,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(prometheus_tsdb_head_samples_appended_total{cluster=~\"$cluster\"}[5m]))",
+          "expr": "sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))",
           "refId": "A"
         }
       ],
@@ -333,7 +337,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(loki_distributor_lines_received_total{cluster=~\"$cluster\"}[5m]))",
+          "expr": "sum(rate(loki_distributor_lines_received_total[5m]))",
           "refId": "A"
         }
       ],
@@ -429,7 +433,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
@@ -441,7 +447,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "up{cluster=~\"$cluster\",job=~\"prometheus|loki|tempo|grafana|alertmanager|alloy|otel-collector\"}",
+          "expr": "up{job=~\"prometheus|loki|tempo|grafana|alertmanager|alloy|otel-collector\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -499,16 +505,23 @@
       },
       "id": 6,
       "options": {
-        "displayLabels": ["name", "percent"],
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
         "legend": {
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "values": ["value"]
+          "values": [
+            "value"
+          ]
         },
         "pieType": "donut",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -524,7 +537,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_storage_blocks_bytes{cluster=~\"$cluster\"}",
+          "expr": "prometheus_tsdb_storage_blocks_bytes",
           "legendFormat": "Prometheus",
           "refId": "A"
         },
@@ -533,7 +546,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(loki_ingester_chunk_stored_bytes_total{cluster=~\"$cluster\"})",
+          "expr": "sum(loki_ingester_chunk_stored_bytes_total)",
           "legendFormat": "Loki",
           "refId": "B"
         },
@@ -542,7 +555,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(tempo_ingester_bytes_received_total{cluster=~\"$cluster\"})",
+          "expr": "sum(tempo_ingester_bytes_received_total)",
           "legendFormat": "Tempo",
           "refId": "C"
         }
@@ -627,7 +640,10 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -644,7 +660,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (job) (rate(prometheus_tsdb_head_samples_appended_total{cluster=~\"$cluster\"}[5m]))",
+          "expr": "sum by (job) (rate(prometheus_tsdb_head_samples_appended_total[5m]))",
           "legendFormat": "{{job}}",
           "refId": "A"
         }
@@ -716,7 +732,10 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -733,7 +752,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (job) (rate(loki_distributor_lines_received_total{cluster=~\"$cluster\"}[5m]))",
+          "expr": "sum by (job) (rate(loki_distributor_lines_received_total[5m]))",
           "legendFormat": "{{job}}",
           "refId": "A"
         }
@@ -744,7 +763,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["platform", "overview", "health"],
+  "tags": [
+    "platform",
+    "overview",
+    "health"
+  ],
   "templating": {
     "list": [
       {
@@ -764,88 +787,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "production",
-          "value": "production"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [
-          {
-            "selected": false,
-            "text": "production",
-            "value": "production"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          },
-          {
-            "selected": false,
-            "text": "development",
-            "value": "development"
-          }
-        ],
-        "query": "production,staging,development",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },

--- a/dashboards/platform/ingestion-health.json
+++ b/dashboards/platform/ingestion-health.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(prometheus_tsdb_head_samples_appended_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) + sum(rate(otelcol_receiver_accepted_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(prometheus_tsdb_head_samples_appended_total[5m])) + sum(rate(otelcol_receiver_accepted_metric_points[5m]))",
           "refId": "A"
         }
       ],
@@ -148,7 +150,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -161,7 +165,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(loki_distributor_lines_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) + sum(rate(otelcol_receiver_accepted_log_records{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(loki_distributor_lines_received_total[5m])) + sum(rate(otelcol_receiver_accepted_log_records[5m]))",
           "refId": "A"
         }
       ],
@@ -214,7 +218,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -227,7 +233,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(tempo_distributor_spans_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) + sum(rate(otelcol_receiver_accepted_spans{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(tempo_distributor_spans_received_total[5m])) + sum(rate(otelcol_receiver_accepted_spans[5m]))",
           "refId": "A"
         }
       ],
@@ -280,7 +286,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -293,7 +301,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(loki_distributor_bytes_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) + sum(rate(tempo_distributor_bytes_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(loki_distributor_bytes_received_total[5m])) + sum(rate(tempo_distributor_bytes_received_total[5m]))",
           "refId": "A"
         }
       ],
@@ -379,7 +387,10 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "mean"],
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -396,7 +407,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(prometheus_tsdb_head_samples_appended_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))",
           "legendFormat": "Prometheus",
           "refId": "A"
         },
@@ -405,7 +416,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_receiver_accepted_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_receiver_accepted_metric_points[5m]))",
           "legendFormat": "OTel Collector",
           "refId": "B"
         }
@@ -479,7 +490,10 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "mean"],
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -496,7 +510,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(loki_distributor_lines_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(loki_distributor_lines_received_total[5m]))",
           "legendFormat": "Loki",
           "refId": "A"
         },
@@ -505,7 +519,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_receiver_accepted_log_records{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_receiver_accepted_log_records[5m]))",
           "legendFormat": "OTel Collector",
           "refId": "B"
         }
@@ -592,7 +606,10 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "sum"],
+          "calcs": [
+            "lastNotNull",
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -609,7 +626,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_processor_dropped_spans{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_processor_dropped_spans[5m]))",
           "legendFormat": "Dropped Spans",
           "refId": "A"
         },
@@ -618,7 +635,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_processor_dropped_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_processor_dropped_metric_points[5m]))",
           "legendFormat": "Dropped Metrics",
           "refId": "B"
         },
@@ -627,7 +644,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_processor_dropped_log_records{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_processor_dropped_log_records[5m]))",
           "legendFormat": "Dropped Logs",
           "refId": "C"
         },
@@ -636,7 +653,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(prometheus_tsdb_head_samples_failed_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(prometheus_tsdb_head_samples_failed_total[5m]))",
           "legendFormat": "Failed Prometheus Samples",
           "refId": "D"
         }
@@ -720,7 +737,10 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "max"],
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -737,7 +757,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * sum(rate(otelcol_processor_dropped_spans{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) / (sum(rate(otelcol_receiver_accepted_spans{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) + 1)",
+          "expr": "100 * sum(rate(otelcol_processor_dropped_spans[5m])) / (sum(rate(otelcol_receiver_accepted_spans[5m])) + 1)",
           "legendFormat": "Spans Drop %",
           "refId": "A"
         },
@@ -746,7 +766,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * sum(rate(otelcol_processor_dropped_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) / (sum(rate(otelcol_receiver_accepted_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) + 1)",
+          "expr": "100 * sum(rate(otelcol_processor_dropped_metric_points[5m])) / (sum(rate(otelcol_receiver_accepted_metric_points[5m])) + 1)",
           "legendFormat": "Metrics Drop %",
           "refId": "B"
         },
@@ -755,7 +775,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * sum(rate(otelcol_processor_dropped_log_records{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) / (sum(rate(otelcol_receiver_accepted_log_records{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) + 1)",
+          "expr": "100 * sum(rate(otelcol_processor_dropped_log_records[5m])) / (sum(rate(otelcol_receiver_accepted_log_records[5m])) + 1)",
           "legendFormat": "Logs Drop %",
           "refId": "C"
         }
@@ -842,7 +862,10 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "sum"],
+          "calcs": [
+            "lastNotNull",
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -859,7 +882,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_receiver_refused_spans{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_receiver_refused_spans[5m]))",
           "legendFormat": "Refused Spans",
           "refId": "A"
         },
@@ -868,7 +891,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_receiver_refused_metric_points{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_receiver_refused_metric_points[5m]))",
           "legendFormat": "Refused Metrics",
           "refId": "B"
         },
@@ -877,7 +900,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(otelcol_receiver_refused_log_records{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(otelcol_receiver_refused_log_records[5m]))",
           "legendFormat": "Refused Logs",
           "refId": "C"
         },
@@ -886,7 +909,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(prometheus_tsdb_head_samples_out_of_order_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(prometheus_tsdb_head_samples_out_of_order_total[5m]))",
           "legendFormat": "Out-of-order Samples",
           "refId": "D"
         }
@@ -970,7 +993,10 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "max"],
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -987,7 +1013,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * otelcol_exporter_queue_size{cluster=~\"$cluster\",namespace=~\"$namespace\"} / (otelcol_exporter_queue_capacity{cluster=~\"$cluster\",namespace=~\"$namespace\"} + 1)",
+          "expr": "100 * otelcol_exporter_queue_size / (otelcol_exporter_queue_capacity + 1)",
           "legendFormat": "{{exporter}} queue",
           "refId": "A"
         }
@@ -998,7 +1024,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["platform", "ingestion", "health"],
+  "tags": [
+    "platform",
+    "ingestion",
+    "health"
+  ],
   "templating": {
     "list": [
       {
@@ -1018,81 +1048,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
       }
     ]
   },

--- a/dashboards/platform/loki-overview.json
+++ b/dashboards/platform/loki-overview.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(loki_distributor_lines_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(loki_distributor_lines_received_total[5m]))",
           "refId": "A"
         }
       ],
@@ -148,7 +150,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -161,7 +165,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(loki_distributor_bytes_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(loki_distributor_bytes_received_total[5m]))",
           "refId": "A"
         }
       ],
@@ -214,7 +218,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -227,7 +233,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(loki_ingester_streams{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(loki_ingester_streams)",
           "refId": "A"
         }
       ],
@@ -280,7 +286,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -293,7 +301,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(loki_compactor_pending_compaction_blocks{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(loki_compactor_pending_compaction_blocks)",
           "refId": "A"
         }
       ],
@@ -379,7 +387,9 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -396,7 +406,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(loki_query_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(loki_query_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
@@ -405,7 +415,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(loki_query_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(loki_query_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -414,7 +424,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(loki_query_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(loki_query_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "C"
         }
@@ -488,7 +498,9 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -505,7 +517,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(loki_request_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\",route=~\".*query.*\"}[5m])) by (route)",
+          "expr": "sum(rate(loki_request_duration_seconds_count{route=~\".*query.*\"}[5m])) by (route)",
           "legendFormat": "{{route}}",
           "refId": "A"
         }
@@ -592,7 +604,9 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -609,7 +623,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(loki_ingester_chunks_flushed_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (reason)",
+          "expr": "sum(rate(loki_ingester_chunks_flushed_total[5m])) by (reason)",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -683,7 +697,9 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -700,7 +716,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(loki_ingester_memory_chunks{cluster=~\"$cluster\",namespace=~\"$namespace\"}) by (pod)",
+          "expr": "sum(loki_ingester_memory_chunks) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -787,7 +803,9 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -804,7 +822,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "loki_ingester_streams{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "loki_ingester_streams",
           "legendFormat": "{{pod}} streams",
           "refId": "A"
         }
@@ -878,7 +896,9 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -895,7 +915,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(loki_index_entries{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(loki_index_entries)",
           "legendFormat": "Index entries",
           "refId": "A"
         }
@@ -906,7 +926,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["platform", "loki", "logs"],
+  "tags": [
+    "platform",
+    "loki",
+    "logs"
+  ],
   "templating": {
     "list": [
       {
@@ -926,81 +950,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
       }
     ]
   },

--- a/dashboards/platform/prometheus-overview.json
+++ b/dashboards/platform/prometheus-overview.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_head_series{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "prometheus_tsdb_head_series",
           "refId": "A"
         }
       ],
@@ -140,7 +142,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -153,7 +157,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(prometheus_tsdb_head_samples_appended_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])",
+          "expr": "rate(prometheus_tsdb_head_samples_appended_total[5m])",
           "refId": "A"
         }
       ],
@@ -206,7 +210,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -219,7 +225,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_storage_blocks_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "prometheus_tsdb_storage_blocks_bytes",
           "refId": "A"
         }
       ],
@@ -272,7 +278,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -285,7 +293,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "avg(scrape_duration_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "avg(scrape_duration_seconds)",
           "refId": "A"
         }
       ],
@@ -338,7 +346,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -351,7 +361,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_rule_evaluation_duration_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\",quantile=\"0.99\"}",
+          "expr": "prometheus_rule_evaluation_duration_seconds{quantile=\"0.99\"}",
           "refId": "A"
         }
       ],
@@ -404,7 +414,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -417,7 +429,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_wal_fsync_duration_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\",quantile=\"0.99\"}",
+          "expr": "prometheus_tsdb_wal_fsync_duration_seconds{quantile=\"0.99\"}",
           "refId": "A"
         }
       ],
@@ -501,7 +513,10 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -518,7 +533,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(prometheus_tsdb_head_samples_appended_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])",
+          "expr": "rate(prometheus_tsdb_head_samples_appended_total[5m])",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -590,7 +605,10 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -607,7 +625,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(prometheus_tsdb_out_of_order_samples_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])",
+          "expr": "rate(prometheus_tsdb_out_of_order_samples_total[5m])",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -692,7 +710,10 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -709,7 +730,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "scrape_duration_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "scrape_duration_seconds",
           "legendFormat": "{{job}}",
           "refId": "A"
         }
@@ -781,7 +802,10 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -798,7 +822,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "up{cluster=~\"$cluster\",namespace=~\"$namespace\"} == 0",
+          "expr": "up == 0",
           "legendFormat": "{{job}} - {{instance}}",
           "refId": "A"
         }
@@ -883,7 +907,10 @@
       "id": 11,
       "options": {
         "legend": {
-          "calcs": ["mean", "last"],
+          "calcs": [
+            "mean",
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -900,7 +927,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_storage_blocks_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "prometheus_tsdb_storage_blocks_bytes",
           "legendFormat": "Blocks",
           "refId": "A"
         },
@@ -909,7 +936,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_wal_storage_size_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "prometheus_tsdb_wal_storage_size_bytes",
           "legendFormat": "WAL",
           "refId": "B"
         }
@@ -981,7 +1008,10 @@
       "id": 12,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -998,7 +1028,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_wal_fsync_duration_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "prometheus_tsdb_wal_fsync_duration_seconds",
           "legendFormat": "p{{quantile}}",
           "refId": "A"
         }
@@ -1009,7 +1039,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["platform", "prometheus", "metrics"],
+  "tags": [
+    "platform",
+    "prometheus",
+    "metrics"
+  ],
   "templating": {
     "list": [
       {
@@ -1029,81 +1063,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
       }
     ]
   },

--- a/dashboards/platform/storage-capacity.json
+++ b/dashboards/platform/storage-capacity.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(prometheus_tsdb_storage_blocks_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(prometheus_tsdb_storage_blocks_bytes)",
           "refId": "A"
         }
       ],
@@ -148,7 +150,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -161,7 +165,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(loki_ingester_bytes_stored{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(loki_ingester_bytes_stored)",
           "refId": "A"
         }
       ],
@@ -214,7 +218,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -227,7 +233,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(tempodb_blocklist_length{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(tempodb_blocklist_length)",
           "refId": "A"
         }
       ],
@@ -280,7 +286,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -293,7 +301,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(prometheus_tsdb_wal_storage_size_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(prometheus_tsdb_wal_storage_size_bytes)",
           "refId": "A"
         }
       ],
@@ -379,7 +387,10 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "mean"],
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -396,7 +407,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_storage_blocks_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "prometheus_tsdb_storage_blocks_bytes",
           "legendFormat": "{{pod}} blocks",
           "refId": "A"
         },
@@ -405,7 +416,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_wal_storage_size_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "prometheus_tsdb_wal_storage_size_bytes",
           "legendFormat": "{{pod}} WAL",
           "refId": "B"
         }
@@ -479,7 +490,10 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "mean"],
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -496,7 +510,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "deriv(prometheus_tsdb_storage_blocks_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1h])",
+          "expr": "deriv(prometheus_tsdb_storage_blocks_bytes[1h])",
           "legendFormat": "Prometheus {{pod}}",
           "refId": "A"
         },
@@ -505,7 +519,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(loki_distributor_bytes_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])",
+          "expr": "rate(loki_distributor_bytes_received_total[5m])",
           "legendFormat": "Loki ingested",
           "refId": "B"
         }
@@ -592,7 +606,9 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -609,7 +625,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "time() - prometheus_tsdb_lowest_timestamp{cluster=~\"$cluster\",namespace=~\"$namespace\"} / 1000",
+          "expr": "time() - prometheus_tsdb_lowest_timestamp / 1000",
           "legendFormat": "{{pod}} data age",
           "refId": "A"
         }
@@ -683,7 +699,10 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "max"],
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -700,7 +719,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "prometheus_tsdb_blocks_loaded{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "prometheus_tsdb_blocks_loaded",
           "legendFormat": "Prometheus {{pod}}",
           "refId": "A"
         },
@@ -709,7 +728,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "tempodb_blocklist_length{cluster=~\"$cluster\",namespace=~\"$namespace\"}",
+          "expr": "tempodb_blocklist_length",
           "legendFormat": "Tempo {{pod}}",
           "refId": "B"
         }
@@ -776,7 +795,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -789,7 +810,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(prometheus_tsdb_storage_blocks_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}[24h], 86400)",
+          "expr": "predict_linear(prometheus_tsdb_storage_blocks_bytes[24h], 86400)",
           "legendFormat": "Projected in 24h",
           "refId": "A"
         }
@@ -863,7 +884,9 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -880,7 +903,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(prometheus_tsdb_compactions_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])",
+          "expr": "rate(prometheus_tsdb_compactions_total[5m])",
           "legendFormat": "Prometheus {{pod}}",
           "refId": "A"
         },
@@ -889,7 +912,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(loki_compactor_compaction_operations_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])",
+          "expr": "rate(loki_compactor_compaction_operations_total[5m])",
           "legendFormat": "Loki {{pod}}",
           "refId": "B"
         }
@@ -900,7 +923,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["platform", "storage", "capacity"],
+  "tags": [
+    "platform",
+    "storage",
+    "capacity"
+  ],
   "templating": {
     "list": [
       {
@@ -920,81 +947,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
       }
     ]
   },

--- a/dashboards/platform/tempo-overview.json
+++ b/dashboards/platform/tempo-overview.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(tempo_distributor_spans_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(tempo_distributor_spans_received_total[5m]))",
           "refId": "A"
         }
       ],
@@ -148,7 +150,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -161,7 +165,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(tempo_distributor_bytes_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(rate(tempo_distributor_bytes_received_total[5m]))",
           "refId": "A"
         }
       ],
@@ -214,7 +218,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -227,7 +233,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(tempo_ingester_live_traces{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(tempo_ingester_live_traces)",
           "refId": "A"
         }
       ],
@@ -280,7 +286,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -293,7 +301,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(tempo_compactor_compaction_objects_total{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+          "expr": "sum(tempo_compactor_compaction_objects_total)",
           "refId": "A"
         }
       ],
@@ -379,7 +387,9 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -396,7 +406,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(tempo_query_frontend_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(tempo_query_frontend_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
@@ -405,7 +415,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(tempo_query_frontend_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(tempo_query_frontend_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -414,7 +424,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(tempo_query_frontend_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(tempo_query_frontend_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "C"
         }
@@ -488,7 +498,9 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -505,7 +517,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(tempo_query_frontend_search_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(tempo_query_frontend_search_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
@@ -514,7 +526,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(tempo_query_frontend_search_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(tempo_query_frontend_search_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "B"
         }
@@ -601,7 +613,9 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -618,7 +632,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(tempo_distributor_spans_received_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (pod)",
+          "expr": "sum(rate(tempo_distributor_spans_received_total[5m])) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -692,7 +706,9 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -709,7 +725,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(tempo_distributor_push_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (pod)",
+          "expr": "sum(rate(tempo_distributor_push_requests_total[5m])) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -796,7 +812,9 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -813,7 +831,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(tempo_ingester_flush_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])) by (pod)",
+          "expr": "sum(rate(tempo_ingester_flush_total[5m])) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -887,7 +905,9 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -904,7 +924,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(tempo_ingester_blocks_per_tenant{cluster=~\"$cluster\",namespace=~\"$namespace\"}) by (pod)",
+          "expr": "sum(tempo_ingester_blocks_per_tenant) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -915,7 +935,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["platform", "tempo", "traces"],
+  "tags": [
+    "platform",
+    "tempo",
+    "traces"
+  ],
   "templating": {
     "list": [
       {
@@ -935,81 +959,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, environment)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
       }
     ]
   },

--- a/dashboards/services/service-capacity.json
+++ b/dashboards/services/service-capacity.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -140,7 +142,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -153,7 +157,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))[7d:5m], 7*24*3600)",
+          "expr": "predict_linear(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))[7d:5m], 7*24*3600)",
           "refId": "A"
         }
       ],
@@ -198,7 +202,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -211,7 +217,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))[30d:5m], 30*24*3600)",
+          "expr": "predict_linear(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))[30d:5m], 30*24*3600)",
           "refId": "A"
         }
       ],
@@ -264,7 +270,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -277,7 +285,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[7d])) - sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[7d] offset 7d))) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[7d] offset 7d))",
+          "expr": "(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[7d])) - sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[7d] offset 7d))) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[7d] offset 7d))",
           "refId": "A"
         }
       ],
@@ -347,7 +355,10 @@
               {
                 "id": "custom.lineStyle",
                 "value": {
-                  "dash": [10, 10],
+                  "dash": [
+                    10,
+                    10
+                  ],
                   "fill": "dash"
                 }
               }
@@ -364,7 +375,11 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "last"],
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -381,7 +396,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "current",
           "refId": "A"
         },
@@ -390,7 +405,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))[7d:5m], 7*24*3600)",
+          "expr": "predict_linear(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))[7d:5m], 7*24*3600)",
           "legendFormat": "predict 7d",
           "refId": "B"
         },
@@ -399,7 +414,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))[30d:5m], 30*24*3600)",
+          "expr": "predict_linear(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))[30d:5m], 30*24*3600)",
           "legendFormat": "predict 30d",
           "refId": "C"
         }
@@ -491,7 +506,10 @@
               {
                 "id": "custom.lineStyle",
                 "value": {
-                  "dash": [10, 10],
+                  "dash": [
+                    10,
+                    10
+                  ],
                   "fill": "dash"
                 }
               }
@@ -508,7 +526,11 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "last"],
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -525,7 +547,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "current",
           "refId": "A"
         },
@@ -534,7 +556,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))[7d:5m], 7*24*3600)",
+          "expr": "predict_linear(sum(rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))[7d:5m], 7*24*3600)",
           "legendFormat": "predict 7d",
           "refId": "B"
         },
@@ -543,7 +565,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))[30d:5m], 30*24*3600)",
+          "expr": "predict_linear(sum(rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))[30d:5m], 30*24*3600)",
           "legendFormat": "predict 30d",
           "refId": "C"
         }
@@ -622,7 +644,10 @@
               {
                 "id": "custom.lineStyle",
                 "value": {
-                  "dash": [10, 10],
+                  "dash": [
+                    10,
+                    10
+                  ],
                   "fill": "dash"
                 }
               }
@@ -639,7 +664,11 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "last"],
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -656,7 +685,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "current",
           "refId": "A"
         },
@@ -665,7 +694,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(sum(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})[7d:5m], 7*24*3600)",
+          "expr": "predict_linear(sum(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})[7d:5m], 7*24*3600)",
           "legendFormat": "predict 7d",
           "refId": "B"
         },
@@ -674,7 +703,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "predict_linear(sum(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})[30d:5m], 30*24*3600)",
+          "expr": "predict_linear(sum(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})[30d:5m], 30*24*3600)",
           "legendFormat": "predict 30d",
           "refId": "C"
         }
@@ -740,7 +769,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -754,7 +785,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (1 - sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])) / count(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}))",
+          "expr": "100 * (1 - sum(rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m])) / count(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}))",
           "refId": "A"
         }
       ],
@@ -806,7 +837,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -820,7 +853,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (1 - sum(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}) / (4 * 1024 * 1024 * 1024 * count(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})))",
+          "expr": "100 * (1 - sum(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"}) / (4 * 1024 * 1024 * 1024 * count(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})))",
           "refId": "A"
         }
       ],
@@ -886,7 +919,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -899,7 +934,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(0.9 - sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))) / (deriv(sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))[7d:5m]) + 0.000001) / 86400",
+          "expr": "(0.9 - sum(rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))) / (deriv(sum(rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))[7d:5m]) + 0.000001) / 86400",
           "refId": "A"
         }
       ],
@@ -965,7 +1000,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -978,7 +1015,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(4 * 1024 * 1024 * 1024 - sum(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})) / (deriv(sum(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})[7d:5m]) + 0.000001) / 86400",
+          "expr": "(4 * 1024 * 1024 * 1024 - sum(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})) / (deriv(sum(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})[7d:5m]) + 0.000001) / 86400",
           "refId": "A"
         }
       ],
@@ -1088,7 +1125,10 @@
       "id": 13,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1105,7 +1145,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (instance) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -1190,7 +1230,10 @@
       "id": 14,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1207,7 +1250,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (instance) (rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "cpu - {{instance}}",
           "refId": "A"
         },
@@ -1216,7 +1259,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "memory - {{instance}}",
           "refId": "B"
         }
@@ -1227,7 +1270,13 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["service", "capacity", "planning", "growth", "scaling"],
+  "tags": [
+    "service",
+    "capacity",
+    "planning",
+    "growth",
+    "scaling"
+  ],
   "templating": {
     "list": [
       {
@@ -1259,64 +1308,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "definition": "label_values(up, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
         "multi": false,
         "name": "service",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "query": "label_values(up, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1334,51 +1333,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "definition": "label_values(up{job=~\"$service\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "query": "label_values(up{job=~\"$service\"}, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "production",
-          "value": "production"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [
-          {
-            "selected": true,
-            "text": "production",
-            "value": "production"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          },
-          {
-            "selected": false,
-            "text": "development",
-            "value": "development"
-          }
-        ],
-        "query": "production,staging,development",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },

--- a/dashboards/services/service-debug.json
+++ b/dashboards/services/service-debug.json
@@ -30,7 +30,7 @@
       "title": "View Logs in Loki",
       "tooltip": "View logs for this service",
       "type": "link",
-      "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22${namespace}%5C%22,service%3D%5C%22${service}%5C%22%7D%22%7D%5D%7D"
+      "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bcompose_service%3D%5C%22${service}%5C%22%7D%22%7D%5D%7D"
     },
     {
       "icon": "external link",
@@ -104,7 +104,7 @@
             {
               "targetBlank": true,
               "title": "View logs",
-              "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22${namespace}%5C%22,service%3D%5C%22${service}%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22${__from}%22,%22to%22:%22${__to}%22%7D%7D"
+              "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bcompose_service%3D%5C%22${service}%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22${__from}%22,%22to%22:%22${__to}%22%7D%7D"
             }
           ],
           "mappings": [],
@@ -176,7 +176,11 @@
       "id": 1,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "sum"],
+          "calcs": [
+            "mean",
+            "max",
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -193,7 +197,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (level) (rate(log_messages_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (level) (rate(log_messages_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{level}}",
           "refId": "A"
         }
@@ -247,7 +251,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -260,7 +266,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(log_messages_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(log_messages_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -313,7 +319,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -326,7 +334,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(log_messages_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",level=~\"error|warn|fatal|critical\"}[5m]))",
+          "expr": "sum(rate(log_messages_total{job=~\"$service\",instance=~\"$instance\",level=~\"error|warn|fatal|critical\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -397,7 +405,11 @@
       "id": 4,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "sum"],
+          "calcs": [
+            "mean",
+            "max",
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -414,7 +426,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(log_messages_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (instance) (rate(log_messages_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -506,7 +518,11 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "sum"],
+          "calcs": [
+            "mean",
+            "max",
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -523,7 +539,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (span_kind) (rate(traces_spanmetrics_calls_total{cluster=~\"$cluster\",namespace=~\"$namespace\",service_name=~\"$service\"}[5m]))",
+          "expr": "sum by (span_kind) (rate(traces_spanmetrics_calls_total{service_name=~\"$service\"}[5m]))",
           "legendFormat": "{{span_kind}}",
           "refId": "A"
         }
@@ -577,7 +593,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -590,7 +608,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(traces_spanmetrics_calls_total{cluster=~\"$cluster\",namespace=~\"$namespace\",service_name=~\"$service\"}[5m]))",
+          "expr": "sum(rate(traces_spanmetrics_calls_total{service_name=~\"$service\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -643,7 +661,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -656,7 +676,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(traces_spanmetrics_calls_total{cluster=~\"$cluster\",namespace=~\"$namespace\",service_name=~\"$service\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}[5m]))",
+          "expr": "sum(rate(traces_spanmetrics_calls_total{service_name=~\"$service\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -727,7 +747,10 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -744,7 +767,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (le) (rate(traces_spanmetrics_latency_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",service_name=~\"$service\"}[5m]))",
+          "expr": "sum by (le) (rate(traces_spanmetrics_latency_bucket{service_name=~\"$service\"}[5m]))",
           "legendFormat": "le {{le}}",
           "refId": "A"
         }
@@ -844,7 +867,12 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "p95", "p99"],
+          "calcs": [
+            "mean",
+            "max",
+            "p95",
+            "p99"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -862,7 +890,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (le, instance) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, instance) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p50 - {{instance}}",
           "refId": "A"
         },
@@ -872,7 +900,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (le, instance) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, instance) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p95 - {{instance}}",
           "refId": "B"
         },
@@ -882,7 +910,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum by (le, instance) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, instance) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p99 - {{instance}}",
           "refId": "C"
         }
@@ -893,7 +921,13 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["service", "debugging", "logs", "traces", "exemplars"],
+  "tags": [
+    "service",
+    "debugging",
+    "logs",
+    "traces",
+    "exemplars"
+  ],
   "templating": {
     "list": [
       {
@@ -925,64 +959,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "definition": "label_values(up, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
         "multi": false,
         "name": "service",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "query": "label_values(up, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1000,51 +984,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "definition": "label_values(up{job=~\"$service\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "query": "label_values(up{job=~\"$service\"}, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "production",
-          "value": "production"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [
-          {
-            "selected": true,
-            "text": "production",
-            "value": "production"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          },
-          {
-            "selected": false,
-            "text": "development",
-            "value": "development"
-          }
-        ],
-        "query": "production,staging,development",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },

--- a/dashboards/services/service-errors.json
+++ b/dashboards/services/service-errors.json
@@ -30,7 +30,7 @@
       "title": "View Error Logs",
       "tooltip": "View error logs in Loki",
       "type": "link",
-      "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22${namespace}%5C%22,service%3D%5C%22${service}%5C%22%7D%20%7C%3D%20%5C%22error%5C%22%22%7D%5D%7D"
+      "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bcompose_service%3D%5C%22${service}%5C%22%7D%20%7C%3D%20%5C%22error%5C%22%22%7D%5D%7D"
     }
   ],
   "liveNow": true,
@@ -94,7 +94,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -107,7 +109,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -160,7 +162,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -173,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"4..\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"4..\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -226,7 +230,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -239,7 +245,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"[45]..\"}[$__range]))",
+          "expr": "sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"[45]..\"}[$__range]))",
           "refId": "A"
         }
       ],
@@ -292,7 +298,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -305,7 +313,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"2..\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"2..\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -407,7 +415,11 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -424,7 +436,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "5xx errors",
           "refId": "A"
         },
@@ -433,7 +445,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"4..\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"4..\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "4xx errors",
           "refId": "B"
         }
@@ -518,7 +530,10 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -535,7 +550,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (status) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"[45]..\"}[5m])))",
+          "expr": "topk(10, sum by (status) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"[45]..\"}[5m])))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -574,16 +589,24 @@
       },
       "id": 7,
       "options": {
-        "displayLabels": ["name", "percent"],
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
         "legend": {
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "values": ["value", "percent"]
+          "values": [
+            "value",
+            "percent"
+          ]
         },
         "pieType": "donut",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -599,7 +622,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (status) (increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"[45]..\"}[5m]))",
+          "expr": "sum by (status) (increase(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"[45]..\"}[5m]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -684,7 +707,10 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -701,7 +727,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (handler) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])))",
+          "expr": "topk(10, sum by (handler) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])))",
           "legendFormat": "{{handler}}",
           "refId": "A"
         }
@@ -773,7 +799,10 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -790,7 +819,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (handler) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"4..\"}[5m])))",
+          "expr": "topk(10, sum by (handler) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"4..\"}[5m])))",
           "legendFormat": "{{handler}}",
           "refId": "A"
         }
@@ -862,7 +891,10 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -879,7 +911,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (handler) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"[45]..\"}[5m])) / sum by (handler) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "topk(10, sum by (handler) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"[45]..\"}[5m])) / sum by (handler) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "{{handler}}",
           "refId": "A"
         }
@@ -964,7 +996,11 @@
       "id": 11,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -981,7 +1017,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum by (instance) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (instance) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum by (instance) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -992,7 +1028,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["service", "errors", "reliability"],
+  "tags": [
+    "service",
+    "errors",
+    "reliability"
+  ],
   "templating": {
     "list": [
       {
@@ -1024,64 +1064,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "definition": "label_values(up, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
         "multi": false,
         "name": "service",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "query": "label_values(up, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1099,51 +1089,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "definition": "label_values(up{job=~\"$service\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "query": "label_values(up{job=~\"$service\"}, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "production",
-          "value": "production"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [
-          {
-            "selected": true,
-            "text": "production",
-            "value": "production"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          },
-          {
-            "selected": false,
-            "text": "development",
-            "value": "development"
-          }
-        ],
-        "query": "production,staging,development",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },

--- a/dashboards/services/service-latency.json
+++ b/dashboards/services/service-latency.json
@@ -158,7 +158,11 @@
       "id": 1,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -175,7 +179,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -184,7 +188,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -193,7 +197,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -260,7 +264,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-9
+          "le": 1e-09
         },
         "legend": {
           "show": true
@@ -285,7 +289,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "refId": "A"
@@ -371,7 +375,10 @@
       "id": 3,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -388,7 +395,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.99, sum by (handler, le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))))",
+          "expr": "topk(10, histogram_quantile(0.99, sum by (handler, le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m]))))",
           "legendFormat": "{{handler}}",
           "refId": "A"
         }
@@ -460,7 +467,10 @@
       "id": 4,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -477,7 +487,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (handler, le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (handler, le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "{{handler}}",
           "refId": "A"
         }
@@ -562,7 +572,9 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["sum"],
+          "calcs": [
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -579,7 +591,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (le) (increase(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (le) (increase(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{le}}s",
           "refId": "A"
         }
@@ -668,7 +680,10 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -685,7 +700,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_request_duration_seconds_sum{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])) / sum(rate(http_request_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_request_duration_seconds_sum{job=~\"$service\",instance=~\"$instance\"}[5m])) / sum(rate(http_request_duration_seconds_count{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "avg latency",
           "refId": "A"
         },
@@ -694,7 +709,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_request_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_request_duration_seconds_count{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "request rate",
           "refId": "B"
         }
@@ -779,7 +794,11 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -796,7 +815,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (instance, le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (instance, le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -807,7 +826,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["service", "latency", "performance"],
+  "tags": [
+    "service",
+    "latency",
+    "performance"
+  ],
   "templating": {
     "list": [
       {
@@ -839,64 +862,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "definition": "label_values(up, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
         "multi": false,
         "name": "service",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "query": "label_values(up, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -914,51 +887,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "definition": "label_values(up{job=~\"$service\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "query": "label_values(up{job=~\"$service\"}, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "production",
-          "value": "production"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [
-          {
-            "selected": true,
-            "text": "production",
-            "value": "production"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          },
-          {
-            "selected": false,
-            "text": "development",
-            "value": "development"
-          }
-        ],
-        "query": "production,staging,development",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },

--- a/dashboards/services/service-overview.json
+++ b/dashboards/services/service-overview.json
@@ -30,7 +30,7 @@
       "title": "View Logs in Loki",
       "tooltip": "View logs for this service",
       "type": "link",
-      "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22${namespace}%5C%22,service%3D%5C%22${service}%5C%22%7D%22%7D%5D%7D"
+      "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bcompose_service%3D%5C%22${service}%5C%22%7D%22%7D%5D%7D"
     },
     {
       "icon": "external link",
@@ -105,7 +105,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -118,7 +120,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -189,7 +191,10 @@
       "id": 2,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -206,7 +211,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (instance) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -252,7 +257,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -265,7 +272,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[$__range]))",
+          "expr": "sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[$__range]))",
           "refId": "A"
         }
       ],
@@ -331,7 +338,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -344,7 +353,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "refId": "A"
         }
       ],
@@ -397,7 +406,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -410,7 +421,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "refId": "A"
         }
       ],
@@ -463,7 +474,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -476,7 +489,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "refId": "A"
         }
       ],
@@ -554,7 +567,10 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -571,7 +587,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -580,7 +596,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -589,7 +605,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -643,7 +659,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-9
+          "le": 1e-09
         },
         "legend": {
           "show": true
@@ -668,7 +684,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "refId": "A"
@@ -741,7 +757,10 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -758,7 +777,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (handler) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "topk(10, sum by (handler) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "{{handler}}",
           "refId": "A"
         }
@@ -825,7 +844,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -838,7 +859,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -890,7 +911,7 @@
             {
               "targetBlank": true,
               "title": "View error logs",
-              "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22${namespace}%5C%22,service%3D%5C%22${service}%5C%22%7D%20%7C%3D%20%5C%22error%5C%22%22%7D%5D,%22range%22:%7B%22from%22:%22${__from}%22,%22to%22:%22${__to}%22%7D%7D"
+              "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bcompose_service%3D%5C%22${service}%5C%22%7D%20%7C%3D%20%5C%22error%5C%22%22%7D%5D,%22range%22:%7B%22from%22:%22${__from}%22,%22to%22:%22${__to}%22%7D%7D"
             }
           ],
           "mappings": [],
@@ -916,7 +937,10 @@
       "id": 11,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -933,7 +957,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum by (instance) (rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (instance) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum by (instance) (rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -987,7 +1011,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1000,7 +1026,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[$__range]))",
+          "expr": "sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[$__range]))",
           "refId": "A"
         }
       ],
@@ -1066,7 +1092,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1079,7 +1107,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -1132,7 +1160,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1145,7 +1175,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})",
           "refId": "A"
         }
       ],
@@ -1229,7 +1259,10 @@
       "id": 15,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1246,7 +1279,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (instance) (rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "cpu - {{instance}}",
           "refId": "A"
         },
@@ -1255,7 +1288,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "memory - {{instance}}",
           "refId": "B"
         }
@@ -1327,7 +1360,10 @@
       "id": 16,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1344,7 +1380,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (process_open_fds{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (process_open_fds{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -1355,7 +1391,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["service", "golden-signals", "overview"],
+  "tags": [
+    "service",
+    "golden-signals",
+    "overview"
+  ],
   "templating": {
     "list": [
       {
@@ -1387,64 +1427,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "definition": "label_values(up, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
         "multi": false,
         "name": "service",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "query": "label_values(up, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1462,51 +1452,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "definition": "label_values(up{job=~\"$service\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "query": "label_values(up{job=~\"$service\"}, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "production",
-          "value": "production"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [
-          {
-            "selected": true,
-            "text": "production",
-            "value": "production"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          },
-          {
-            "selected": false,
-            "text": "development",
-            "value": "development"
-          }
-        ],
-        "query": "production,staging,development",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },

--- a/dashboards/services/service-saturation.json
+++ b/dashboards/services/service-saturation.json
@@ -82,7 +82,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -95,7 +97,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -166,7 +168,11 @@
       "id": 2,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -183,7 +189,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(process_cpu_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m]))",
+          "expr": "sum by (instance) (rate(process_cpu_seconds_total{job=~\"$service\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -255,7 +261,10 @@
       "id": 3,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -272,7 +281,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (rate(container_cpu_cfs_throttled_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\",container=~\"$service\"}[5m]))",
+          "expr": "sum by (instance) (rate(container_cpu_cfs_throttled_seconds_total{container=~\"$service\"}[5m]))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -339,7 +348,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -352,7 +363,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum(process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})",
           "refId": "A"
         }
       ],
@@ -423,7 +434,11 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -440,7 +455,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (process_resident_memory_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (process_resident_memory_bytes{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -512,7 +527,10 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -529,7 +547,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (go_memstats_heap_alloc_bytes{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -596,7 +614,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -609,7 +629,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(go_goroutines{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum(go_goroutines{job=~\"$service\",instance=~\"$instance\"})",
           "refId": "A"
         }
       ],
@@ -680,7 +700,11 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -697,7 +721,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (go_goroutines{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (go_goroutines{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -769,7 +793,10 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -786,7 +813,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (go_threads{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (go_threads{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -871,7 +898,11 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -888,7 +919,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (process_open_fds{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (process_open_fds{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -960,7 +991,9 @@
       "id": 11,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -977,7 +1010,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (process_max_fds{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (process_max_fds{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -1062,7 +1095,10 @@
       "id": 12,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1079,7 +1115,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (workqueue_depth{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (workqueue_depth{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -1151,7 +1187,10 @@
       "id": 13,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1168,7 +1207,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (pool_connections_open{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (pool_connections_open{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "open - {{instance}}",
           "refId": "A"
         },
@@ -1177,7 +1216,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (instance) (pool_connections_idle{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"})",
+          "expr": "sum by (instance) (pool_connections_idle{job=~\"$service\",instance=~\"$instance\"})",
           "legendFormat": "idle - {{instance}}",
           "refId": "B"
         }
@@ -1188,7 +1227,11 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["service", "saturation", "resources"],
+  "tags": [
+    "service",
+    "saturation",
+    "resources"
+  ],
   "templating": {
     "list": [
       {
@@ -1220,64 +1263,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "definition": "label_values(up, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
         "multi": false,
         "name": "service",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "query": "label_values(up, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1295,51 +1288,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "definition": "label_values(up{job=~\"$service\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "query": "label_values(up{job=~\"$service\"}, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "production",
-          "value": "production"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [
-          {
-            "selected": true,
-            "text": "production",
-            "value": "production"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          },
-          {
-            "selected": false,
-            "text": "development",
-            "value": "development"
-          }
-        ],
-        "query": "production,staging,development",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },

--- a/dashboards/services/service-slo.json
+++ b/dashboards/services/service-slo.json
@@ -30,7 +30,7 @@
       "title": "View Error Logs",
       "tooltip": "View error logs for this service",
       "type": "link",
-      "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22${namespace}%5C%22,service%3D%5C%22${service}%5C%22%7D%20%7C%3D%20%5C%22error%5C%22%22%7D%5D%7D"
+      "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bcompose_service%3D%5C%22${service}%5C%22%7D%20%7C%3D%20%5C%22error%5C%22%22%7D%5D%7D"
     }
   ],
   "liveNow": true,
@@ -93,7 +93,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -107,7 +109,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "1 - (sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "1 - (sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "refId": "A"
         }
       ],
@@ -159,7 +161,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -173,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "refId": "A"
         }
       ],
@@ -225,7 +229,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -239,7 +245,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "refId": "A"
         }
       ],
@@ -292,7 +298,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -305,7 +313,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "1 - (sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[30d])) / sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[30d])))",
+          "expr": "1 - (sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[30d])) / sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[30d])))",
           "refId": "A"
         }
       ],
@@ -370,7 +378,9 @@
       "options": {
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -384,7 +394,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (1 - (sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[30d])) / sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[30d])) - 0.999) / 0.001)",
+          "expr": "100 * (1 - (sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[30d])) / sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[30d])) - 0.999) / 0.001)",
           "refId": "A"
         }
       ],
@@ -461,7 +471,10 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "min"],
+          "calcs": [
+            "mean",
+            "min"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -478,7 +491,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * (1 - (sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[30d])) / sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[30d])) - 0.999) / 0.001)",
+          "expr": "100 * (1 - (sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[30d])) / sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[30d])) - 0.999) / 0.001)",
           "legendFormat": "Error Budget Remaining",
           "refId": "A"
         }
@@ -545,7 +558,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -558,7 +573,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "((0.001 * sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[30d])) - sum(increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[30d]))) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h])))",
+          "expr": "((0.001 * sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[30d])) - sum(increase(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[30d]))) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h])))",
           "refId": "A"
         }
       ],
@@ -610,7 +625,7 @@
             {
               "targetBlank": true,
               "title": "View error logs",
-              "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22${namespace}%5C%22,service%3D%5C%22${service}%5C%22%7D%20%7C%3D%20%5C%22error%5C%22%22%7D%5D,%22range%22:%7B%22from%22:%22${__from}%22,%22to%22:%22${__to}%22%7D%7D"
+              "url": "/explore?left=%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bcompose_service%3D%5C%22${service}%5C%22%7D%20%7C%3D%20%5C%22error%5C%22%22%7D%5D,%22range%22:%7B%22from%22:%22${__from}%22,%22to%22:%22${__to}%22%7D%7D"
             }
           ],
           "mappings": [],
@@ -636,7 +651,9 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["sum"],
+          "calcs": [
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -653,7 +670,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (status) (increase(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h]))",
+          "expr": "sum by (status) (increase(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -720,7 +737,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -733,7 +752,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[1h]))) / 0.001",
+          "expr": "(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[1h]))) / 0.001",
           "refId": "A"
         }
       ],
@@ -786,7 +805,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -799,7 +820,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[6h])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[6h]))) / 0.001",
+          "expr": "(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[6h])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[6h]))) / 0.001",
           "refId": "A"
         }
       ],
@@ -878,7 +899,10 @@
       "id": 11,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -895,7 +919,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[1h]))) / 0.001",
+          "expr": "(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[1h]))) / 0.001",
           "legendFormat": "1h (fast)",
           "refId": "A"
         },
@@ -904,7 +928,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[6h])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[6h]))) / 0.001",
+          "expr": "(sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[6h])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[6h]))) / 0.001",
           "legendFormat": "6h (slow)",
           "refId": "B"
         }
@@ -995,7 +1019,10 @@
       "id": 12,
       "options": {
         "legend": {
-          "calcs": ["mean", "min"],
+          "calcs": [
+            "mean",
+            "min"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1012,7 +1039,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "1 - (sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[5m])))",
+          "expr": "1 - (sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[5m])))",
           "legendFormat": "Availability (5m)",
           "refId": "A"
         },
@@ -1021,7 +1048,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "1 - (sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h])) / sum(rate(http_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\",instance=~\"$instance\"}[1h])))",
+          "expr": "1 - (sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\",status=~\"5..\"}[1h])) / sum(rate(http_requests_total{job=~\"$service\",instance=~\"$instance\"}[1h])))",
           "legendFormat": "Availability (1h)",
           "refId": "B"
         }
@@ -1032,7 +1059,13 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["service", "slo", "sli", "error-budget", "burn-rate"],
+  "tags": [
+    "service",
+    "slo",
+    "sli",
+    "error-budget",
+    "burn-rate"
+  ],
   "templating": {
     "list": [
       {
@@ -1064,64 +1097,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up, cluster)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(up, cluster)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\"}, namespace)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "definition": "label_values(up, job)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
         "multi": false,
         "name": "service",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "query": "label_values(up, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1139,51 +1122,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "definition": "label_values(up{job=~\"$service\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$service\"}, instance)",
+        "query": "label_values(up{job=~\"$service\"}, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "production",
-          "value": "production"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Environment",
-        "multi": false,
-        "name": "environment",
-        "options": [
-          {
-            "selected": true,
-            "text": "production",
-            "value": "production"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          },
-          {
-            "selected": false,
-            "text": "development",
-            "value": "development"
-          }
-        ],
-        "query": "production,staging,development",
-        "skipUrlSync": false,
-        "type": "custom"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Removes nonexistent `cluster`/`namespace`/`environment` template variables and label matchers from all 15 Platform and Services folder dashboards — these labels are never scraped by Prometheus (only appear as metadata in `prometheus.yaml`'s `global.external_labels`, not as queryable series labels), so every dropdown was permanently empty and every panel query matched zero series.
- Platform dashboards (8): panel `expr`s no longer filter on dead `cluster=~"$cluster",namespace=~"$namespace"` matchers.
- Services dashboards (7): `service` variable now resolves via `label_values(up, job)` (real job names: prometheus, loki, tempo, alertmanager, otel-collector, etc.) instead of a namespace-scoped query that never returned anything; "View Logs in Loki" link now queries `{compose_service="$service"}` instead of the nonexistent `{namespace=...,service=...}` pair.
- Follow-up to #177, which fixed the Application/Infrastructure dashboards and home dashboard; this closes out item 4 from that audit (the remaining Services/Platform folders).

## AI-Assisted Review Block

**What does this PR do?**
Fixes broken template variable plumbing across 15 Grafana dashboards in the Platform and Services folders. All of them assumed Kubernetes-style `cluster`/`namespace` labels that don't exist in this Docker Compose stack, so their variable dropdowns were always empty and dependent panel queries always returned no data.

**What could go wrong?**
Dashboard JSON is now reformatted (2-space `json.dumps` output) for the touched files, which is a larger diff than the semantic change alone — reviewers should focus on the query/variable content, not the formatting. No config, compose, or scrape-target changes are included.

**What tests cover this change?**
Verified against the live local stack via the Grafana HTTP API and direct Prometheus queries after restarting the `grafana` container:
- All 15 dashboards still load and parse as valid JSON.
- `alertmanager-overview`'s alert-count panel query now returns real data (`sum(alertmanager_alerts{state="active"})` → `5`) instead of an empty result.
- The Services `service` variable's underlying query (`label_values(up, job)`) resolves to the real Prometheus job list (`alertmanager, alloy, grafana, loki, node-exporter, otel-app-metrics, otel-collector, prometheus, tempo, telemetry-generator`).
- No dashboard files retain `$cluster`/`$namespace` references or malformed matcher syntax (`{,`, `,}`, `{}`).

No automated dashboard tests exist in this repo (`tests/unit` covers config YAML/JSON conventions, not Grafana panel semantics) — this is manual/API verification only.

**Architecture check:**
- Only `dashboards/**` touched, per §4 dashboard conventions (datasource UIDs as string refs, no numeric IDs — unaffected by this change).
- No cross-plane impact — this is local Grafana dashboard JSON, not shared with uFawkesPipe/uFawkesRes/uFawkesDORA.

**What I was NOT sure about:**
The Services dashboards' RED-methodology panels (Traffic/Latency/Errors/SLO) query generic metric names like `http_requests_total` that don't exist anywhere in this stack — this is a vendored Kubernetes-microservices dashboard template, not something built for this Compose stack's actual per-component metrics. Fixing the variable plumbing makes the dropdowns work, but those specific panels will still show "No data" until someone maps each job to its real metric names (a separate, larger design task with no clean universal answer — out of scope here). Saturation/Capacity panels use standard Prometheus-client process metrics (`process_cpu_seconds_total`, etc.) and should work for Go-binary components.

## Test plan

- [ ] `docker compose restart grafana` and confirm all 15 dashboards load without JSON errors
- [ ] Spot-check Platform dashboards (Alertmanager, Prometheus, Loki, Tempo, Alloy, Global Health, Ingestion Health, Storage Capacity) show real data on at least one panel
- [ ] Confirm Services dashboards' `service`/`instance` variable dropdowns populate with real job/instance names
- [ ] Confirm "View Logs in Loki" link on a Services dashboard opens Explore with a working `{compose_service="..."}` query