### PR TITLE
docs(plan): add Path to Late Beta plan and tracking issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ steps another agent calls directly.
 | 5        | `docs/CHANGE_IMPACT_MAP.md`  | What breaks when a service config changes                          |
 | 5.5      | `docs/DEPLOYMENT_STRATEGY.md` | Progressive delivery model — must exist before production traffic  |
 | 5.6      | `docs/PR_STANDARD.md`        | PR title and body format rules                                     |
+| 5.7      | `docs/PATH_TO_LATE_BETA.md`  | Beta readiness bar and open gaps — do not close as "beta ready" until these clear |
 
 If any of these don't exist for this repo, agents proceed with what's
 available and note the gap — they don't invent the missing content.

--- a/docs/PATH_TO_LATE_BETA.md
+++ b/docs/PATH_TO_LATE_BETA.md
@@ -1,0 +1,80 @@
+# Path to Late Beta — uFawkesObs
+
+> Living document. "Late beta" is not yet a defined maturity stage anywhere
+> else in this repo — this doc defines it and tracks progress toward it.
+> Update status as issues close.
+
+---
+
+## Where We Are
+
+Milestones M1–M4 are complete (`docs/product/spec.md`): core Compose stack,
+repo hardening, cross-plane integration docs, and DORA/ecosystem wiring are
+all shipped and tagged `v0.1.0`. `main` CI is green. This is effectively
+**alpha** — internally dogfooded, functionally complete for the target
+scope, but never validated against a real external adopter and with several
+known gaps that would burn one on first contact.
+
+## What "Late Beta" Means Here
+
+Per `docs/product/discovery-draft.md`, the target user is a 3–15 person
+engineering team running Docker Compose who wants production-grade metrics,
+logs, traces, and alerting without a SaaS bill. **Late beta means that team
+can clone the repo, run `make up`, and rely on it for real (non-production)
+use with reasonable confidence** — not that uFawkesObs is production-hardened
+or multi-tenant.
+
+Concretely, late beta requires:
+
+1. The onboarding promise is *measured*, not assumed (LB-01).
+2. The stack doesn't leak telemetry data by default when run on a shared or
+   cloud host, not just a laptop (LB-02).
+3. An alert actually reaches a human somewhere (LB-03).
+4. Rollback has been proven to work, not just documented (LB-04).
+5. The deploy pipeline itself is stable — no known flakiness (LB-05).
+6. Beta adopters have a real way to report friction back (LB-06).
+7. The backlog they'd land on to contribute is trustworthy, not stale
+   (LB-07).
+
+## Explicitly Out of Scope for Late Beta
+
+- **M5 — Kubernetes/Helm deployment** (`v2.0.0` per `docs/product/spec.md`,
+  issues #84–#87). The target persona ships on Docker Compose; Kubernetes
+  support is a separate, later milestone for a different audience.
+- **Multi-host progressive delivery** (canary/staging/load-balanced
+  production, per `docs/DEPLOYMENT_STRATEGY.md`'s "Target Model"). That's
+  production-hardening for when uFawkesObs serves real production traffic,
+  which is explicitly a future gate, not a beta requirement.
+- **TLS between internal services, object storage backends, HA** — all
+  listed in `docs/KNOWN_LIMITATIONS.md` as intentional gaps for a
+  single-host local-dev/eval deployment. Still out of scope for beta.
+
+## Exit Criteria
+
+| ID | Task | Issue | Status |
+|----|------|-------|--------|
+| LB-01 | Measure `time_to_first_signal_minutes` onboarding baseline | [#179](https://github.com/paruff/uFawkesObs/issues/179) | 🔲 PENDING |
+| LB-02 | Restrict Loki/Tempo/Prometheus/Alertmanager ports to localhost by default | [#180](https://github.com/paruff/uFawkesObs/issues/180) | 🔲 PENDING |
+| LB-03 | Add a tested Slack notification channel for Alertmanager | [#181](https://github.com/paruff/uFawkesObs/issues/181) | 🔲 PENDING |
+| LB-04 | Run and document a live rollback drill | [#182](https://github.com/paruff/uFawkesObs/issues/182) | 🔲 PENDING |
+| LB-05 | Investigate GitOps Reconciliation Deploy transient failure | [#183](https://github.com/paruff/uFawkesObs/issues/183) | 🔲 PENDING |
+| LB-06 | Add a beta feedback channel | [#184](https://github.com/paruff/uFawkesObs/issues/184) | 🔲 PENDING |
+| LB-07 | Reconcile `docs/plan.md` status drift against real issue state | [#185](https://github.com/paruff/uFawkesObs/issues/185) | 🔲 PENDING |
+
+All issues are labeled `late-beta` for tracking:
+<https://github.com/paruff/uFawkesObs/issues?q=is%3Aissue+is%3Aopen+label%3Alate-beta>
+
+## Already Done (not re-tracked here)
+
+- `scripts/check-env.sh` already fail-fasts on default/weak
+  `GRAFANA_ADMIN_PASSWORD` — the "default credentials" gap in
+  `docs/KNOWN_LIMITATIONS.md` is enforced, not just documented.
+- PR #178 (merged) fixed Platform/Services dashboard variable plumbing that
+  referenced nonexistent `cluster`/`namespace`/`environment` labels.
+
+## Definition of Done
+
+Late beta is reached when all seven issues above are closed and
+`docs/KNOWN_LIMITATIONS.md` / `docs/DEPLOYMENT_STRATEGY.md` are updated to
+reflect the new defaults. At that point, update this doc's status header and
+announce readiness via the LB-06 feedback channel.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -9,6 +9,8 @@
 
 ## Guide to Using This Plan
 
+- For the cross-cutting maturity gate (not a feature milestone), see
+  [`docs/PATH_TO_LATE_BETA.md`](PATH_TO_LATE_BETA.md).
 - This implementation plan guides the development of the uFawkesObs platform.
 - Tasks are derived from the actual open issues backlog in `gh issue list`.
 - Do not start any task until all its **Dependencies** are fully completed.


### PR DESCRIPTION
## Summary

- Adds `docs/PATH_TO_LATE_BETA.md`, defining what "late beta" means for uFawkesObs (target 3-15 person Docker Compose team can rely on it for real, non-production use) since no maturity stage was previously defined anywhere in the repo.
- Explicitly scopes Kubernetes/Helm (M5, `v2.0.0`) and multi-host progressive delivery out of late beta — those are later/production milestones for a different bar.
- Files 7 concrete, grounded issues (#179–#185, labeled `late-beta`) covering the real gaps found while auditing current state: unmeasured onboarding claim, unrestricted Loki/Tempo/Prometheus/Alertmanager ports, webhook-only alerting, unverified rollback, a flaky GitOps deploy run observed on `main`, no beta feedback channel, and stale `docs/plan.md` status vs. real issue state.
- Links the new doc from `docs/plan.md` and `AGENTS.md` §3.

## Test plan

- [x] `pre-commit` hooks passed locally (markdownlint, gitleaks, conventional commit format)
- [x] All 7 linked issues confirmed created and labeled `late-beta`
- [ ] Human review of the late-beta bar definition and scope cuts (Kubernetes/multi-host explicitly deferred)

## AI-Assisted Review Block

**What does this PR do?**
Adds a plan doc defining "late beta" readiness for uFawkesObs and opens issues tracking the path there.

**What could go wrong?**
The proposed readiness bar (7 items) is my own synthesis of existing docs (`KNOWN_LIMITATIONS.md`, `DEPLOYMENT_STRATEGY.md`, `discovery-draft.md`) and live observations (port bindings, a transient deploy failure, disabled Discussions) — not a bar the user has explicitly signed off on yet. Worth confirming the scope cuts (no Kubernetes, no multi-host) match intent before treating the 7 issues as canonical.

**What tests cover this change?**
None needed — docs-only change, no code/config touched.

**Architecture check:**
- Layer(s) touched: `docs/` only (planning), plus one table row each in `docs/plan.md` and `AGENTS.md`.
- Cross-plane impact: none. No `compose.yaml`, config, or dashboard changes.

**What I was NOT sure about:**
Whether "late beta" should be scoped narrower or wider than the 7 issues filed — flagging for review rather than assuming.