### PR TITLE
feat(dora): add dora-compute + pushgateway, fold worker into dora-api (#205)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ GRAFANA_ADMIN_PASSWORD=REPLACE_ME
 # (dora profile only). No default is provided in compose.yaml — required.
 DORA_POSTGRES_URL=postgresql://ufawkesres:REPLACE_ME@fawkes-postgres:5432/ufawkesres  # pragma: allowlist secret
 
+# dora-compute batch job settings (dora profile only) — OPTIONAL, defaults shown.
+# How many days back each compute cycle looks, and how often it runs.
+DORA_COMPUTE_WINDOW_DAYS=30
+DORA_COMPUTE_INTERVAL_SECONDS=3600
+
 # Notification channel webhooks — OPTIONAL, blank/placeholder keeps the default
 # webhook-only test sink. Replace REPLACE_ME with a real incoming webhook to
 # enable alerts reaching a human. See docs/alertmanager-operations.md →

--- a/compose.yaml
+++ b/compose.yaml
@@ -609,6 +609,109 @@ services:
       - observability
     profiles: ["dora"]
 
+# Prometheus pushgateway — receives batch-pushed DORA metrics from
+# dora-compute, since it's a periodic job rather than a scrape target
+# (see ADR-007 amendment; issue #205).
+  pushgateway:
+    image: prom/pushgateway:v1.11.0
+    container_name: dora-pushgateway
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:9091:9091"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+        reservations:
+          cpus: "0.05"
+          memory: 32M
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:9091/-/healthy",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+        tag: "pushgateway"
+    labels:
+      - "plane=obstackd"
+      - "component=pushgateway"
+      - "managed-by=fawkes"
+      - "profile=dora"
+    networks:
+      - observability
+    profiles: ["dora"]
+
+# DORA metrics compute — periodic batch job computing DORA metrics from
+# DORA_POSTGRES_URL and pushing them to pushgateway (issue #205; metrics.py
+# is a one-shot CLI, so run.sh loops it — see ADR-007 amendment).
+  dora-compute:
+    build:
+      context: .
+      dockerfile: dora/compute/Dockerfile
+    container_name: ufawkesdora-compute
+    restart: unless-stopped
+    depends_on:
+      dora-db-init:
+        condition: service_completed_successfully
+      pushgateway:
+        condition: service_healthy
+    environment:
+      - TZ=UTC
+      - DATABASE_URL=${DORA_POSTGRES_URL:?Set DORA_POSTGRES_URL in .env (see .env.example) — no credential default is provided in compose.yaml}
+      - PUSHGATEWAY_URL=http://pushgateway:9091
+      - DORA_COMPUTE_WINDOW_DAYS=${DORA_COMPUTE_WINDOW_DAYS:-30}
+      - DORA_COMPUTE_INTERVAL_SECONDS=${DORA_COMPUTE_INTERVAL_SECONDS:-3600}
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+    healthcheck:
+      # No HTTP endpoint — run.sh writes a heartbeat file after each
+      # successful compute cycle; see dora/compute/Dockerfile.
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import os,sys,time; p='/tmp/dora-compute-heartbeat'; stale=int(os.environ.get('DORA_COMPUTE_INTERVAL_SECONDS','3600'))*2; sys.exit(0 if os.path.exists(p) and time.time()-os.path.getmtime(p)<stale else 1)",
+        ]
+      interval: 5m
+      timeout: 10s
+      retries: 3
+      start_period: 2m
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+        tag: "dora-compute"
+    labels:
+      - "plane=obstackd"
+      - "component=dora-compute"
+      - "managed-by=fawkes"
+      - "profile=dora"
+    networks:
+      - observability
+    profiles: ["dora"]
+
 # DORA metrics compute plane (connects to uFawkesDORA ingestion API and uFawkesRes Postgres)
   otel-collector-dora:
     image: otel/opentelemetry-collector-contrib:0.120.0

--- a/dora/compute/Dockerfile
+++ b/dora/compute/Dockerfile
@@ -1,0 +1,51 @@
+# ============================================================================
+# uFawkesDORA Compute — Multi-stage Dockerfile
+# ----------------------------------------------------------------------------
+# Stage 1: Build / install dependencies
+# Stage 2: Runtime image (non-root user, heartbeat-file health check)
+#
+# Build context: repository root (see compose.yaml dora-compute service).
+# No pyproject.toml / console_scripts here — every dora/* service ships its
+# own requirements file and a direct entrypoint (see ADR-007 amendment).
+# ============================================================================
+
+# ── Stage 1: Build ─────────────────────────────────────────────────────────────
+
+FROM python:3.13-slim AS builder
+
+WORKDIR /build
+
+COPY dora/compute/requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# ── Stage 2: Runtime ───────────────────────────────────────────────────────────
+
+FROM python:3.13-slim
+
+RUN groupadd -r ufawkes && useradd -r -g ufawkes -d /app -s /sbin/nologin ufawkes
+
+WORKDIR /app
+
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+
+# Keeps the `compute.*` import namespace so `python -m compute.metrics` works
+COPY dora/compute/__init__.py ./compute/__init__.py
+COPY dora/compute/metrics.py ./compute/metrics.py
+COPY dora/compute/archetype.py ./compute/archetype.py
+COPY dora/compute/vsi.py ./compute/vsi.py
+COPY dora/compute/run.sh ./run.sh
+
+RUN chown -R ufawkes:ufawkes /app
+
+USER ufawkes
+
+# No HTTP endpoint — run.sh writes a heartbeat file after each successful
+# compute cycle; unhealthy if it goes stale for more than 2x the interval.
+HEALTHCHECK --interval=5m --timeout=10s --start-period=2m --retries=3 \
+    CMD python3 -c "\
+import os, sys, time; \
+p = '/tmp/dora-compute-heartbeat'; \
+stale_after = int(os.environ.get('DORA_COMPUTE_INTERVAL_SECONDS', '3600')) * 2; \
+sys.exit(0 if os.path.exists(p) and time.time() - os.path.getmtime(p) < stale_after else 1)"
+
+CMD ["/bin/sh", "run.sh"]

--- a/dora/compute/run.sh
+++ b/dora/compute/run.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Runs the DORA metrics compute batch job on a fixed interval, pushing
+# results to the Prometheus pushgateway. metrics.py is a one-shot CLI
+# (see ADR-007 amendment — push-based, not a scrape target); this loop
+# is what turns it into a long-running service (issue #205).
+set -eu
+
+: "${DATABASE_URL:?Set DORA_POSTGRES_URL in .env (see .env.example)}"
+: "${PUSHGATEWAY_URL:?Set PUSHGATEWAY_URL}"
+
+WINDOW_DAYS="${DORA_COMPUTE_WINDOW_DAYS:-30}"
+INTERVAL_SECONDS="${DORA_COMPUTE_INTERVAL_SECONDS:-3600}"
+
+echo "dora-compute starting (window=${WINDOW_DAYS}d, interval=${INTERVAL_SECONDS}s)"
+
+while true; do
+    if python -m compute.metrics --window "$WINDOW_DAYS" --pushgateway "$PUSHGATEWAY_URL"; then
+        date +%s >/tmp/dora-compute-heartbeat
+    else
+        echo "dora-compute cycle failed, will retry next interval" >&2
+    fi
+    sleep "$INTERVAL_SECONDS"
+done

--- a/dora/ingestion/api/main.py
+++ b/dora/ingestion/api/main.py
@@ -9,6 +9,7 @@ Endpoints:
     GET  /health      — Health check with queue depth.
 """
 
+import asyncio
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -22,16 +23,28 @@ from ingestion.api.queue import (
     get_queue_depth,
 )
 from ingestion.api.validator import validate_payload, validate_payloads
+from ingestion.processor.worker import run_worker_loop
 
 # ── Lifecycle ──────────────────────────────────────────────────────────────────
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Startup / shutdown lifecycle."""
-    # Startup: pool is lazy-initialized on first use
+    """Startup / shutdown lifecycle.
+
+    Runs the event_queue worker loop as a background task rather than a
+    separate container (issue #205) — the connection pool is shared and
+    lazy-initialized on first use by either the API or the worker.
+    """
+    shutdown_event = asyncio.Event()
+    worker_task = asyncio.create_task(run_worker_loop(shutdown_event=shutdown_event))
     yield
-    # Shutdown: close the connection pool
+    # Shutdown: signal the worker loop to stop, then close the pool
+    shutdown_event.set()
+    try:
+        await asyncio.wait_for(worker_task, timeout=5)
+    except (TimeoutError, asyncio.CancelledError):
+        worker_task.cancel()
     await close_pool()
 
 

--- a/tests/unit/test_dora_consolidation.py
+++ b/tests/unit/test_dora_consolidation.py
@@ -297,6 +297,119 @@ class TestDoraDatabaseFiles:
 
 
 # ---------------------------------------------------------------------------
+# compose.yaml dora-compute + pushgateway services (issue #205)
+# ---------------------------------------------------------------------------
+class TestComposeDoraCompute:
+    """dora-compute is a periodic batch job (own Dockerfile, no
+    pyproject.toml) pushing metrics to pushgateway — see ADR-007 amendment.
+    """
+
+    def test_service_present(self, compose_data: dict) -> None:
+        assert "dora-compute" in compose_data.get("services", {}), (
+            "compose.yaml missing dora-compute service"
+        )
+
+    def test_own_dockerfile(self, compose_data: dict) -> None:
+        svc = compose_data["services"]["dora-compute"]
+        assert svc.get("build", {}).get("dockerfile") == "dora/compute/Dockerfile", (
+            "dora-compute must build from its own Dockerfile, not share dora-api's"
+        )
+
+    def test_dora_profile(self, compose_data: dict) -> None:
+        svc = compose_data["services"]["dora-compute"]
+        assert "dora" in svc.get("profiles", []), (
+            "dora-compute must be gated behind the dora profile"
+        )
+
+    def test_healthcheck_defined(self, compose_data: dict) -> None:
+        assert "healthcheck" in compose_data["services"]["dora-compute"], (
+            "every service must define a healthcheck (AGENTS.md §4)"
+        )
+
+    def test_database_url_from_dora_postgres_url(self, compose_data: dict) -> None:
+        svc = compose_data["services"]["dora-compute"]
+        env = svc.get("environment", [])
+        assert any(
+            isinstance(e, str)
+            and e.startswith("DATABASE_URL=")
+            and "DORA_POSTGRES_URL" in e
+            for e in env
+        ), "dora-compute must derive DATABASE_URL from DORA_POSTGRES_URL"
+
+    def test_pushgateway_url_points_at_pushgateway_service(
+        self, compose_data: dict
+    ) -> None:
+        svc = compose_data["services"]["dora-compute"]
+        env = svc.get("environment", [])
+        assert "PUSHGATEWAY_URL=http://pushgateway:9091" in env, (
+            "dora-compute must push to the pushgateway compose service by name"
+        )
+
+    def test_waits_for_pushgateway_healthy(self, compose_data: dict) -> None:
+        svc = compose_data["services"]["dora-compute"]
+        depends_on = svc.get("depends_on", {})
+        assert depends_on.get("pushgateway", {}).get("condition") == (
+            "service_healthy"
+        ), "dora-compute must wait for pushgateway to be healthy before starting"
+
+
+class TestComposePushgateway:
+    """The pushgateway service receives dora-compute's batch-pushed metrics."""
+
+    def test_service_present(self, compose_data: dict) -> None:
+        assert "pushgateway" in compose_data.get("services", {}), (
+            "compose.yaml missing pushgateway service"
+        )
+
+    def test_dora_profile(self, compose_data: dict) -> None:
+        svc = compose_data["services"]["pushgateway"]
+        assert "dora" in svc.get("profiles", []), (
+            "pushgateway must be gated behind the dora profile"
+        )
+
+    def test_healthcheck_defined(self, compose_data: dict) -> None:
+        assert "healthcheck" in compose_data["services"]["pushgateway"], (
+            "every service must define a healthcheck (AGENTS.md §4)"
+        )
+
+    def test_pinned_image(self, compose_data: dict) -> None:
+        svc = compose_data["services"]["pushgateway"]
+        image = svc.get("image", "")
+        assert image and ":latest" not in image, (
+            "pushgateway image must be pinned — no latest tags (AGENTS.md §4)"
+        )
+
+
+class TestDoraComputeFiles:
+    """dora-compute build inputs moved/added for issue #205."""
+
+    EXPECTED_FILES = ["Dockerfile", "run.sh"]
+
+    @pytest.mark.parametrize("rel", EXPECTED_FILES)
+    def test_file_present(self, rel: str) -> None:
+        assert (DORA_DIR / "compute" / rel).is_file(), (
+            f"expected dora/compute/{rel} — issue #205 did not land"
+        )
+
+
+# ---------------------------------------------------------------------------
+# dora-api background worker fold-in (issue #205)
+# ---------------------------------------------------------------------------
+class TestIngestionWorkerFoldIn:
+    """The event_queue worker runs as a background task inside dora-api's
+    FastAPI lifespan, not a separate container (see ADR-007 amendment)."""
+
+    def test_lifespan_starts_worker_loop(self) -> None:
+        src = (DORA_DIR / "ingestion" / "api" / "main.py").read_text(encoding="utf-8")
+        assert "from ingestion.processor.worker import run_worker_loop" in src
+        assert "run_worker_loop(shutdown_event=shutdown_event)" in src
+
+    def test_lifespan_stops_worker_on_shutdown(self) -> None:
+        src = (DORA_DIR / "ingestion" / "api" / "main.py").read_text(encoding="utf-8")
+        assert "shutdown_event.set()" in src
+
+
+# ---------------------------------------------------------------------------
 # Container import contract
 # ---------------------------------------------------------------------------
 class TestIngestionImportContract:


### PR DESCRIPTION
Stacked on #211 (base branch is `feat/dora-consolidation-02-db-init`, not
`main`) — this PR's diff will shrink to just the #205 changes once #211
merges and this is retargeted to `main`.

## AI-Assisted Review Block

**What does this PR do?**
Implements DORA-CONSOLIDATION-05 (#205): adds a `dora-compute` service with
its own Dockerfile (no `pyproject.toml`/entry-points — see ADR-007's
amendment) that loops `compute/metrics.py` (a one-shot batch CLI) on an
interval and pushes results to a new `pushgateway` service. Also folds
`dora/ingestion/processor/worker.py`'s existing event_queue worker loop into
`dora-api`'s FastAPI lifespan as a background task, instead of standing up a
third container for it.

**What could go wrong?**
- `dora-compute`'s healthcheck is a heartbeat file (`/tmp/dora-compute-heartbeat`)
  written after each successful cycle, since there's no HTTP endpoint to
  probe — stale for more than 2x `DORA_COMPUTE_INTERVAL_SECONDS` means
  unhealthy. A single failed cycle won't flap the container; it just skips
  writing the heartbeat and retries next interval.
- `dora-compute` depends on `pushgateway` being healthy and `dora-db-init`
  having completed before it starts.
- Folding the worker into `dora-api`'s lifespan means a worker crash could
  in theory affect the API process — mitigated by `run_worker_loop`'s
  existing per-event try/except (a bad event fails and retries up to
  `MAX_ATTEMPTS`, it doesn't crash the loop).
- On shutdown, the worker task gets 5s to stop gracefully before being
  cancelled — long enough for `dequeue_next`'s default 1s poll interval.

**What tests cover this change?**
`tests/unit/test_dora_consolidation.py` — new `TestComposeDoraCompute`,
`TestComposePushgateway`, `TestDoraComputeFiles`, `TestIngestionWorkerFoldIn`
classes cover: service presence, own Dockerfile, `dora` profile, healthcheck,
`DATABASE_URL`/`PUSHGATEWAY_URL` wiring, `depends_on` ordering, pinned image,
and that `main.py`'s lifespan actually starts/stops the worker loop. 70/70
tests pass locally. `docker compose --profile dora config` validates clean.
`shellcheck` clean on `dora/compute/run.sh`.

**Architecture check:**
- Layer touched: `compose.yaml` (2 new services) + `dora/compute/` (new
  Dockerfile + run.sh) + `dora/ingestion/api/main.py` (lifespan) — correct
  per AGENTS.md §4 (dora profile, pinned `prom/pushgateway:v1.11.0`, no
  `latest` tags, every service has a healthcheck).
- Cross-plane impact: none — `pushgateway` and `dora-compute` are new,
  internal-only (no exposed hostname other services depend on yet; #204 will
  add the Prometheus scrape job that makes these metrics visible).

**What I was NOT sure about:**
Whether a fixed polling interval (default 1h, via `DORA_COMPUTE_INTERVAL_SECONDS`)
is the right cadence, versus something driven by an actual schedule/cron. Went
with the simplest thing that works — a shell loop — since there's no scheduler
dependency already in this repo's stack to hang a cron job off of. Easy to
tune via `.env` if 1h turns out wrong.