### PR TITLE
chore(deploy): enable and guard LB-04 rollback drill for live execution (#182)

### DIFF
--- a/docs/DEPLOYMENT_STRATEGY.md
+++ b/docs/DEPLOYMENT_STRATEGY.md
@@ -90,6 +90,14 @@ automatically, and confirms the host returns to a healthy previous state.
 Status: **PENDING** — runbook ready, live drill not yet executed against a real
 target host ([issue #182](https://github.com/paruff/uFawkesObs/issues/182)).
 
+2026-08-11: static enablement review (guard tests + wiring verification)
+confirmed the drill's fault-injection path (`config/otel/**` →
+`deploy-compose-restart` → `post-deploy-verify` → `rollback`) is wired in
+`deploy.yml`, and cleared the suspected runner-token blocker in
+[issue #193](https://github.com/paruff/uFawkesObs/issues/193) (the revert+push
+runs on the target host, not the runner). The live drill still must prove host
+push credentials and `main` branch protection permit the revert.
+
 | Drill date | Host | Pre-drill SHA | Time to rollback | Recovered? | Gaps |
 |---|---|---|---|---|---|
 | _pending_ | — | — | — | — | — |

--- a/docs/ROLLBACK_DRILL.md
+++ b/docs/ROLLBACK_DRILL.md
@@ -54,9 +54,13 @@ docker compose ps           # all services running
 The drill pushes a deliberately-bad commit to `main`, and the automated
 rollback pushes a revert to `main`. Both must be permitted:
 
-- Check branch protection on `main` (Settings → Branches). If direct pushes or
-  GITHUB_TOKEN pushes are blocked, the drill **cannot run as automated** — use
-  the manual fallback in [Safety & Cleanup](#safety--cleanup) and file a
+- The rollback's `git push origin main` executes **on the target host over
+  SSH** — the host pushes with its own cloned `origin` credential, not a runner
+  token. The host must therefore already hold a working **push credential**
+  for `origin` (verify with `git fetch origin main` from the host).
+- Check branch protection on `main` (Settings → Branches). If it rejects the
+  host's push or a direct push path, the drill **cannot run as automated** —
+  use the manual fallback in [Safety & Cleanup](#safety--cleanup) and file a
   follow-up issue.
 
 ### 4. Environment approval ready
@@ -258,17 +262,31 @@ line.
 - Every gap issue must reference this drill's run URL and the failing evidence
   row(s).
 
-**Known suspected gap (identified by static review, to be confirmed by the
-drill):**
+### Static review of the suspected gap — 2026-08-11 (LB-04 enablement)
 
-- [ ] Rollback cannot push the revert to `main` —
-  `reusable-rollback.yml` declares `permissions: {}` and job-level
-  `contents: read`, and the job has no `actions/checkout` step, so its
-  `GITHUB_TOKEN` cannot write `contents` and the fresh runner has no git
-  credentials. The `git push origin main` step is therefore expected to fail
-  (403 / "could not read Username"), which under `set -euo pipefail` aborts the
-  script **before** `make up` — leaving the host broken and `main` unreverted.
-  Tracked in [issue #193](https://github.com/paruff/uFawkesObs/issues/193).
+The suspected gap below was re-checked statically during LB-04 enablement
+(`tests/unit/test_deploy_pipeline.py` and `tests/unit/test_deploy_docs.py`).
+
+**Verdict: issue #193's two stated reasons are refuted.** The rollback job's
+`git revert` + `git push origin main` execute **on the target host over SSH,
+not on the runner** — the git commands are shipped through an `ssh … bash -s`
+heredoc in `reusable-rollback.yml@v1.2.0`. Consequences:
+
+- The runner's `GITHUB_TOKEN` (downgraded to `contents: read`) is **not** the
+  credential that pushes; the host pushes with its own `origin` credential, so
+  the token-permission concern does **not** gate the drill.
+- The missing `actions/checkout` on the runner is irrelevant to the push for
+  the same reason; the steps that need `DEPLOY_KEY` read it directly from the
+  `secrets:` pass-through, which read-only permissions do not block.
+
+**Remaining live-drill unknowns (only the live run can clear these):**
+
+- [ ] The target host holds a working **push credential** for `origin`.
+- [ ] `main` branch protection lets the host's revert push land.
+
+Evidence rows 6–9 in the Evidence Log exist to record these against the run.
+Tracked in [issue #193](https://github.com/paruff/uFawkesObs/issues/193) —
+the live drill confirms or refutes the remaining unknowns.
 
 ---
 

--- a/tests/unit/test_deploy_docs.py
+++ b/tests/unit/test_deploy_docs.py
@@ -74,6 +74,34 @@ class TestRollbackDrillRunbook:
         )
 
 
+class TestRollbackDrillStaticVerification:
+    """Verify the runbook records the LB-04 enablement static review (#182)."""
+
+    def test_runbook_records_static_verdict_on_gap(
+        self, rollback_drill_text: str
+    ) -> None:
+        assert "refutes" in rollback_drill_text, (
+            "Runbook must record the static-review verdict that issue #193's "
+            "runner-token reasoning is refuted"
+        )
+
+    def test_runbook_contrasts_host_and_runner_execution(
+        self, rollback_drill_text: str
+    ) -> None:
+        assert "not on the runner" in rollback_drill_text, (
+            "Runbook must document that the revert+push runs on the target "
+            "host, not on the runner"
+        )
+
+    def test_runbook_names_remaining_live_unknowns(
+        self, rollback_drill_text: str
+    ) -> None:
+        assert "push credential" in rollback_drill_text, (
+            "Runbook must name the remaining live-drill unknowns (target host "
+            "push credential, main branch protection)"
+        )
+
+
 class TestDeploymentStrategyRollbackSection:
     """Verify the deployment strategy links the drill and does not overclaim."""
 

--- a/tests/unit/test_deploy_pipeline.py
+++ b/tests/unit/test_deploy_pipeline.py
@@ -1,0 +1,235 @@
+"""
+Unit tests guarding the LB-04 rollback drill wiring (#182).
+
+These tests lock in the conditions in `.github/workflows/deploy.yml` that the
+rollback drill in `docs/ROLLBACK_DRILL.md` depends on:
+
+* a bad `config/otel/**` (or `config/alertmanager/**`) commit is classified as
+  `non_reloadable_config`, so it takes the `deploy-compose-restart` path rather
+  than the config-reload path;
+* `deploy-compose-restart` requires the `compose-restart` environment approval;
+* `post-deploy-verify` probes the host health script with a bounded timeout;
+* the `rollback` job fires only when `post-deploy-verify` fails, is pinned to a
+  released `reusable-rollback` workflow, and receives all four deploy secrets.
+
+Run:  pytest tests/unit/test_deploy_pipeline.py -v
+      (no running stack required — reads YAML statically)
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import Any
+
+import pytest
+import yaml
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEPLOY_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "deploy.yml"
+
+REUSABLE_ROLLBACK_PREFIX = "paruff/ufawkespipe/.github/workflows/reusable-rollback.yml@"
+
+REQUIRED_DEPLOY_SECRETS: tuple[str, ...] = (
+    "DEPLOY_HOST",
+    "DEPLOY_USER",
+    "DEPLOY_KEY",
+    "DEPLOY_HOST_KEY",
+)
+
+PINNED_REF_RE = re.compile(r"(?:v[0-9]+\.[0-9]+\.[0-9]+|[0-9a-f]{40})$")
+
+BAD_DRILL_PATHS: tuple[str, ...] = (
+    "config/otel/collector.yaml",
+    "config/alertmanager/alertmanager.yml",
+)
+
+
+def _load_workflow(path: pathlib.Path) -> dict[str, Any]:
+    if not path.exists():
+        pytest.fail(f"Expected file not found: {path}")
+    text = path.read_text(encoding="utf-8")
+    doc = yaml.safe_load(text)
+    if True in doc:  # PyYAML 1.1 parses the GitHub `on:` key as boolean True
+        doc["on"] = doc.pop(True)
+    return doc
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """Translate a glob supporting `**` (crossing directories) to a regex."""
+    out: list[str] = []
+    i = 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if ch == "*":
+            if i + 1 < len(pattern) and pattern[i + 1] == "*":
+                if i + 2 < len(pattern) and pattern[i + 2] == "/":
+                    out.append("(?:[^/]+/)*")
+                    i += 3
+                else:
+                    out.append("(?:.*)")
+                    i += 2
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif ch == "?":
+            out.append("[^/]")
+            i += 1
+        elif ch == "[":
+            end = pattern.find("]", i)
+            if end != -1:
+                out.append(pattern[i : end + 1])
+                i = end + 1
+            else:
+                out.append("\\[")
+                i += 1
+        else:
+            out.append(re.escape(ch))
+            i += 1
+    return "".join(out)
+
+
+def _in_group(patterns: list[str], path: str) -> bool:
+    """Return whether `path` matches a dorny/paths-filter group's patterns."""
+    matched = False
+    for raw in patterns:
+        negated = raw.startswith("!")
+        pattern = raw[1:] if negated else raw
+        hit = re.fullmatch(_glob_to_regex(pattern), path) is not None
+        if negated and hit:
+            return False
+        matched = matched or hit
+    return matched
+
+
+@pytest.fixture(scope="module")
+def deploy_workflow() -> dict[str, Any]:
+    """Return the parsed GitOps Reconciliation Deploy workflow."""
+    return _load_workflow(DEPLOY_WORKFLOW_PATH)
+
+
+@pytest.fixture(scope="module")
+def path_filters(
+    deploy_workflow: dict[str, Any],
+) -> dict[str, list[str]]:
+    """Return the detect-changes path-filter groups as name to patterns."""
+    steps = deploy_workflow["jobs"]["detect-changes"]["steps"]
+    filter_step = next(step for step in steps if step.get("id") == "filter")
+    filters_block: str = filter_step["with"]["filters"]
+    return yaml.safe_load(filters_block)
+
+
+class TestDeployTrigger:
+    """The drill pushes to main; the push trigger must fire on it."""
+
+    def test_deploy_runs_on_main_push(self, deploy_workflow: dict[str, Any]) -> None:
+        trigger = deploy_workflow["on"]
+        assert "push" in trigger, "deploy.yml must trigger on push"
+        assert "main" in trigger["push"]["branches"]
+
+    def test_deploy_paths_cover_drill_inputs(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        paths = deploy_workflow["on"]["push"]["paths"]
+        for expected in ("config/**", "compose.yaml", ".env.example", "dashboards/**"):
+            assert expected in paths, f"deploy trigger missing path {expected}"
+
+
+class TestRollbackWiring:
+    """The drill's core assertion: post-deploy-verify failure fires rollback."""
+
+    def test_rollback_requires_post_deploy_verify(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        job = deploy_workflow["jobs"]["rollback"]
+        needs = job.get("needs", [])
+        if isinstance(needs, str):
+            needs = [needs]
+        assert "post-deploy-verify" in needs
+
+    def test_rollback_fires_only_when_verify_fails(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        condition = deploy_workflow["jobs"]["rollback"].get("if", "")
+        assert "failure()" in condition
+        assert "needs.post-deploy-verify.result" in condition
+        assert "'failure'" in condition
+
+    def test_rollback_uses_pinned_reusable_workflow(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        uses = deploy_workflow["jobs"]["rollback"].get("uses", "")
+        assert uses.startswith(REUSABLE_ROLLBACK_PREFIX), (
+            f"Unexpected rollback workflow: {uses}"
+        )
+        ref = uses.rsplit("@", 1)[-1]
+        assert PINNED_REF_RE.search(ref), f"Rollback workflow ref not pinned: {ref}"
+
+    def test_rollback_receives_all_deploy_secrets(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        secrets = deploy_workflow["jobs"]["rollback"].get("secrets", {})
+        assert secrets, "rollback job must forward deploy secrets"
+        for name in REQUIRED_DEPLOY_SECRETS:
+            value = secrets.get(name, "")
+            assert name in value, f"rollback job missing secret {name}"
+
+    def test_rollback_restarts_with_make_up(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        restart = deploy_workflow["jobs"]["rollback"]["with"]["restart-command"]
+        assert "make up" in restart
+
+
+class TestPostDeployVerify:
+    """The drill relies on post-deploy-verify being a real, bounded health gate."""
+
+    def test_verify_waits_for_a_deploy_job(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        verify = deploy_workflow["jobs"]["post-deploy-verify"]
+        assert {"deploy-config-reload", "deploy-compose-restart"} <= set(
+            verify["needs"]
+        )
+        assert "always()" in verify.get("if", "")
+
+    def test_verify_has_bounded_timeout(self, deploy_workflow: dict[str, Any]) -> None:
+        timeout = deploy_workflow["jobs"]["post-deploy-verify"].get("timeout-minutes")
+        assert timeout is not None and int(timeout) > 0
+
+    def test_verify_probes_host_health_script(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        steps = deploy_workflow["jobs"]["post-deploy-verify"]["steps"]
+        joined = "\n".join(str(step) for step in steps)
+        assert "wait-healthy.sh" in joined
+        assert "localhost:8888" in joined
+
+
+class TestDrillPathClassification:
+    """The drill's bad-deploy recipe must hit the compose-restart path."""
+
+    @pytest.mark.parametrize("bad_path", BAD_DRILL_PATHS)
+    def test_bad_config_is_non_reloadable(
+        self,
+        deploy_workflow: dict[str, Any],
+        path_filters: dict[str, list[str]],
+        bad_path: str,
+    ) -> None:
+        assert _in_group(path_filters["non_reloadable_config"], bad_path)
+        assert not _in_group(path_filters["reload"], bad_path)
+        assert not _in_group(path_filters["compose"], bad_path)
+
+    def test_bad_config_triggers_compose_restart_environment(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        job = deploy_workflow["jobs"]["deploy-compose-restart"]
+        assert job.get("environment") == "compose-restart"
+        assert "non_reloadable_config_changed" in job.get("if", "")
+
+    def test_prometheus_stays_on_config_reload_path(
+        self, path_filters: dict[str, list[str]]
+    ) -> None:
+        known_path = "config/prometheus/prometheus.yml"
+        assert _in_group(path_filters["reload"], known_path)
+        assert not _in_group(path_filters["non_reloadable_config"], known_path)


### PR DESCRIPTION
## Summary

Enables LB-04's live rollback drill (#182): adds regression-guard tests that lock in the `deploy.yml` wiring the drill depends on (bad `config/otel/**` → `non_reloadable_config` → compose-restart path → `post-deploy-verify` bounded host probe → rollback fires only on its failure), and documents the static-review finding that clears issue #193's suspected blocker ahead of the live run.

The live drill itself remains a human-gated exercise (requires a real sandbox host, `compose-restart` environment approval, and repo-admin access) — this change reduces the risk that the drill rots or fails for a reason that can be caught statically.

## AI-Assisted Review Block

**What does this PR do?**
- Adds `tests/unit/test_deploy_pipeline.py` — static YAML guards asserting: deploy pushes to `main` fire on config/compose/env/dashboards; the `rollback` job is gated on `post-deploy-verify` failure only, uses a pinned `reusable-rollback.yml@v1.2.0` call, forwards all four deploy secrets, restarts with `make up`; `post-deploy-verify` has a bounded timeout and probes `wait-healthy.sh`; the drill's bad-config paths classify as `non_reloadable` (compose-restart path), Prometheus stays on the reload path.
- Extends `tests/unit/test_deploy_docs.py` with invariants that the runbook records the static-review verdict on issue #193 ("refuted" runner-token reasoning, host-side push, remaining live unknowns).
- Updates `docs/ROLLBACK_DRILL.md` precondition 3 (host push credential + branch protection are the real go/no-go checks) and replaces the "known suspected gap" with a dated static-review verdict; adds a status note to `docs/DEPLOYMENT_STRATEGY.md`. LB-04 stays **PENDING** — live drill not yet executed.

**What could go wrong?**
- The guard tests hard-code current deploy wiring (job names, filter groups, pinned ref). A legitimate future refactor of `deploy.yml` will need to update these tests — the strings are the point, but they add CI friction on intentional change.
- The static-review verdict on #193 is analysis, not evidence: only the live drill can finally confirm host push credentials and branch protection. The docs say so explicitly and do not claim the drill is done.

**What tests cover this change?**
- `tests/unit/test_deploy_pipeline.py` and `tests/unit/test_deploy_docs.py` (new/extended). Full suite: 274 passed locally. Pre-commit (ruff lint+format, markdownlint, gitleaks, yamllint) green on all changed files.

**Architecture check:**
- Layer(s) touched: tests (`tests/unit/`) and docs only — **no** `compose.yaml`, `config/**`, `.env.example`, or `dashboards/**` changes, so the GitOps reconciliation deploy does **not** fire on this merge.
- Cross-plane impact: none (no changes to uFawkesPipe, uFawkesRes, or uFawkesDORA contracts). Reads `reusable-rollback.yml@v1.2.0` from uFawkesPipe but does not modify it.

**What I was NOT sure about:**
- Whether the target host retains a push credential and whether `main` branch protection permits the host's revert push — only the live drill (human + sandbox host) can confirm; this is tracked in issue #193 and left PENDING.