### PR TITLE
chore(product): measure time_to_first_signal_minutes onboarding baseline

### DIFF
--- a/docs/PATH_TO_LATE_BETA.md
+++ b/docs/PATH_TO_LATE_BETA.md
@@ -53,7 +53,7 @@ Concretely, late beta requires:
 
 | ID | Task | Issue | Status |
 |----|------|-------|--------|
-| LB-01 | Measure `time_to_first_signal_minutes` onboarding baseline | [#179](https://github.com/paruff/uFawkesObs/issues/179) | 🔲 PENDING |
+| LB-01 | Measure `time_to_first_signal_minutes` onboarding baseline | [#179](https://github.com/paruff/uFawkesObs/issues/179) | ✅ DONE (93s, PASS) |
 | LB-02 | Restrict Loki/Tempo/Prometheus/Alertmanager ports to localhost by default | [#180](https://github.com/paruff/uFawkesObs/issues/180) | 🔲 PENDING |
 | LB-03 | Add a tested Slack notification channel for Alertmanager | [#181](https://github.com/paruff/uFawkesObs/issues/181) | 🔲 PENDING |
 | LB-04 | Run and document a live rollback drill | [#182](https://github.com/paruff/uFawkesObs/issues/182) | 🔲 PENDING |

--- a/docs/product/discovery-draft.md
+++ b/docs/product/discovery-draft.md
@@ -9,12 +9,12 @@ test_type_reasoning: "\"Ready to use within 2 minutes\" is a claim about the rea
 dora_ai_capability: null
 dora_core_capability: "Monitoring and Observability"
 metric: "time_to_first_signal_minutes"
-measurement_source: "manual (timed via scripts/smoke-test.sh against a fresh clone)"
-baseline: "not yet measured — establish baseline by timing scripts/smoke-test.sh from a clean checkout"
+measurement_source: "manual (timed docker health polling against a genuine `git clone` of main, commit d2bff8c; note: `scripts/smoke-test.sh` referenced by the original draft of this field does not exist in the repo — no such script was ever added)"
+baseline: "93s (1.55 min) from `make up` to all 7 core services healthy, with live Prometheus scrape data and 26 provisioned Grafana dashboards already present. PASS against the <2 minute target. Caveat: Docker images were already cached on the test machine from prior local work, so this excludes cold image-pull time, which is network-dependent and not controlled by this repo."
 prior_art: "Grafana Cloud free tier, Datadog, SigNoz, OpenObserve — all viable alternatives for a small team. uFawkesObs's answer isn't a new telemetry backend, it's composing the same OSS components (Prometheus, Loki, Tempo, Grafana, OTel Collector, Alertmanager) that those vendors already build on, pre-wired and pre-provisioned, so a small team gets the vendor's default experience without the vendor's invoice."
 status: ready-for-spec
 retrospective: true
-assumption_validated: false
+assumption_validated: true
 ---
 
 # Discovery Brief: uFawkesObs (Product-Level)
@@ -85,12 +85,13 @@ containers and observing Grafana render data.
   on top of; it doesn't measure its own AI capability directly.
 - Metric: `time_to_first_signal_minutes` — wall-clock time from a fresh clone
   to a live, data-populated Grafana dashboard.
-- Current baseline: not yet measured — establish it by timing
-  `scripts/smoke-test.sh` from a clean checkout.
+- Current baseline: **93s (1.55 min)**, measured 2026-08-10 against a genuine
+  fresh clone — PASS against target. See `baseline` in frontmatter for method
+  and caveats (image-cache warm, `scripts/smoke-test.sh` doesn't exist).
 - Target: < 2 minutes (matches the acceptance criterion above).
-- Measurement: manual timing today; a candidate future improvement is having
-  `scripts/smoke-test.sh` emit its own duration so this becomes
-  self-measuring rather than a manual stopwatch exercise.
+- Measurement: manual timing today; a candidate future improvement is a real
+  `scripts/smoke-test.sh` that emits its own duration so this becomes
+  self-measuring rather than a one-off manual exercise.
 
 ## Prior Art
 
@@ -139,11 +140,13 @@ A candid read of this document, not a flattering one:
 What would make the riskiest assumption stop being a guess, ranked cheapest
 first:
 
-1. **Measure the acceptance criterion for real, now.** Time
-   `scripts/smoke-test.sh` against a genuinely fresh clone and record the
-   actual `time_to_first_signal_minutes` baseline. This is achievable
-   immediately, with no user contact required, and turns "not yet measured"
-   into a real number.
+1. **Measure the acceptance criterion for real, now.** ✅ Done 2026-08-10 —
+   93s against a genuine fresh clone, PASS against the <2 minute target. See
+   `baseline` in frontmatter. Note: `scripts/smoke-test.sh` does not exist in
+   the repo; the measurement used direct docker health polling instead. This
+   validates the *onboarding-speed* sub-claim only — the deeper churn/
+   operational-burden risk in `riskiest_assumption` is still open; see (2)
+   and (3) below.
 2. **Mine existing low-cost signal before running new experiments.** Check
    GitHub repo Insights (clone/traffic trends vs. stars, return-visitor
    rate) and scan open/closed issues for operational-burden complaints


### PR DESCRIPTION
Closes #179.

## AI-Assisted Review Block

**What does this PR do?**
Records a real, timed measurement of `time_to_first_signal_minutes` (LB-01 of the Path to Late Beta plan) instead of leaving it as an unmeasured assumption. Updates `docs/product/discovery-draft.md` frontmatter (`measurement_source`, `baseline`, `assumption_validated`) and body prose, plus the LB-01 status row in `docs/PATH_TO_LATE_BETA.md`.

**Method:** Cloned `main` (commit `d2bff8c`) fresh into an isolated directory, configured `.env` with a non-default `GRAFANA_ADMIN_PASSWORD`, ran `make up`, and polled all 7 core service health endpoints plus Prometheus's `up` metric and Grafana's dashboard list until live data was confirmed present.

**Result:** 93s (1.55 min) from `make up` to all 7 core services healthy, with live Prometheus scrape data and 26 provisioned Grafana dashboards already in place — **PASS** against the <2 minute target.

**What could go wrong?**
- The measurement excludes cold Docker image-pull time, since all images were already cached locally from prior work on this machine. A true cold-cache number would be dominated by network speed variance rather than anything this repo controls, so I documented this explicitly as a caveat in the `baseline` field rather than spending significant bandwidth/time deleting and re-pulling ~8 images for a noisier number.
- `docs/product/discovery-draft.md` originally referenced `scripts/smoke-test.sh` as the measurement mechanism, but that script does not exist anywhere in the repo. I corrected `measurement_source` to reflect the actual method used (direct health-endpoint polling) and noted the stale reference rather than silently working around it.
- Also discovered `scripts/wait-healthy.sh` (the closest existing equivalent to the missing smoke-test script) requires Bash 4+, but macOS ships Bash 3.2 by default and this test machine has no newer Bash installed, so that script can't run as-is on a stock Mac. Not part of LB-01's scope (it's not in `make up`'s critical path), so I didn't fix it here — flagging it as a possible small follow-up.

**What tests cover this change?**
None — this is a documentation/measurement recording change, not new code or config behavior. No existing test suite references `docs/product/discovery-draft.md`.

**Architecture check:**
- Only `docs/` files touched — no `compose.yaml`, `config/`, `scripts/`, or `dashboards/` changes, no architecture layers affected.
- No cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDORA) — this is a product-discovery doc, not a wired integration point.

**What I was NOT sure about:**
- Whether `assumption_validated: true` correctly represents what was tested. The frontmatter's `riskiest_assumption` field is actually about long-term operational-burden churn risk, which this measurement does *not* address — only the onboarding-speed acceptance criterion. I flipped the boolean per issue #179's explicit instruction ("flip riskiest_assumption framing... based on the result") but added an inline caveat in the "Next Actual Discovery Experiment" section clarifying that the deeper churn risk is still open (experiments #2–#3, unstarted). A human reviewer may want a different field-semantics resolution here.
- Whether the `scripts/wait-healthy.sh` Bash 4+ incompatibility on macOS is worth its own tracked issue — left as a note rather than filing one, since it's outside LB-01's explicit scope.