### PR TITLE
docs(plan): reconcile plan.md status against gh issue list (LB-07 #185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   corrected to `telemetry-generator` (the actual demo app)
 - Reconciled `docs/plan.md` status column against real GitHub issue state
   (multiple tasks were done but still shown pending)
+- **Closed superseded/duplicate backlog issues as part of LB-07 (#185):** #51–#54
+  (OBS-DORA DevLake design) and M4 tracking issues #80–#83 closed as superseded
+  by the M4 rework, linking `docs/reviews/M4-02-ecosystem-review.md`; #71 closure
+  verified and documented. `docs/plan.md` status column now matches
+  `gh issue list --state all` as of 2026-08-12.
 
 ## [0.1.0] — 2026-06-28
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -126,8 +126,9 @@ is `apps/telemetry-generator`. Fix: replace the `media-refinery` references with
 
 1. **A1** — done (2026-07-27).
 2. **A2** — done (2026-07-27): statuses reconciled, issue #71 closed.
-   **A3** — pending: closing #51–#54 as superseded requires confirmation
-   before a bulk close (see PM note below).
+   **A3** — done (2026-08-12): #51–#54 closed as superseded (LB-07 #185),
+   linking `docs/reviews/M4-02-ecosystem-review.md`. M4 tracking issues
+   #80–#83 closed as superseded in the same pass.
 3. **B1, B2** — done (2026-07-27): `docs/product/` and `docs/features/`
    introduced, see above.
 4. **C1, C2** — root cleanup.

--- a/docs/PATH_TO_LATE_BETA.md
+++ b/docs/PATH_TO_LATE_BETA.md
@@ -59,7 +59,7 @@ Concretely, late beta requires:
 | LB-04 | Run and document a live rollback drill | [#182](https://github.com/paruff/uFawkesObs/issues/182) | 🔲 PENDING (runbook ready) |
 | LB-05 | Investigate GitOps Reconciliation Deploy transient failure | [#183](https://github.com/paruff/uFawkesObs/issues/183) | 🔲 PENDING |
 | LB-06 | Add a beta feedback channel | [#184](https://github.com/paruff/uFawkesObs/issues/184) | 🔲 PENDING |
-| LB-07 | Reconcile `docs/plan.md` status drift against real issue state | [#185](https://github.com/paruff/uFawkesObs/issues/185) | 🔲 PENDING |
+| LB-07 | Reconcile `docs/plan.md` status drift against real issue state | [#185](https://github.com/paruff/uFawkesObs/issues/185) | 🟡 IN PROGRESS (plan.md reconciled 2026-08-12; superseded issues #51–#54, #80–#83 closed) |
 
 All issues are labeled `late-beta` for tracking:
 <https://github.com/paruff/uFawkesObs/issues?q=is%3Aissue+is%3Aopen+label%3Alate-beta>

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,6 +2,7 @@
 
 **Version:** 1.1.0
 **Date:** 2026-06-28
+**Last reconciled:** 2026-08-12 (LB-07, #185) — status column refreshed against `gh issue list --state all`
 **Repo:** paruff/uFawkesObs
 **Status:** Active
 
@@ -331,7 +332,7 @@
 - **Status:** 🟡 MOSTLY DONE (PR #138) — core deliverables shipped under a
   lowercase filename (`docs/multi-stack-integration.md`, not the
   `MULTI_STACK_INTEGRATION.md` the issue names); Makefile integration targets
-  not found. Issue #54 still open on GitHub.
+  not found. Issue #54 closed 2026-08-10 as superseded (M4 rework, LB-07 #185).
 - **Tasks:**
   1. Create `docs/MULTI_STACK_INTEGRATION.md` with sections for each sister stack
   2. Create `docker-compose.integration.yml` at repo root
@@ -354,7 +355,7 @@
 
 - **Description:** Define what counts as a deployment, incident, and restoration within uFawkesObs telemetry. This contract is consumed by uFawkesDORA's ingestion API.
 - **Backlog Issue:** #80
-- **Status:** ✅ DONE (PR #147 merged)
+- **Status:** ✅ DONE (PR #147 merged); issue #80 closed 2026-08-12 as superseded (LB-07 #185)
 - **Details:**
    - Created `docs/adr/ADR-006-dora-metric-definitions.md` (note: ADR-006, not ADR-004 — ADR-004 is the Grafana 12 migration)
    - Defines deployment/incident spans, 4 DORA metrics, metric naming conventions
@@ -370,7 +371,7 @@
 - **Description:** Configure uFawkesObs's `dora` compose profile to connect to uFawkesDORA's ingestion API (for event forwarding) and uFawkesRes's shared PostgreSQL (for DORA metric snapshots). No DevLake or MySQL in uFawkesObs — those now live in uFawkesDORA/uFawkesRes.
 - **Backlog Issue:** #81, #51
 - **Dependencies:** M4-01
-- **Status:** ✅ DONE (PR #148 merged)
+- **Status:** ✅ DONE (PR #148 merged); issues #81 and #51 closed 2026-08-10/12 as superseded (LB-07 #185)
 - **Ecosystem Review:** See `docs/reviews/M4-02-ecosystem-review.md`. DevLake moved to uFawkesDORA; MySQL replaced by uFawkesRes PostgreSQL. uFawkesObs M4 scope is now: data contract (M4-01), recording rules (M4-03), dashboard (M4-04), and cross-plane wiring (this task).
 - **Details:**
    - Added `dora` profile to `compose.yaml` with `otel-collector-dora` service forwarding DORA metrics to uFawkesDORA
@@ -393,7 +394,7 @@
 - **Description:** Configure Prometheus recording rules inside uFawkesObs for continuous calculation of DORA metrics. Rules query Prometheus metrics scraped from OTel Collector; derived metrics pushed by uFawkesDORA compute job via pushgateway.
 - **Backlog Issue:** #82, #53
 - **Dependencies:** M4-02
-- **Status:** ✅ DONE (commit 3ad1661, extended with rework rate in this branch)
+- **Status:** ✅ DONE (commit 3ad1661, extended with rework rate in this branch); issues #82 and #53 closed 2026-08-10/12 as superseded (LB-07 #185)
 - **Notes:** DORA 2026 now defines 5 key metrics — the classic 4 plus rework rate from the AI Capabilities Model.
 - **Details:**
    - Created `config/prometheus/rules/ufawkesobs-dora-metrics.yml` with 5 DORA recording rules:
@@ -423,9 +424,9 @@
 - **Description:** Pre-provision a dedicated DORA dashboard in Grafana showing real-time calculations. Dashboard reads from Prometheus (time-series) and uFawkesRes PostgreSQL via Grafana Postgres datasource plugin (current snapshots). Metrics: Deployment Frequency, Lead Time, Change Failure Rate, Failed Deployment Recovery Time (FDRT), and Rework Rate.
 - **Backlog Issue:** #83, #52
 - **Dependencies:** M4-03
-- **Status:** ✅ DONE
+- **Status:** ✅ DONE; issues #83 and #52 closed 2026-08-10/12 as superseded (LB-07 #185)
 - **Tasks:**
-  1. Create `config/grafana/dashboards/dora-metrics.json` containing panel models for the 5 DORA indicators.
+  1. Create `dashboards/platform/dora-metrics.json` (mounted via `./dashboards/platform` in `compose.yaml`) containing panel models for the 5 DORA indicators.
   2. Enforce standard DORA performance bands (Elite/High/Medium/Low) using color thresholds.
   3. Configure dashboard to use both Prometheus and Postgres datasources.
 - **Acceptance Criteria:**


### PR DESCRIPTION
Closes #185

## What

Reconciles `docs/plan.md` status column against the real `gh issue list --state all` state, per LB-07 (#185):

- Marked superseded backlog issues **#51–#54** (OBS-DORA DevLake design) as closed, linking `docs/reviews/M4-02-ecosystem-review.md`.
- Closed **M4 tracking issues #80–#83** as superseded by the M4 rework (same DevLake → uFawkesDORA / MySQL → uFawkesRes Postgres story), so `docs/plan.md` statuses (DONE) match GitHub state.
- Verified **#71** (M2-01): `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `.github/ISSUE_TEMPLATE/` all exist — closure documented with a confirmation comment.
- Fixed remaining `docs/plan.md` drift (M3-05 stale "issue #54 still open" text; M4-04 dashboard path updated to the real `dashboards/platform/dora-metrics.json`).
- Added a `Last reconciled` marker to `docs/plan.md`, updated `docs/IMPLEMENTATION_PLAN.md` A3 execution note, `docs/PATH_TO_LATE_BETA.md` LB-07 row, and `CHANGELOG.md`.

## Services affected

None — documentation only. No `compose.yaml`, `config/`, or `scripts/` changes.

## Port / volume changes

None

## Secrets check

- [x] No credentials, API keys, or tokens committed
- [x] `.env` files not included in diff

## AI-Assisted Review Block

**What does this PR do?**
Reconciles `docs/plan.md` status column against real GitHub issue state and closes the stale DevLake-era backlog (#51–#54, #80–#83) as superseded per the M4 ecosystem review, verifying #71.

**What could go wrong?**
Low risk — docs only. The GitHub issue closures are reversible. Note that the status `dates` in `docs/plan.md` are day-granular and reflect the actual `closedAt` values from the issues (#51–#54 closed 2026-08-10; #80–#83 closed 2026-08-12).

**What tests cover this change?**
`npx markdownlint-cli` on all touched markdown files (passes) and `pytest tests/unit/` (294 passed). No unit test asserts on `docs/plan.md` contents.

**Architecture check:**
- What layer(s) were touched and are they correct per §4? Docs layer only (§4 "config/ files" and "dashboards/" untouched; the dashboard path fix simply documents the real layout).
- Any cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDORA)? No — this closes tracking issues that describe work already shipped via the M4 rework; uFawkesDORA/uFawkesRes roles were established in the ecosystem review.

**What I was NOT sure about:**
- Closing #80–#83 goes slightly beyond the literal "close #51–#54, fix #71" in #185, but issue #185 also asks to fix any other plan.md drift, and the user confirmed closing #80–#83 as superseded.
- Whether `docs/plan.md` should also bump the plan version; I kept it at 1.1.0 and added a `Last reconciled` line instead.