### PR TITLE
feat(dora): merge DORA regression alerts, add pushgateway scrape job (#204)

### DIFF
--- a/config/prometheus/prometheus.yaml
+++ b/config/prometheus/prometheus.yaml
@@ -21,6 +21,7 @@ rule_files:
   - "/etc/prometheus/rules/ufawkesobs-self-monitoring.yml"
   - "/etc/prometheus/rules/ai-rules.yml"
   - "/etc/prometheus/rules/ufawkesobs-dora-metrics.yml"
+  - "/etc/prometheus/rules/ufawkesobs-dora-regression.yml"
 
 # Scrape configurations
 scrape_configs:
@@ -143,5 +144,18 @@ scrape_configs:
           plane: "obstackd"
           component: "node-exporter"
     scrape_interval: 15s
+    metrics_path: "/metrics"
+
+  # Pushgateway — scraped for batch-pushed DORA metrics from dora-compute
+  # (dora profile only; issue #204). honor_labels keeps the job/instance
+  # labels dora-compute pushed rather than overwriting them with this job's.
+  - job_name: "pushgateway"
+    honor_labels: true
+    static_configs:
+      - targets: ["pushgateway:9091"]
+        labels:
+          plane: "obstackd"
+          component: "pushgateway"
+    scrape_interval: 60s
     metrics_path: "/metrics"
     scheme: "http"

--- a/config/prometheus/rules/ufawkesobs-dora-regression.yml
+++ b/config/prometheus/rules/ufawkesobs-dora-regression.yml
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# DORA Regression Alerts — trend-based alerts on the pushed metrics from
+# dora-compute (issue #205), routed through pushgateway. Distinct from the
+# scrape-based recording rules in ufawkesobs-dora-metrics.yml: these fire on
+# short-window vs. long-window drift within the same metric, rather than on
+# an absolute threshold.
+#
+# Source metrics (pushed by dora/compute/metrics.py via pushgateway,
+# labeled by team_id):
+#   - dora_deployment_frequency_per_week (gauge)
+#   - dora_lead_time_p50_hours / dora_lead_time_p95_hours (gauge)
+#   - dora_fdrt_p50_hours (gauge)
+#   - dora_cfr_pct (gauge)
+#   - dora_rework_rate_pct (gauge)
+#
+# Merged from uFawkesDORA's alerts/dora-regression.yaml (issue #204).
+#
+# NOT merged: uFawkesDORA's alerts/leading-indicator.yaml. Its two alerts
+# reference dora_pr_cycle_time_seconds_bucket and dora_pr_size_lines_added,
+# and nothing in this repo emits either metric yet — there's no PR-cycle or
+# PR-size collector (that's issue #208's "collector patterns" scope).
+# Merging it now would ship alerts that can never fire. Revisit once #208
+# lands.
+
+groups:
+  - name: ufawkesobs_dora_regression
+    interval: 60s
+    rules:
+      - alert: DORARegressionDeploymentFrequencyDrop
+        expr: |
+          (
+            avg_over_time(dora_deployment_frequency_per_week[7d])
+            /
+            avg_over_time(dora_deployment_frequency_per_week[30d])
+          ) < 0.70
+        for: 24h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "Deployment frequency dropped >30% vs 30-day average"
+          description: |
+            {{ $labels.team_id }} deploying {{ $value | humanize }}x/wk vs its
+            30-day average. Check for blocked PRs or an in-progress migration.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#deployment-frequency-drop"
+
+      - alert: DORARegressionDeploymentFrequencyDropAbsent
+        expr: |
+          absent(dora_deployment_frequency_per_week)
+        for: 1h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "Deployment frequency metric missing"
+          description: |
+            dora_deployment_frequency_per_week is absent. dora-compute may not
+            be pushing to pushgateway — check the dora-compute container.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#deployment-frequency-drop-absent"
+
+      - alert: DORARegressionLeadTimeIncrease
+        expr: |
+          (
+            avg_over_time(dora_lead_time_p50_hours[7d])
+            /
+            avg_over_time(dora_lead_time_p50_hours[30d])
+          ) > 1.5
+        for: 48h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "Lead time increased >50% vs 30-day average"
+          description: |
+            {{ $labels.team_id }} lead time at {{ $value }}hrs vs its 30-day
+            average. Check for growing PR size or review bottlenecks.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#lead-time-increase"
+
+      - alert: DORARegressionLeadTimeIncreaseAbsent
+        expr: |
+          absent(dora_lead_time_p50_hours)
+        for: 1h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "Lead time metric missing"
+          description: |
+            dora_lead_time_p50_hours is absent. dora-compute may not be
+            pushing to pushgateway — check the dora-compute container.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#lead-time-increase-absent"
+
+      - alert: DORARegressionFDRTSpike
+        expr: |
+          dora_fdrt_p50_hours > (avg_over_time(dora_fdrt_p50_hours[30d]) * 2)
+        for: 6h
+        labels:
+          severity: critical
+          category: dora
+        annotations:
+          summary: "FDRT doubled vs 30-day average — throughput at risk"
+          description: |
+            Recovery taking {{ $value }}hrs vs the 30-day average. FDRT is a
+            Throughput metric (DORA 2025) — this blocks re-deployment.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#fdrt-spike"
+
+      - alert: DORARegressionFDRTSpikeAbsent
+        expr: |
+          absent(dora_fdrt_p50_hours)
+        for: 1h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "FDRT metric missing"
+          description: |
+            dora_fdrt_p50_hours is absent. dora-compute may not be pushing to
+            pushgateway — check the dora-compute container.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#fdrt-spike-absent"
+
+      - alert: DORARegressionCFRSpike
+        expr: |
+          dora_cfr_pct > (avg_over_time(dora_cfr_pct[30d]) + 5)
+        for: 24h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "Change Failure Rate +5 points above 30-day average"
+          description: |
+            {{ $labels.team_id }} CFR at {{ $value }}% vs its 30-day average.
+            Check recent deployments for quality issues.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#cfr-spike"
+
+      - alert: DORARegressionCFRSpikeAbsent
+        expr: |
+          absent(dora_cfr_pct)
+        for: 1h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "CFR metric missing"
+          description: |
+            dora_cfr_pct is absent. dora-compute may not be pushing to
+            pushgateway — check the dora-compute container.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#cfr-spike-absent"
+
+      - alert: DORARegressionReworkRateClimb
+        expr: |
+          dora_rework_rate_pct > (avg_over_time(dora_rework_rate_pct[30d]) + 3)
+        for: 48h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "Rework Rate climbing — possible AI over-generation effect"
+          description: |
+            Rework Rate at {{ $value }}% vs its 30-day average. Per DORA 2025,
+            Rework Rate is the primary AI quality signal. Check PR size trend.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#rework-rate-climb"
+
+      - alert: DORARegressionReworkRateClimbAbsent
+        expr: |
+          absent(dora_rework_rate_pct)
+        for: 1h
+        labels:
+          severity: warning
+          category: dora
+        annotations:
+          summary: "Rework Rate metric missing"
+          description: |
+            dora_rework_rate_pct is absent. dora-compute may not be pushing to
+            pushgateway — check the dora-compute container.
+          runbook_url: "https://github.com/paruff/uFawkesObs/blob/main/docs/runbooks/dora.md#rework-rate-climb-absent"

--- a/tests/unit/test_dora_regression_alerts.py
+++ b/tests/unit/test_dora_regression_alerts.py
@@ -1,0 +1,166 @@
+"""
+Unit tests for the DORA regression alert rules (issue #204).
+
+Merges uFawkesDORA's alerts/dora-regression.yaml into
+config/prometheus/rules/ufawkesobs-dora-regression.yml, and adds the
+pushgateway scrape job these pushed-metric alerts depend on.
+
+Note: uFawkesDORA's alerts/leading-indicator.yaml is deliberately NOT
+merged — it references dora_pr_cycle_time_seconds_bucket and
+dora_pr_size_lines_added, which nothing in this repo emits yet (no
+PR-cycle/PR-size collector exists — that's issue #208 scope).
+"""
+
+import pathlib
+
+import yaml
+
+
+class TestDoraRegressionRulesFile:
+    """Test the merged DORA regression alert rules file."""
+
+    def _load(self, project_root):
+        rules_path = (
+            pathlib.Path(project_root)
+            / "config"
+            / "prometheus"
+            / "rules"
+            / "ufawkesobs-dora-regression.yml"
+        )
+        with open(rules_path, "r") as f:
+            return yaml.safe_load(f), rules_path
+
+    def test_rules_file_exists(self, project_root):
+        _, path = self._load(project_root)
+        assert path.exists(), f"DORA regression rules file not found: {path}"
+
+    def test_rules_file_valid_yaml(self, project_root):
+        rules, _ = self._load(project_root)
+        assert rules is not None, "DORA regression rules file is empty"
+
+    def test_has_regression_group(self, project_root):
+        rules, _ = self._load(project_root)
+        group_names = [g["name"] for g in rules["groups"]]
+        assert "ufawkesobs_dora_regression" in group_names
+
+    def test_expected_alerts_present(self, project_root):
+        rules, _ = self._load(project_root)
+        for group in rules["groups"]:
+            if group["name"] == "ufawkesobs_dora_regression":
+                alert_names = [r["alert"] for r in group["rules"] if "alert" in r]
+                required = [
+                    "DORARegressionDeploymentFrequencyDrop",
+                    "DORARegressionLeadTimeIncrease",
+                    "DORARegressionFDRTSpike",
+                    "DORARegressionCFRSpike",
+                    "DORARegressionReworkRateClimb",
+                ]
+                for name in required:
+                    assert name in alert_names, f"Missing alert: {name}"
+                return
+        raise AssertionError("ufawkesobs_dora_regression group not found")
+
+    def test_leading_indicator_alerts_not_merged(self, project_root):
+        """PR-cycle/PR-size alerts stay out until issue #208 adds a collector."""
+        rules, _ = self._load(project_root)
+        alert_names = [
+            r["alert"]
+            for group in rules["groups"]
+            for r in group["rules"]
+            if "alert" in r
+        ]
+        assert "DoraLeadingIndicatorPRCycle" not in alert_names
+        assert "DoraLeadingIndicatorPRSize" not in alert_names
+
+    def test_alerts_have_category_and_severity(self, project_root):
+        rules, _ = self._load(project_root)
+        for group in rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule:
+                    labels = rule.get("labels", {})
+                    assert "category" in labels, (
+                        f"Alert {rule['alert']} missing category label"
+                    )
+                    assert "severity" in labels, (
+                        f"Alert {rule['alert']} missing severity label"
+                    )
+
+    def test_alerts_have_runbook_url(self, project_root):
+        rules, _ = self._load(project_root)
+        for group in rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule:
+                    annotations = rule.get("annotations", {})
+                    assert "runbook_url" in annotations, (
+                        f"Alert {rule['alert']} missing runbook_url"
+                    )
+                    assert "paruff/uFawkesObs" in annotations["runbook_url"], (
+                        f"Alert {rule['alert']} runbook_url should point at "
+                        "uFawkesObs, not the archived uFawkesDORA repo"
+                    )
+
+    def test_alerts_reference_pushgateway_metrics(self, project_root):
+        """Every expr must reference a metric dora-compute actually emits."""
+        rules, _ = self._load(project_root)
+        emitted_metrics = {
+            "dora_deployment_frequency_per_week",
+            "dora_lead_time_p50_hours",
+            "dora_lead_time_p95_hours",
+            "dora_fdrt_p50_hours",
+            "dora_cfr_pct",
+            "dora_rework_rate_pct",
+        }
+        for group in rules["groups"]:
+            for rule in group["rules"]:
+                if "alert" in rule:
+                    expr = rule["expr"]
+                    assert any(metric in expr for metric in emitted_metrics), (
+                        f"Alert {rule['alert']} expr references no known "
+                        f"dora-compute metric: {expr}"
+                    )
+
+
+class TestDoraRegressionRulesReferencedInPrometheusConfig:
+    """Test that the new rule file is wired into Prometheus."""
+
+    def test_rule_file_in_rule_files(self, prometheus_config_path):
+        with open(prometheus_config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        rule_files = config.get("rule_files", [])
+        assert "/etc/prometheus/rules/ufawkesobs-dora-regression.yml" in rule_files, (
+            "ufawkesobs-dora-regression.yml should be referenced in rule_files"
+        )
+
+
+class TestPushgatewayScrapeJob:
+    """Test the Prometheus scrape job added for pushgateway (issue #204)."""
+
+    def test_pushgateway_job_exists(self, prometheus_config_path):
+        with open(prometheus_config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        job_names = [sc["job_name"] for sc in config["scrape_configs"]]
+        assert "pushgateway" in job_names
+
+    def test_pushgateway_job_honors_labels(self, prometheus_config_path):
+        """honor_labels must be true so pushed job/instance labels survive scraping."""
+        with open(prometheus_config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        for sc in config["scrape_configs"]:
+            if sc["job_name"] == "pushgateway":
+                assert sc.get("honor_labels") is True
+                return
+        raise AssertionError("pushgateway scrape job not found")
+
+    def test_pushgateway_job_targets_container(self, prometheus_config_path):
+        with open(prometheus_config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        for sc in config["scrape_configs"]:
+            if sc["job_name"] == "pushgateway":
+                targets = sc["static_configs"][0]["targets"]
+                assert "pushgateway:9091" in targets
+                return
+        raise AssertionError("pushgateway scrape job not found")


### PR DESCRIPTION
## Summary

Part of the [DORA-CONSOLIDATION](https://github.com/paruff/uFawkesObs/blob/main/docs/adr/ADR-007-dora-consolidation.md) plan (issue #204). Stacked on #212 (issue #205) — merge target for this PR will move to `main` once #211/#212 land.

- Merges uFawkesDORA's `alerts/dora-regression.yaml` (5 alerts) into `config/prometheus/rules/ufawkesobs-dora-regression.yml`, renamed to a `DORARegression*` prefix to avoid colliding with the existing recording-rule-based `DORA*` alerts in `ufawkesobs-dora-metrics.yml`.
- Adds paired `*Absent` guard alerts for each, matching this repo's existing convention (`ufawkesobs-dora-metrics.yml`).
- Adds the `pushgateway` Prometheus scrape job (`honor_labels: true`) these pushed metrics depend on — the `pushgateway` service itself was already added in #212 (issue #205) but had no scrape job wired up yet.
- **Deliberately does not merge** uFawkesDORA's `alerts/leading-indicator.yaml` (2 alerts). They reference `dora_pr_cycle_time_seconds_bucket` and `dora_pr_size_lines_added`, and nothing in this repo emits either metric — there's no PR-cycle or PR-size collector yet. That's issue #208's "collector patterns" scope; merging these now would ship alerts that can never fire.

## What could go wrong?

- The new alert thresholds are trend-based (rolling 7d/30d comparisons) rather than absolute, so they'll stay silent until `dora-compute` has pushed at least 30 days of history — expected, not a bug.
- `runbook_url` annotations point at `docs/runbooks/dora.md` anchors. That file doesn't exist yet — this is a **pre-existing gap** (the already-merged `ufawkesobs-dora-metrics.yml` alerts have the same dangling links), not something introduced here. Flagging for a follow-up, not blocking.

## What tests cover this change?

- `tests/unit/test_dora_regression_alerts.py` (new, TDD-first): rule file exists/valid YAML, expected alert group/names present, leading-indicator alerts explicitly absent, all alerts have `category`/`severity` labels and a `runbook_url`, every `expr` references a metric `dora-compute` actually emits, rule file is wired into `prometheus.yaml`'s `rule_files`, and the `pushgateway` scrape job exists with `honor_labels: true` and the correct target.
- Validated with `promtool check rules` / `check config` via the pinned `prom/prometheus:v3.5.4` image — all 5 rule files parse cleanly (10 new rules found).
- `docker compose config -q` passes.

## Architecture check

- **Layer(s) touched:** `config/prometheus/rules/` (new alert-rules file, §4 dashboards/rules conventions) and `config/prometheus/prometheus.yaml` (rule_files + scrape_configs, per AGENTS.md §8: "Any change to Prometheus scrape config requires a note on what metrics will be affected" — see above, this adds scrape coverage for `dora_deployment_frequency_per_week`, `dora_lead_time_p50_hours`, `dora_lead_time_p95_hours`, `dora_fdrt_p50_hours`, `dora_cfr_pct`, `dora_rework_rate_pct`).
- **Cross-plane impact:** None beyond the already-agreed uFawkesDORA→uFawkesObs consolidation (ADR-007). No changes to uFawkesRes/uFawkesPipe/uFawkesDevX integration points.

## What I was NOT sure about

- Whether to create `docs/runbooks/dora.md` as part of this PR (it's referenced by both the pre-existing and new alerts but doesn't exist) — left as a follow-up rather than scope-creeping into runbook authoring here.
- Whether to also carry over the `interval: 1h` from uFawkesDORA's source file — used `interval: 60s` instead to match this repo's own `ufawkesobs-dora-metrics.yml` convention.