### PR TITLE
chore(deploy): document rollback drill runbook for LB-04 (#182)

### DIFF
--- a/docs/DEPLOYMENT_STRATEGY.md
+++ b/docs/DEPLOYMENT_STRATEGY.md
@@ -67,11 +67,35 @@ Before implementing the target model:
 
 ### Automated (Current)
 
-When `post-deploy-verify` fails in `deploy.yml`, the `rollback` job:
+When `post-deploy-verify` fails in `deploy.yml`, the `rollback` job
+(`paruff/ufawkespipe/.github/workflows/reusable-rollback.yml@v1.2.0`):
 1. SSHs into the target host
 2. Runs `git revert HEAD --no-edit`
 3. Pushes the revert to `origin main`
 4. Runs `make up` to restart the previous stack
+
+> **Not yet proven.** This path is documented and wired in CI but has never
+> been exercised end-to-end against a real host. It is **unproven** until a
+> live rollback drill records successful results (LB-04). See
+> [Rollback Drill (LB-04)](#rollback-drill-lb-04) below.
+
+### Rollback Drill (LB-04)
+
+The end-to-end drill is defined in
+[`docs/ROLLBACK_DRILL.md`](ROLLBACK_DRILL.md) — an executable procedure that
+pushes a deliberately-bad commit to a non-prod host, confirms
+`post-deploy-verify` catches it, confirms the `rollback` job fires
+automatically, and confirms the host returns to a healthy previous state.
+
+Status: **PENDING** — runbook ready, live drill not yet executed against a real
+target host ([issue #182](https://github.com/paruff/uFawkesObs/issues/182)).
+
+| Drill date | Host | Pre-drill SHA | Time to rollback | Recovered? | Gaps |
+|---|---|---|---|---|---|
+| _pending_ | — | — | — | — | — |
+
+Any gap found during the drill gets its own follow-up issue; results and
+corrections land back in `docs/ROLLBACK_DRILL.md`.
 
 ### Manual (Fallback)
 

--- a/docs/PATH_TO_LATE_BETA.md
+++ b/docs/PATH_TO_LATE_BETA.md
@@ -56,13 +56,19 @@ Concretely, late beta requires:
 | LB-01 | Measure `time_to_first_signal_minutes` onboarding baseline | [#179](https://github.com/paruff/uFawkesObs/issues/179) | ✅ DONE (93s, PASS) |
 | LB-02 | Restrict Loki/Tempo/Prometheus/Alertmanager ports to localhost by default | [#180](https://github.com/paruff/uFawkesObs/issues/180) | 🔲 PENDING |
 | LB-03 | Add a tested Slack notification channel for Alertmanager | [#181](https://github.com/paruff/uFawkesObs/issues/181) | 🔲 PENDING |
-| LB-04 | Run and document a live rollback drill | [#182](https://github.com/paruff/uFawkesObs/issues/182) | 🔲 PENDING |
+| LB-04 | Run and document a live rollback drill | [#182](https://github.com/paruff/uFawkesObs/issues/182) | 🔲 PENDING (runbook ready) |
 | LB-05 | Investigate GitOps Reconciliation Deploy transient failure | [#183](https://github.com/paruff/uFawkesObs/issues/183) | 🔲 PENDING |
 | LB-06 | Add a beta feedback channel | [#184](https://github.com/paruff/uFawkesObs/issues/184) | 🔲 PENDING |
 | LB-07 | Reconcile `docs/plan.md` status drift against real issue state | [#185](https://github.com/paruff/uFawkesObs/issues/185) | 🔲 PENDING |
 
 All issues are labeled `late-beta` for tracking:
 <https://github.com/paruff/uFawkesObs/issues?q=is%3Aissue+is%3Aopen+label%3Alate-beta>
+
+> LB-04: the executable drill is in `docs/ROLLBACK_DRILL.md` and linked from
+> `docs/DEPLOYMENT_STRATEGY.md`. The live run against a non-prod host is still
+> PENDING. A suspected rollback-push gap (reusable-rollback `GITHUB_TOKEN`
+> permissions / missing checkout) is tracked as a follow-up issue — the drill
+> will confirm or refute it.
 
 ## Already Done (not re-tracked here)
 

--- a/docs/ROLLBACK_DRILL.md
+++ b/docs/ROLLBACK_DRILL.md
@@ -1,0 +1,301 @@
+# Rollback Drill — uFawkesObs
+
+> **Status: PENDING** — runbook ready; the live drill has not been executed
+> against a real target host yet. See [LB-04](https://github.com/paruff/uFawkesObs/issues/182).
+>
+> Part of the Path to Late Beta plan — `docs/PATH_TO_LATE_BETA.md`.
+
+This document is the **executable** procedure for deliberately breaking a
+non-production deployment and confirming the automated rollback path
+(`post-deploy-verify` → `rollback`) actually restores the host. It exists
+because the rollback machinery in `deploy.yml` has never been exercised
+end-to-end, and a beta adopter must be able to trust that rollback works the
+one time it is needed.
+
+The drill is run by a human (PM or infra owner) with GitHub repo admin access
+and SSH access to the non-prod target host. **Never run this against a host
+that carries production traffic.**
+
+---
+
+## Preconditions
+
+Before starting, confirm all of the following. If any is missing, **stop** and
+resolve it before running the drill.
+
+### 1. A non-prod target host
+
+- `DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_KEY` / `DEPLOY_HOST_KEY` repo
+  secrets must point at a **throwaway / sandbox host**, not production.
+- `DEPLOY_PATH` repo variable set to the absolute clone path on that host.
+- Confirm the current production host is **not** the drill host:
+  ```bash
+  gh secret list                       # repo-level secrets
+  gh variable list                     # repo-level variables
+  ```
+  Verify `DEPLOY_HOST` resolves to the sandbox.
+
+### 2. Healthy baseline
+
+On the target host, the stack must already be healthy at the commit you are
+about to break:
+
+```bash
+ssh "${DEPLOY_USER}@${DEPLOY_HOST}"
+cd "${DEPLOY_PATH:-$HOME/uFawkesObs}"
+git status --short          # clean
+git log --oneline -3        # note the current HEAD
+docker compose ps           # all services running
+./scripts/wait-healthy.sh   # exit 0
+```
+
+### 3. Main is pushable
+
+The drill pushes a deliberately-bad commit to `main`, and the automated
+rollback pushes a revert to `main`. Both must be permitted:
+
+- Check branch protection on `main` (Settings → Branches). If direct pushes or
+  GITHUB_TOKEN pushes are blocked, the drill **cannot run as automated** — use
+  the manual fallback in [Safety & Cleanup](#safety--cleanup) and file a
+  follow-up issue.
+
+### 4. Environment approval ready
+
+The compose-restart deploy path requires GitHub Environment approval
+(`environment: compose-restart`). During the drill a human must be ready to
+**approve** that environment when prompted.
+
+### 5. Timing baseline
+
+Record the current time and the deploy run numbers so the drill can be timed:
+
+```bash
+date -u +%FT%TZ
+gh run list --workflow="GitOps Reconciliation Deploy" --limit 3
+```
+
+### 6. Notify / schedule
+
+The drill intentionally turns `main` red for a few minutes (a broken commit is
+pushed, CI fails, and — if all goes well — the rollback re-reverts it). Pick a
+window when no one is merging, and announce it in the team channel.
+
+---
+
+## Bad-Deploy Recipe
+
+Goal: a commit where **the deploy succeeds but `post-deploy-verify` fails**.
+That is the only failure mode that triggers the `rollback` job
+(`if: failure() && needs.post-deploy-verify.result == 'failure'` in
+`deploy.yml`). If the deploy step itself fails, `post-deploy-verify` is skipped
+and rollback never fires — so the recipe must not break the deploy step.
+
+**Recommended recipe:** break `config/otel/collector.yaml` with a YAML syntax
+error.
+
+Why this works:
+
+- `config/otel/**` is classified as `non_reloadable_config` by
+  `detect-changes`, so `deploy-compose-restart` runs (`make up`).
+- `docker compose up -d` exits 0 even if the OTel Collector container crashes
+  shortly after start — the deploy step **succeeds**.
+- `post-deploy-verify` runs `scripts/wait-healthy.sh`, which probes
+  `http://localhost:8888/metrics`. The Collector never comes up, so the probe
+  times out, `wait-healthy.sh` exits non-zero, and `post-deploy-verify`
+  **fails**.
+- Rollback triggers, reverts the commit, and restarts the previous stack.
+
+Create the bad commit (example — an unparseable YAML scalar):
+
+```bash
+git checkout -b drill/lb04-bad-deploy
+printf 'receivers:\n  otlp:\n   protocol: \n    : broken\n' \
+  > config/otel/collector.yaml
+git add config/otel/collector.yaml
+git commit -m "chore(drill): deliberately break otel collector config (LB-04)"
+git push origin drill/lb04-bad-deploy
+```
+
+Alternative recipes (same failure mode, choose one):
+
+- Break `config/alertmanager/alertmanager.yml` (also `non_reloadable_config`).
+- Override a service `command:` in `compose.yaml` to an invalid flag so the
+  container exits at boot (compose path).
+
+Do **not** use a bad Prometheus config as the recipe: Prometheus `/-/reload`
+returns 200 even when the reload fails, so `deploy-config-reload` and the
+health probe both "pass" and rollback never fires. That is a realistic
+false-negative, but it does not exercise the rollback path.
+
+---
+
+## Drill Procedure
+
+Execute in order. Record timestamps and evidence as you go (see
+[Evidence Log](#evidence-log)).
+
+### Step 1 — Record baseline
+
+```bash
+date -u +%FT%TZ
+ssh "${DEPLOY_USER}@${DEPLOY_HOST}" "${DEPLOY_PATH:-$HOME/uFawkesObs}/scripts/wait-healthy.sh" && echo BASELINE_OK
+```
+
+### Step 2 — Push the bad commit to main
+
+```bash
+git push origin drill/lb04-bad-deploy:main
+```
+
+> Expected: a new run of **GitOps Reconciliation Deploy** starts on the bad
+> SHA. `detect-changes` → `deploy-compose-restart` waits on the
+> `compose-restart` environment approval.
+
+### Step 3 — Approve the compose-restart environment
+
+In the Actions UI, open the deploy run → **Approve** the `compose-restart`
+environment.
+
+### Step 4 — Watch the deploy + verification
+
+Expected sequence on the host (watch via
+`ssh … 'cd ${DEPLOY_PATH} && docker compose ps && docker logs --tail 20 otel-collector'`):
+
+1. `git pull --ff-only origin main` brings down the bad commit.
+2. `make up` starts the stack; the OTel Collector crashes (`exec … no YAML` /
+   config parse error in logs).
+3. `post-deploy-verify` runs `wait-healthy.sh`; after the timeout it reports
+   `❌ OTel Collector not healthy` and the job **fails**.
+
+### Step 5 — Confirm the rollback fires automatically
+
+- The `rollback` job (`uses: paruff/ufawkespipe/.github/workflows/reusable-rollback.yml@v1.2.0`)
+  must start **automatically** (no human trigger) within seconds of
+  `post-deploy-verify` failing.
+- Expected inside the rollback job:
+  1. SSH to target.
+  2. `git revert --no-edit HEAD` — reverts the bad commit **locally**.
+  3. `git push origin main` — the revert must reach `main`.
+  4. `make up` — previous stack restarts.
+
+### Step 6 — Confirm recovery
+
+- The rollback push creates a **new** deploy run on the revert SHA; that run's
+  `post-deploy-verify` must pass.
+- On the host, confirm the previous healthy state:
+  ```bash
+  ssh "${DEPLOY_USER}@${DEPLOY_HOST}" "${DEPLOY_PATH:-$HOME/uFawkesObs}/scripts/wait-healthy.sh" && echo RECOVERED
+  docker compose ps
+  ```
+- Confirm `main` is clean and CI is green again:
+  ```bash
+  git fetch origin main && git log origin/main --oneline -3   # HEAD~1 == pre-drill SHA
+  gh run list --limit 5
+  ```
+
+**Drill success criteria (all must hold):**
+
+1. `post-deploy-verify` caught the bad deploy (job failed).
+2. `rollback` fired automatically — no human pressed the button.
+3. The host returned to a healthy previous state.
+4. `main` self-healed: it contains the revert, and the post-revert deploy
+   verified green.
+
+---
+
+## Evidence Log
+
+Capture each line into a pastebin/comment on the drill's follow-up issue
+(below). The workflow run URL is the primary artifact:
+
+```
+Workflow run: https://github.com/paruff/uFawkesObs/actions/runs/<RUN_ID>
+```
+
+| # | Timestamp (UTC) | Event | Expected | Observed | Pass/Fail |
+|---|---|---|---|---|---|
+| 1 | | Baseline `wait-healthy.sh` | exit 0 | | |
+| 2 | | Bad commit pushed to main | deploy run starts | | |
+| 3 | | `compose-restart` env approved | deploy proceeds | | |
+| 4 | | OTel Collector container | crashes at boot | | |
+| 5 | | `post-deploy-verify` | FAILS (wait-healthy timeout) | | |
+| 6 | | `rollback` job | auto-starts | | |
+| 7 | | `git revert` on host | local revert applied | | |
+| 8 | | `git push origin main` (revert) | main reverted | | |
+| 9 | | `make up` after revert | previous stack restarts | | |
+| 10 | | Recovery `wait-healthy.sh` | exit 0 | | |
+| 11 | | Post-revert deploy verify | PASS | | |
+| 12 | | `main` CI | green | | |
+
+**Timing:** note seconds from Step 2 push → Step 5 rollback start, and from
+Step 5 → Step 6 recovery. These go into the results table.
+
+---
+
+## Results & Follow-Up
+
+After the drill, fill in the summary and link it from
+`docs/DEPLOYMENT_STRATEGY.md` (Rollback Drill section) and this file's status
+line.
+
+```markdown
+## Drill Results — <date> (run <RUN_ID>)
+
+- Host: <non-prod host>
+- Pre-drill SHA: <...>  Post-revert SHA: <...>
+- Time to rollback start: <s>   Time to recovery: <s>
+- post-deploy-verify caught the break: yes/no
+- rollback fired automatically: yes/no
+- Host returned to healthy: yes/no
+- main self-healed: yes/no
+- Gaps found: <list>
+```
+
+**Rules for gaps** (from issue #182):
+
+- Any gap found gets its **own follow-up issue** — do not silently patch it in
+  the same PR that documents the drill.
+- Every gap issue must reference this drill's run URL and the failing evidence
+  row(s).
+
+**Known suspected gap (identified by static review, to be confirmed by the
+drill):**
+
+- [ ] Rollback cannot push the revert to `main` —
+  `reusable-rollback.yml` declares `permissions: {}` and job-level
+  `contents: read`, and the job has no `actions/checkout` step, so its
+  `GITHUB_TOKEN` cannot write `contents` and the fresh runner has no git
+  credentials. The `git push origin main` step is therefore expected to fail
+  (403 / "could not read Username"), which under `set -euo pipefail` aborts the
+  script **before** `make up` — leaving the host broken and `main` unreverted.
+  Tracked in [issue #193](https://github.com/paruff/uFawkesObs/issues/193).
+
+---
+
+## Safety & Cleanup
+
+- **Never run against a production host.** Verify `DEPLOY_HOST` first
+  (Preconditions).
+- The drill deliberately puts a broken commit on `main`. If automated rollback
+  does **not** fire or does not complete, restore manually **immediately**:
+
+  ```bash
+  # From a clean checkout of main:
+  git revert --no-edit HEAD
+  git push origin main
+  # On the target host:
+  ssh "${DEPLOY_USER}@${DEPLOY_HOST}"
+  cd "${DEPLOY_PATH:-$HOME/uFawkesObs}"
+  git pull --ff-only origin main
+  make up
+  ./scripts/wait-healthy.sh
+  ```
+
+- After the drill, confirm the local drill branch is deleted and `main` has no
+  leftover drill artifacts:
+  ```bash
+  git branch -D drill/lb04-bad-deploy
+  git fetch origin main && git diff --stat origin/main@{1} origin/main || true
+  ```
+- If any step could not be completed, leave LB-04 **PENDING** and file a
+  follow-up issue describing the blocker. Do not mark the drill done.

--- a/tests/unit/test_deploy_docs.py
+++ b/tests/unit/test_deploy_docs.py
@@ -1,0 +1,98 @@
+"""
+Unit tests guarding the LB-04 rollback drill documentation (#182).
+
+These tests lock in that the rollback drill runbook exists, covers the
+required phases (preconditions, bad-deploy recipe, procedure, evidence,
+results, safety), and that the deployment strategy document links it and
+does NOT claim the rollback path is proven until the drill records results.
+
+Run:  pytest tests/unit/test_deploy_docs.py -v
+      (no running stack required — reads docs statically)
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+ROLLBACK_DRILL = PROJECT_ROOT / "docs" / "ROLLBACK_DRILL.md"
+DEPLOYMENT_STRATEGY = PROJECT_ROOT / "docs" / "DEPLOYMENT_STRATEGY.md"
+
+REQUIRED_RUNBOOK_SECTIONS: tuple[str, ...] = (
+    "## Preconditions",
+    "## Bad-Deploy Recipe",
+    "## Drill Procedure",
+    "## Evidence Log",
+    "## Results & Follow-Up",
+    "## Safety & Cleanup",
+)
+
+
+@pytest.fixture(scope="module")
+def rollback_drill_text() -> str:
+    """Return the rollback drill runbook contents."""
+    if not ROLLBACK_DRILL.exists():
+        pytest.fail(f"Rollback drill runbook not found at {ROLLBACK_DRILL}")
+    return ROLLBACK_DRILL.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def deployment_strategy_text() -> str:
+    """Return the deployment strategy document contents."""
+    if not DEPLOYMENT_STRATEGY.exists():
+        pytest.fail(f"Deployment strategy not found at {DEPLOYMENT_STRATEGY}")
+    return DEPLOYMENT_STRATEGY.read_text(encoding="utf-8")
+
+
+class TestRollbackDrillRunbook:
+    """Verify the runbook exists and covers every drill phase."""
+
+    @pytest.mark.parametrize(
+        "heading", REQUIRED_RUNBOOK_SECTIONS, ids=REQUIRED_RUNBOOK_SECTIONS
+    )
+    def test_runbook_has_required_section(
+        self, rollback_drill_text: str, heading: str
+    ) -> None:
+        """Assert the runbook contains each required phase heading."""
+        assert heading in rollback_drill_text, (
+            f"Rollback drill runbook is missing required section '{heading}'"
+        )
+
+    def test_runbook_defines_success_criteria(self, rollback_drill_text: str) -> None:
+        """Assert the drill defines how success is judged."""
+        assert "success" in rollback_drill_text.lower(), (
+            "Rollback drill runbook must define success criteria"
+        )
+
+    def test_runbook_provides_evidence_template(self, rollback_drill_text: str) -> None:
+        """Assert the runbook gives a concrete evidence log template."""
+        assert "Evidence" in rollback_drill_text
+        assert "github.com" in rollback_drill_text, (
+            "Evidence template must reference the GitHub workflow run URL to record"
+        )
+
+
+class TestDeploymentStrategyRollbackSection:
+    """Verify the deployment strategy links the drill and does not overclaim."""
+
+    def test_strategy_references_runbook(self, deployment_strategy_text: str) -> None:
+        """Assert the strategy document links the rollback drill runbook."""
+        assert "ROLLBACK_DRILL.md" in deployment_strategy_text, (
+            "Deployment strategy must link docs/ROLLBACK_DRILL.md in its "
+            "rollback section"
+        )
+
+    def test_strategy_does_not_claim_rollback_is_proven(
+        self, deployment_strategy_text: str
+    ) -> None:
+        """Assert the strategy does not present the rollback as verified."""
+        assert "ROLLBACK_DRILL.md" in deployment_strategy_text
+        assert (
+            "unproven" in deployment_strategy_text.lower()
+            or "not yet" in deployment_strategy_text.lower()
+        ), (
+            "Deployment strategy must not claim the rollback path is proven — "
+            "LB-04 drill results are still PENDING"
+        )

--- a/tests/unit/test_deploy_docs.py
+++ b/tests/unit/test_deploy_docs.py
@@ -69,7 +69,7 @@ class TestRollbackDrillRunbook:
     def test_runbook_provides_evidence_template(self, rollback_drill_text: str) -> None:
         """Assert the runbook gives a concrete evidence log template."""
         assert "Evidence" in rollback_drill_text
-        assert "github.com" in rollback_drill_text, (
+        assert "Workflow run: https://" in rollback_drill_text, (
             "Evidence template must reference the GitHub workflow run URL to record"
         )
 


### PR DESCRIPTION
## Summary

Implements issue #182 (LB-04). Adds an **executable rollback drill runbook** (`docs/ROLLBACK_DRILL.md`) that walks through deliberately breaking a non-prod deployment and confirming `post-deploy-verify` catches it, `rollback` fires automatically, and the host returns to a healthy previous state. Links the runbook from `docs/DEPLOYMENT_STRATEGY.md`, stops that doc from claiming the rollback path is proven, and adds unit tests that guard the runbook's existence and required phases.

Also files **follow-up issue #193** for a high-confidence gap found via static review: `reusable-rollback.yml@v1.2.0` sets `permissions: {}` / `contents: read` and has no `actions/checkout`, so its `git push origin main` is expected to fail (403 / no credentials) — leaving the host broken and `main` unreverted. Per issue #182's "gaps get their own follow-up issues" rule, this is tracked, not silently patched.

## Changes

- `docs/ROLLBACK_DRILL.md` (new) — preconditions, a deterministic bad-deploy recipe (broken `config/otel/collector.yaml`), step-by-step drill, evidence log + timing templates, results table, safety/cleanup, manual fallback.
- `docs/DEPLOYMENT_STRATEGY.md` — rollback section now marks the path **unproven**, links the runbook, adds a Drill results table (PENDING).
- `docs/PATH_TO_LATE_BETA.md` — LB-04 row notes runbook ready, still PENDING; footnote cross-references the follow-up issue.
- `tests/unit/test_deploy_docs.py` (new) — guards the runbook exists and covers Preconditions / Bad-Deploy Recipe / Drill Procedure / Evidence Log / Results & Follow-Up / Safety & Cleanup, and that the strategy doc does not overclaim rollback as proven.

## AI-Assisted Review Block

**What does this PR do?**
Adds the executable procedure and guards for the LB-04 rollback drill, corrects the deployment strategy doc's overclaim that rollback is proven, and files follow-up issue #193 for a suspected rollback-push gap identified by static review.

**What could go wrong?**
- The runbook instructs the PM to push a deliberately-bad commit to `main` and relies on automated rollback. If rollback is broken (as #193 suspects) and the manual fallback isn't run, `main` stays broken. The runbook puts the manual fallback in Safety & Cleanup and requires a non-prod `DEPLOY_HOST` first.
- The drill's bad commit breaks `config/otel/collector.yaml`; unit-test CI for that commit will fail. Expected and documented (drill intentionally reddens `main` briefly).
- Docs-only PR; no runtime config, compose, or image changes — deployment behavior is untouched.

**What tests cover this change?**
- New `tests/unit/test_deploy_docs.py`: 10 tests guarding runbook existence, required phases, success criteria, evidence template, and the strategy doc's honest status. All pass.
- Full unit suite: 257 passed. Pre-commit (ruff, markdownlint, Gitleaks) passes.
- The live drill itself is NOT executed — requires a real non-prod host + deploy secrets (acceptance criterion 1).

**Architecture check:**
- What layer(s) were touched and are they correct per §4?
  - Only `docs/` and `tests/unit/` — no compose.yaml, no config/, no dashboards/, no scripts. No architecture-rule impact.
- Any cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDORA)?
  - None. The follow-up issue #193 points at `paruff/ufawkespipe`'s reusable-rollback workflow but makes no change there (deliberately, per the "no silent patching" rule).

**What I was NOT sure about:**
- Whether the rollback push actually fails. Static analysis + GitHub's documented token-permissions behavior strongly suggest it does, but the drill is the ground truth — issue #193 is marked as "drill will confirm or refute".
- The exact "bad deploy" recipe that reliably fails `post-deploy-verify` without failing the deploy step; the runbook picks broken OTel config and documents why broken Prometheus config would NOT work (reload returns 200 even on failure).

## Verification Evidence

| Check | Result |
|---|---|
| Unit tests (`pytest tests/unit/`) | 257 passed (incl. 10 new doc-guard tests) |
| Pre-commit (ruff, markdownlint, Gitleaks) | passed |
| PR size | 433 changed lines (431+2) — over 400 limit, needs human `large-pr-approved` label |
| Live drill executed | **PENDING** — requires non-prod host + deploy secrets; procedure ready in `docs/ROLLBACK_DRILL.md` |

## Notes (AGENTS.md §4 / PR_STANDARD)

- No image version changes, no Prometheus scrape-config changes, no healthcheck changes — the Prometheus/version-bump note sections do not apply.
- Per issue #182: any gap found during the drill gets its own follow-up issue. Suspected gap already filed as **#193**.

## Acceptance Criteria (issue #182)

- [ ] Drill executed against a real target, not just read through — **PENDING** (needs non-prod host; drill will likely confirm #193 first)
- [x] Results documented in `docs/DEPLOYMENT_STRATEGY.md` / linked runbook — runbook, evidence templates, and results table are in place (results pending the live run)
- [x] Any gaps found get their own follow-up issues — #193 filed for the suspected rollback-push gap
