### PR TITLE
feat(dora): merge 5 DORA dashboards from uFawkesDORA (#203)

### DIFF
--- a/dashboards/platform/dora-ai-impact.json
+++ b/dashboards/platform/dora-ai-impact.json
@@ -1,0 +1,450 @@
+{
+  "title": "AI Impact",
+  "uid": "ufawkesobs-dora-ai-impact",
+  "version": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "ufawkesobs",
+    "dora",
+    "ufawkes",
+    "ai-impact"
+  ],
+  "description": "Dashboard showing the impact of AI-assisted development on delivery metrics: PR size trend, code churn rate (placeholder), Rework Rate vs Deployment Frequency, and FDRT trend.",
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "refresh": "5m",
+  "editable": true,
+  "graphTooltip": 0,
+  "templating": {
+    "list": [
+      {
+        "name": "team",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "ufawkesres-postgres"
+        },
+        "query": "SELECT DISTINCT source FROM raw_events ORDER BY source",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": "%",
+        "sort": 1,
+        "label": "Team",
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "",
+      "type": "text",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "transparent": true,
+      "options": {
+        "content": "<div style=\"display: flex; justify-content: space-between; align-items: center; padding: 8px 16px;\"><div><h1 style=\"margin: 0;\">AI Impact</h1><span style=\"color: #888; font-size: 0.9em;\">Monitoring the effects of AI-assisted development on delivery quality and flow</span></div><div style=\"text-align: right;\"><span style=\"color: #aaa; font-size: 0.85em;\">Data from PostgreSQL raw_events table</span></div></div>",
+        "mode": "html"
+      }
+    },
+    {
+      "id": 2,
+      "title": "PR Size 14-day MA",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "14-day moving average of lines added per merged PR. AI inflates PR size 50-150% \u2014 monitor Rework Rate for quality signal (DORA 2025).",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  date_trunc('day', recorded_at) AS time,\n  AVG((metadata->>'lines_added')::int)::numeric(10,1) AS overall_avg_lines,\n  AVG(CASE WHEN (metadata->>'ai_assisted')::boolean THEN (metadata->>'lines_added')::int ELSE NULL END)::numeric(10,1) AS ai_assisted_avg_lines\nFROM raw_events\nWHERE event_type = 'pr'\n  AND metadata->>'status' = 'merged'\n  AND source ILIKE '$team'\n  AND (metadata->>'lines_added')::int >= 0\n  AND recorded_at >= NOW() - INTERVAL '14 days'\nGROUP BY 1\nORDER BY 1;",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ai_assisted_avg_lines"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "dashed"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.dashLength",
+                "value": 5
+              },
+              {
+                "id": "custom.spaceLength",
+                "value": 5
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Code Churn Rate",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Code churn rate: lines changed within 14 days of original commit divided by total lines in the repository. [PLACEHOLDER - requires commit data integration]",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT 'N/A' AS value",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "text"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value"
+      }
+    },
+    {
+      "id": 4,
+      "title": "FDRT Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Failed Deployment Recovery Time trend. FDRT is a Throughput metric per DORA 2025 \u2014 fast recovery enables faster re-deployment. This is NOT MTTR.",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  date_trunc('day', recorded_at) AS time,\n  AVG(fdrt_hours)::numeric(10,1) AS fdrt_trend\nFROM dora_snapshots\nWHERE team_id = '$team'\n  AND recorded_at >= NOW() - INTERVAL '30 days'\nGROUP BY 1\nORDER BY 1;",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 1,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 1.0
+              },
+              {
+                "color": "orange",
+                "value": 24.0
+              },
+              {
+                "color": "red",
+                "value": 168.0
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Rework Rate vs Deployment Frequency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Dual-axis chart showing Rework Rate (left) and Deployment Frequency (right). The 'faster but messier' quadrant is high DF with high Rework Rate.",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  time,\n  value AS rework_rate_pct\nFROM (\n  SELECT\n    date_trunc('day', recorded_at) AS time,\n    AVG(rework_rate_pct * 100) AS value\n  FROM dora_snapshots\n  WHERE team_id = '$team'\n    AND recorded_at >= NOW() - INTERVAL '30 days'\n  GROUP BY 1\n) sub\nORDER BY 1;",
+          "refId": "A"
+        },
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  date_trunc('day', recorded_at) AS time,\n  AVG(deployment_frequency_per_week) AS value\nFROM dora_snapshots\nWHERE team_id = '$team'\n  AND recorded_at >= NOW() - INTERVAL '30 days'\nGROUP BY 1\nORDER BY 1;",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "fillOpacity": 10,
+          "lineWidth": 2,
+          "pointSize": 3
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rework_rate_pct"
+            },
+            "properties": [
+              {
+                "id": "custom.unit",
+                "value": "percent"
+              },
+              {
+                "id": "custom.decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.min",
+                "value": 0
+              },
+              {
+                "id": "custom.max",
+                "value": 50
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Rework Rate (%)"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "deployment_frequency_per_week"
+            },
+            "properties": [
+              {
+                "id": "custom.unit",
+                "value": "none"
+              },
+              {
+                "id": "custom.decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.min",
+                "value": 0
+              },
+              {
+                "id": "custom.scale",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Deployments/Week"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ]
+      }
+    }
+  ],
+  "id": null
+}

--- a/dashboards/platform/dora-archetype-profile.json
+++ b/dashboards/platform/dora-archetype-profile.json
@@ -1,0 +1,434 @@
+{
+  "title": "Archetype Profile",
+  "uid": "ufawkesobs-dora-archetype-profile",
+  "version": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "ufawkesobs",
+    "dora",
+    "ufawkes",
+    "archetype"
+  ],
+  "description": "Team's current archetype, confidence, radar chart of five metrics vs archetype centroid, and recommendations based on the 2025 DORA seven-archetype model. Includes link to wellbeing survey.",
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "refresh": "5m",
+  "editable": true,
+  "graphTooltip": 0,
+  "templating": {
+    "list": [
+      {
+        "name": "team",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "ufawkesres-postgres"
+        },
+        "query": "SELECT DISTINCT team_id FROM archetype_history ORDER BY team_id",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "sort": 1,
+        "label": "Team",
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "",
+      "type": "text",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "transparent": true,
+      "options": {
+        "content": "<div style=\"display: flex; justify-content: space-between; align-items: center; padding: 8px 16px;\"><div><h1 style=\"margin: 0;\">Archetype Profile</h1><span style=\"color: #888; font-size: 0.9em;\">Current team archetype, confidence, and recommendations based on delivery metrics and wellbeing data</span></div><div style=\"text-align: right;\"><span style=\"color: #aaa; font-size: 0.85em;\">Data refreshed every 5m from PostgreSQL archetype_history table | <a href=\"https://github.com/paruff/uFawkesDORA/blob/main/compute/archetype_survey.md\" target=\"_blank\" style=\"color: #1f78b4; text-decoration: underline;\">Wellbeing Survey</a></span></div></div>",
+        "mode": "html"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Archetype",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "The team's current archetype based on the latest classification.",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT archetype FROM archetype_history WHERE team_id = '$team' ORDER BY recorded_at DESC LIMIT 1;",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "stringify": true,
+          "textMode": "auto"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "textModeAutoTrim": "false"
+      }
+    },
+    {
+      "id": 3,
+      "title": "Confidence",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Confidence score (0-1) of the archetype classification. Confidence is capped at 0.65 when wellbeing survey data is not available.",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT confidence FROM archetype_history WHERE team_id = '$team' ORDER BY recorded_at DESC LIMIT 1;",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d63902",
+                "value": 0.5
+              },
+              {
+                "color": "#d68b00",
+                "value": 0.75
+              },
+              {
+                "color": "#1b7f3a",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Confidence Limited Notice",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Shows warning when confidence is low due to lack of wellbeing survey data.",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT CASE WHEN confidence < 0.65 THEN 1 ELSE 0 END AS warning_flag FROM archetype_history WHERE team_id = '$team' ORDER BY recorded_at DESC LIMIT 1;",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": ""
+                },
+                "1": {
+                  "text": "\u26a0 Confidence limited \u2014 no wellbeing survey data"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value"
+      }
+    },
+    {
+      "id": 5,
+      "title": "Archetype Radar Chart",
+      "type": "radar",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Radar chart showing the team's normalized metric values (solid line) compared to the archetype centroid (dashed line). Metrics are normalized 0-1 where 1 is best.",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 9
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "WITH latest AS (\n  SELECT\n    archetype,\n    deployment_frequency_norm AS df,\n    lead_time_norm AS lt,\n    fdrt_norm AS f,\n    cfr_norm AS c,\n    rework_rate_norm AS r\n  FROM archetype_history\n  WHERE team_id = '$team'\n  ORDER BY recorded_at DESC\n  LIMIT 1\n),\ncentroids AS (\n  SELECT\n    archetype,\n    CASE archetype\n      WHEN 'Harmonious high-achievers' THEN 0.85\n      WHEN 'Pragmatic performers' THEN 0.75\n      WHEN 'Stable and methodical' THEN 0.65\n      WHEN 'Constrained by process' THEN 0.60\n      WHEN 'Legacy bottleneck' THEN 0.40\n      WHEN 'High impact, low cadence' THEN 0.50\n      ELSE 0.60\n    END AS df_centroid,\n    CASE archetype\n      WHEN 'Harmonious high-achievers' THEN 0.85\n      WHEN 'Pragmatic performers' THEN 0.75\n      WHEN 'Stable and methodical' THEN 0.85\n      WHEN 'Constrained by process' THEN 0.60\n      WHEN 'Legacy bottleneck' THEN 0.40\n      WHEN 'High impact, low cadence' THEN 0.50\n      ELSE 0.60\n    END AS lt_centroid,\n    CASE archetype\n      WHEN 'Harmonious high-achievers' THEN 0.85\n      WHEN 'Pragmatic performers' THEN 0.75\n      WHEN 'Stable and methodical' THEN 0.85\n      WHEN 'Constrained by process' THEN 0.60\n      WHEN 'Legacy bottleneck' THEN 0.40\n      WHEN 'High impact, low cadence' THEN 0.50\n      ELSE 0.60\n    END AS f_centroid,\n    CASE archetype\n      WHEN 'Harmonious high-achievers' THEN 0.75\n      WHEN 'Pragmatic performers' THEN 0.65\n      WHEN 'Stable and methodical' THEN 0.85\n      WHEN 'Constrained by process' THEN 0.60\n      WHEN 'Legacy bottleneck' THEN 0.40\n      WHEN 'High impact, low cadence' THEN 0.50\n      ELSE 0.60\n    END AS r_centroid\n  FROM latest\n)\nSELECT\n  \n  'Deployment Frequency' AS metric,\n  df AS value,\n  df_centroid AS centroid\nFROM latest, centroids\nUNION ALL\nSELECT\n  'Lead Time' AS metric,\n  lt AS value,\n  lt_centroid AS centroid\nFROM latest, centroids\nUNION ALL\nSELECT\n  'FDRT' AS metric,\n  f AS value,\n  f_centroid AS centroid\nFROM latest, centroids\nUNION ALL\nSELECT\n  'Change Failure Rate' AS metric,\n  c AS value,\n  c_centroid AS centroid\nFROM latest, centroids\nUNION ALL\nSELECT\n  'Rework Rate' AS metric,\n  r AS value,\n  r_centroid AS centroid\nFROM latest, centroids\nORDER BY metric;",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0.0
+              },
+              {
+                "color": "red",
+                "value": 1.0
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "centroid"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.dashLength",
+                "value": 5
+              },
+              {
+                "id": "custom.spaceLength",
+                "value": 5
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Recommendation 1",
+      "type": "text",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "transparent": true,
+      "options": {
+        "content": "",
+        "mode": "html"
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "WITH latest AS (\n  SELECT archetype FROM archetype_history WHERE team_id = '$team' ORDER BY recorded_at DESC LIMIT 1\n)\nSELECT\n  CASE archetype\n    WHEN 'Harmonious high-achievers' THEN 'Continue fostering psychological safety and recognition to sustain high performance and wellbeing.'\n    WHEN 'Pragmatic performers' THEN 'Invest in team engagement initiatives to improve wellbeing while maintaining delivery speed.'\n    WHEN 'Stable and methodical' THEN 'Gradually increase deployment frequency through automation and batch size reduction.'\n    WHEN 'Constrained by process' THEN 'Identify and eliminate non-value-adding process steps to free up capacity for innovation.'\n    WHEN 'Legacy bottleneck' THEN 'Prioritize technical debt reduction and system modernization to improve stability and morale.'\n    WHEN 'High impact, low cadence' THEN 'Increase deployment frequency through CI/CD improvements and smaller batch sizes.'\n    ELSE 'Focus on improving both delivery metrics and team wellbeing through targeted interventions.'\n  END AS recommendation\nFROM latest;",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "text"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "title": "Recommendation 2",
+      "type": "text",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 24,
+        "y": 9
+      },
+      "transparent": true,
+      "options": {
+        "content": "",
+        "mode": "html"
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "WITH latest AS (\n  SELECT archetype FROM archetype_history WHERE team_id = '$team' ORDER BY recorded_at DESC LIMIT 1\n)\nSELECT\n  CASE archetype\n    WHEN 'Harmonious high-achievers' THEN 'Regularly review workload distribution to prevent burnout during high-throughput periods.'\n    WHEN 'Pragmatic performers' THEN 'Implement regular retrospectives focused on team happiness and sustainable pace.'\n    WHEN 'Stable and methodical' THEN 'Experiment with feature flags and trunk-based development to enable faster feedback loops.'\n    WHEN 'Constrained by process' THEN 'Adopt value stream mapping to quantify delays and target process improvements.'\n    WHEN 'Legacy bottleneck' THEN 'Establish a dedicated tiger team for critical system modernization efforts.'\n    WHEN 'High impact, low cadence' THEN 'Implement automated testing and deployment pipelines to reduce release friction.'\n    ELSE 'Establish clear OKRs that balance delivery performance with team health metrics.'\n  END AS recommendation\nFROM latest;",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "text"
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "id": null
+}

--- a/dashboards/platform/dora-leading-indicators.json
+++ b/dashboards/platform/dora-leading-indicators.json
@@ -1,0 +1,917 @@
+{
+  "title": "DORA Leading Indicators",
+  "uid": "ufawkesobs-dora-leading-indicators",
+  "version": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "ufawkesobs",
+    "dora",
+    "ufawkes",
+    "leading-indicators",
+    "early-warning"
+  ],
+  "description": "Leading indicators that predict DORA metric degradation before it happens \u2014 PR cycle time, PR size, CI duration, rework rate trend, and branch age. All data sourced from PostgreSQL (raw_events table).",
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "refresh": "5m",
+  "editable": true,
+  "graphTooltip": 0,
+  "templating": {
+    "list": [
+      {
+        "name": "team",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "ufawkesres-postgres"
+        },
+        "query": "SELECT DISTINCT source FROM raw_events ORDER BY source",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": "%",
+        "sort": 1,
+        "label": "Team",
+        "multi": false
+      },
+      {
+        "name": "window",
+        "type": "interval",
+        "query": "7d,30d,90d",
+        "auto": false,
+        "auto_step": 30,
+        "refresh": 1,
+        "label": "Window",
+        "current": {
+          "text": "30d",
+          "value": "30d"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "",
+      "type": "text",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "transparent": true,
+      "options": {
+        "content": "<div style=\"display: flex; justify-content: space-between; align-items: center; padding: 8px 16px;\"><div><h1 style=\"margin: 0;\">DORA Leading Indicators</h1><span style=\"color: #888; font-size: 0.9em;\">Early warning signals that predict DORA metric degradation \u2014 act on these before the lagging metrics move</span></div><div style=\"text-align: right;\"><span style=\"color: #aaa; font-size: 0.85em;\">All data from PostgreSQL (raw_events) \u2014 no Prometheus data for leading indicators</span></div></div>",
+        "mode": "html"
+      }
+    },
+    {
+      "id": 2,
+      "title": "PR Cycle Time P90",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "P90 time from PR opened to PR merged. When PR cycle time exceeds 24 hours, individual PRs are spending too long in review \u2014 this predicts Lead Time increase. Degradation means: engineering hours are being absorbed by review delays rather than flowing into production.",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 0,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT percentile_cont(0.9) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (merged_ts - opened_ts)) / 3600) AS pr_cycle_p90_hours\nFROM (\n  SELECT pr_number,\n    MIN(CASE WHEN metadata->>'status' = 'opened' THEN (metadata->>'occurred_at')::timestamptz END) AS opened_ts,\n    MIN(CASE WHEN metadata->>'status' = 'merged'  THEN (metadata->>'occurred_at')::timestamptz END) AS merged_ts\n  FROM raw_events\n  WHERE event_type = 'pr'\n    AND source ILIKE '$team'\n    AND recorded_at >= NOW() - INTERVAL '1 $window'\n  GROUP BY pr_number\n) pr_cycles\nWHERE opened_ts IS NOT NULL AND merged_ts IS NOT NULL AND merged_ts > opened_ts;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#6cc644",
+                "value": 4
+              },
+              {
+                "color": "orange",
+                "value": 12
+              },
+              {
+                "color": "red",
+                "value": 24
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 3,
+      "title": "PR Size (Lines Added) 14d MA",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "14-day moving average of lines added per merged PR. When this climbs, it signals larger PRs that are harder to review thoroughly \u2014 predicting Rework Rate increase. AI-assisted PRs average 50-150% larger than baseline \u2014 monitor for Rework Rate correlation (DORA 2025).",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 5,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT AVG(lines)::numeric(10,1) AS avg_lines_added_14d\nFROM (\n  SELECT (metadata->>'lines_added')::int AS lines\n  FROM raw_events\n  WHERE event_type = 'pr'\n    AND metadata->>'status' = 'merged'\n    AND source ILIKE '$team'\n    AND (metadata->>'lines_added')::int >= 0\n    AND recorded_at >= NOW() - INTERVAL '14 days'\n) pr_sizes\nWHERE lines IS NOT NULL;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 4,
+      "title": "CI Duration 7d MA",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "7-day moving average of deployment duration in minutes. When CI duration climbs, deployments take longer and teams deploy less often \u2014 predicting Deployment Frequency drop. Degradation means: CI pipeline bottlenecks are reducing throughput capacity.",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 10,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT AVG(duration_seconds / 60.0)::numeric(10,1) AS ci_duration_minutes_7d\nFROM raw_events\nWHERE event_type = 'deployment'\n  AND duration_seconds IS NOT NULL\n  AND duration_seconds > 0\n  AND source ILIKE '$team'\n  AND recorded_at >= NOW() - INTERVAL '7 days';",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 5,
+      "title": "Rework Rate 14d MA",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "14-day moving average of Rework Rate. When rework rate trends up, quality debt is accumulating \u2014 predicting CFR trajectory increase. Degradation means: recent deployments are generating unplanned fix work that will surface as failures.",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 15,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT COALESCE(\n    rework_count::numeric / NULLIF(total_dep_count, 0), 0\n  )::numeric(5,4) AS rework_rate_14d\nFROM (\n  SELECT\n    COUNT(*) FILTER (WHERE event_type = 'rework' AND (metadata->>'user_visible')::boolean = true) AS rework_count,\n    COUNT(*) FILTER (WHERE event_type = 'deployment') AS total_dep_count\n  FROM raw_events\n  WHERE source ILIKE '$team'\n    AND recorded_at >= NOW() - INTERVAL '14 days'\n) counts;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 6,
+      "title": "Branch Age P90",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "P90 time from first commit to PR merge. When branch age exceeds 3 days, feature branches live too long \u2014 predicting Lead Time increase and batch size violation. LIMITATION: True branch age (time from branch creation to merge) requires GitHub API polling. This panel uses PR merge time minus first_commit_at as a proxy from stored PR events. Wire GitHub API branch listing for exact branch age.",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT percentile_cont(0.9) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM ((metadata->>'occurred_at')::timestamptz - (metadata->>'first_commit_at')::timestamptz)) / 3600) AS branch_age_p90_hours\nFROM raw_events\nWHERE event_type = 'pr'\n  AND metadata->>'status' = 'merged'\n  AND source ILIKE '$team'\n  AND metadata ? 'first_commit_at'\n  AND (metadata->>'occurred_at')::timestamptz > (metadata->>'first_commit_at')::timestamptz\n  AND recorded_at >= NOW() - INTERVAL '1 $window';",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 24
+              },
+              {
+                "color": "red",
+                "value": 72
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 7,
+      "title": "PR Cycle Time Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Daily P90 PR cycle time trend. Rising trend predicts Lead Time increase.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT date_trunc('day', merged_ts) AS time,\n  percentile_cont(0.9) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (merged_ts - opened_ts)) / 3600) AS pr_cycle_p90_hours\nFROM (\n  SELECT pr_number,\n    MIN(CASE WHEN metadata->>'status' = 'opened' THEN (metadata->>'occurred_at')::timestamptz END) AS opened_ts,\n    MIN(CASE WHEN metadata->>'status' = 'merged'  THEN (metadata->>'occurred_at')::timestamptz END) AS merged_ts\n  FROM raw_events\n  WHERE event_type = 'pr'\n    AND source ILIKE '$team'\n    AND recorded_at >= NOW() - INTERVAL '1 $window'\n  GROUP BY pr_number\n) pr_cycles\nWHERE opened_ts IS NOT NULL AND merged_ts IS NOT NULL AND merged_ts > opened_ts\nGROUP BY 1 ORDER BY 1;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 12
+              },
+              {
+                "color": "red",
+                "value": 24
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 8,
+      "title": "PR Size Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Daily average lines added per merged PR. Rising trend predicts Rework Rate increase. AI-assisted PRs average 50-150% larger than baseline \u2014 monitor for Rework Rate correlation (DORA 2025).",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT date_trunc('day', recorded_at) AS time,\n  AVG((metadata->>'lines_added')::int)::numeric(10,1) AS avg_lines_added,\n  COUNT(*) FILTER (WHERE (metadata->>'ai_assisted')::boolean = true) AS ai_pr_count,\n  COUNT(*) AS total_pr_count\nFROM raw_events\nWHERE event_type = 'pr'\n  AND metadata->>'status' = 'merged'\n  AND source ILIKE '$team'\n  AND recorded_at >= NOW() - INTERVAL '1 $window'\nGROUP BY 1 ORDER BY 1;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ai_pr_count"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.yAxis",
+                "value": {
+                  "show": true,
+                  "label": "AI PRs"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 9,
+      "title": "CI Duration Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Daily average deployment duration in minutes. Rising trend predicts Deployment Frequency drop.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT date_trunc('day', recorded_at) AS time,\n  AVG(duration_seconds / 60.0)::numeric(10,1) AS avg_ci_minutes\nFROM raw_events\nWHERE event_type = 'deployment'\n  AND duration_seconds IS NOT NULL\n  AND duration_seconds > 0\n  AND source ILIKE '$team'\n  AND recorded_at >= NOW() - INTERVAL '1 $window'\nGROUP BY 1 ORDER BY 1;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 10,
+      "title": "Rework Rate Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Daily rework rate trend. Rising trend predicts CFR trajectory increase.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT day AS time,\n  COALESCE(rework_count::numeric / NULLIF(dep_count, 0), 0)::numeric(5,4) AS rework_rate\nFROM (\n  SELECT date_trunc('day', recorded_at) AS day,\n    COUNT(*) FILTER (WHERE event_type = 'deployment') AS dep_count,\n    COUNT(*) FILTER (WHERE event_type = 'rework' AND (metadata->>'user_visible')::boolean = true) AS rework_count\n  FROM raw_events\n  WHERE source ILIKE '$team'\n    AND recorded_at >= NOW() - INTERVAL '1 $window'\n  GROUP BY 1\n) daily ORDER BY 1;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 11,
+      "title": "Branch Age Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Daily P90 branch age trend. Rising trend predicts Lead Time increase and batch size violation. LIMITATION: Uses PR merge time minus first_commit_at as proxy. True branch age requires GitHub API branch listing.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT date_trunc('day', (metadata->>'occurred_at')::timestamptz) AS time,\n  percentile_cont(0.9) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM ((metadata->>'occurred_at')::timestamptz - (metadata->>'first_commit_at')::timestamptz)) / 3600) AS branch_age_p90_hours\nFROM raw_events\nWHERE event_type = 'pr'\n  AND metadata->>'status' = 'merged'\n  AND source ILIKE '$team'\n  AND metadata ? 'first_commit_at'\n  AND (metadata->>'occurred_at')::timestamptz > (metadata->>'first_commit_at')::timestamptz\n  AND recorded_at >= NOW() - INTERVAL '1 $window'\nGROUP BY 1 ORDER BY 1;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 24
+              },
+              {
+                "color": "red",
+                "value": 72
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 12,
+      "title": "Leading \u2192 Lagging Indicator Map",
+      "type": "text",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "transparent": false,
+      "options": {
+        "content": "<div style=\"padding: 12px;\">\n  <h3 style=\"margin: 0 0 10px 0;\">Leading \u2192 Lagging Indicator Map</h3>\n  <table style=\"width: 100%; border-collapse: collapse; font-size: 0.9em;\">\n    <thead>\n      <tr style=\"border-bottom: 2px solid #555;\">\n        <th style=\"text-align: left; padding: 6px 8px;\">Leading Indicator</th>\n        <th style=\"text-align: left; padding: 6px 8px;\">Predicts</th>\n        <th style=\"text-align: left; padding: 6px 8px;\">DORA Capability</th>\n      </tr>\n    </thead>\n    <tbody>\n      <tr style=\"border-bottom: 1px solid #333;\">\n        <td style=\"padding: 6px 8px;\">PR Cycle Time P90 > 24hrs</td>\n        <td style=\"padding: 6px 8px;\">Lead Time increase</td>\n        <td style=\"padding: 6px 8px;\">Monitoring</td>\n      </tr>\n      <tr style=\"border-bottom: 1px solid #333;\">\n        <td style=\"padding: 6px 8px;\">PR Size (lines added) 14d MA climbing</td>\n        <td style=\"padding: 6px 8px;\">Rework Rate increase</td>\n        <td style=\"padding: 6px 8px;\">AI Capability 5</td>\n      </tr>\n      <tr style=\"border-bottom: 1px solid #333;\">\n        <td style=\"padding: 6px 8px;\">CI Duration 7d MA climbing</td>\n        <td style=\"padding: 6px 8px;\">Deployment Frequency drop</td>\n        <td style=\"padding: 6px 8px;\">Monitoring</td>\n      </tr>\n      <tr style=\"border-bottom: 1px solid #333;\">\n        <td style=\"padding: 6px 8px;\">Rework Rate 14d MA climbing</td>\n        <td style=\"padding: 6px 8px;\">CFR trajectory</td>\n        <td style=\"padding: 6px 8px;\">Monitoring</td>\n      </tr>\n      <tr>\n        <td style=\"padding: 6px 8px;\">Branch Age P90 > 3 days</td>\n        <td style=\"padding: 6px 8px;\">Lead Time increase + batch size violation</td>\n        <td style=\"padding: 6px 8px;\">Monitoring</td>\n      </tr>\n    </tbody>\n  </table>\n  <div style=\"margin-top: 12px; padding: 8px; background: #2a2a2a; border-radius: 4px; font-size: 0.85em;\">\n    <strong>AI Note:</strong> AI-assisted PRs average 50-150% larger than baseline \u2014 monitor PR Size trend for Rework Rate correlation (DORA 2025).\n  </div>\n  <div style=\"margin-top: 8px; padding: 8px; background: #2a2a2a; border-radius: 4px; font-size: 0.85em;\">\n    <strong>Branch Age Note:</strong> True branch age requires GitHub API polling. This dashboard uses <code>pr-event occurred_at (merged) \u2212 first_commit_at</code> as a proxy from stored PR events. Wire GitHub API branch listing for exact branch age.\n  </div>\n</div>",
+        "mode": "html"
+      }
+    }
+  ],
+  "id": null
+}

--- a/dashboards/platform/dora-overview.json
+++ b/dashboards/platform/dora-overview.json
@@ -1,0 +1,1455 @@
+{
+  "title": "DORA Overview",
+  "uid": "ufawkesobs-dora-overview",
+  "version": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "ufawkesobs",
+    "dora",
+    "ufawkes",
+    "delivery-metrics"
+  ],
+  "description": "Five DORA delivery metrics: current values, 30/90-day trends, and tier classifications per the DORA 2025 framework. Reads from Prometheus (time-series) and Postgres (snapshots).",
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "refresh": "5m",
+  "editable": true,
+  "graphTooltip": 0,
+  "templating": {
+    "list": [
+      {
+        "name": "team",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values(dora_deployment_frequency_per_week, team)",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "sort": 1,
+        "label": "Team",
+        "multi": false
+      },
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values(dora_deployment_frequency_per_week{team=~\"$team\"}, service)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "sort": 1,
+        "label": "Service",
+        "multi": true
+      },
+      {
+        "name": "environment",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values(dora_deployment_frequency_per_week{team=~\"$team\", service=~\"$service\"}, environment)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "sort": 1,
+        "label": "Environment",
+        "multi": true
+      },
+      {
+        "name": "window",
+        "type": "interval",
+        "query": "7d,30d,90d",
+        "auto": false,
+        "auto_step": 30,
+        "refresh": 1,
+        "label": "Window",
+        "current": {
+          "text": "30d",
+          "value": "30d"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "",
+      "type": "text",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "transparent": true,
+      "options": {
+        "content": "<div style=\"display: flex; justify-content: space-between; align-items: center; padding: 8px 16px;\">\n  <div>\n    <h1 style=\"margin: 0;\">DORA Overview</h1>\n    <span style=\"color: #888; font-size: 0.9em;\">DORA 2025 framework \u2014 Five delivery metrics</span>\n  </div>\n  <div style=\"text-align: right;\">\n    <span style=\"color: #aaa; font-size: 0.85em;\">Data refreshes every 5m from Prometheus pushgateway + Postgres</span>\n  </div>\n</div>",
+        "mode": "html"
+      }
+    },
+    {
+      "id": 2,
+      "title": "\u26a0 Proxy Metrics Active",
+      "type": "text",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "description": "Banner displayed when proxy_metrics=true \u2014 indicates lead time uses PR merge time as first_commit proxy",
+      "transparent": false,
+      "options": {
+        "content": "<div style=\"background: #ff8c00; color: #fff; padding: 8px 16px; border-radius: 4px; font-weight: bold;\">\n  \u26a0 Proxy metrics active \u2014 wire deployment events with <code>first_commit_at</code> for accurate lead time data. See <a href=\"https://github.com/paruff/uFawkesDORA/blob/main/collectors/README.md\" style=\"color: #fff; text-decoration: underline;\">collectors/README.md</a>.\n</div>",
+        "mode": "html"
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT proxy_metrics FROM dora_snapshots WHERE team_id = '$team' ORDER BY recorded_at DESC LIMIT 1;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "list",
+            "filterable": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "dark-orange",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "value": "false",
+              "text": "",
+              "options": {
+                "false": {
+                  "text": ""
+                }
+              }
+            },
+            {
+              "type": "value",
+              "value": "true",
+              "text": "",
+              "options": {
+                "true": {
+                  "text": ""
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "repeat": null,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 3,
+      "title": "Deployment Frequency",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "How often code is successfully deployed to production. DORA 2025 classifications: Elite = On-demand (multiple/day), High = 1/week\u20131/day, Medium = 1/month\u20131/week, Low = < 1/month",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 0,
+        "y": 5
+      },
+      "targets": [
+        {
+          "expr": "last_over_time(dora_deployment_frequency_per_week{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}[$window])",
+          "legendFormat": "{{team}} - {{service}} - {{environment}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d63902",
+                "value": null
+              },
+              {
+                "color": "#d68b00",
+                "value": 0.25
+              },
+              {
+                "color": "#6cc644",
+                "value": 1
+              },
+              {
+                "color": "#1b7f3a",
+                "value": 7
+              }
+            ]
+          },
+          "mappings": [],
+          "decimals": 1,
+          "displayName": "Deployments / week"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "value": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Deployments / week"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "interval": "$window",
+      "maxDataPoints": 100
+    },
+    {
+      "id": 4,
+      "title": "Lead Time for Changes",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time from first commit to running in production (P50). DORA 2025 classifications: Elite = < 1 hour, High = 1 day\u20131 week, Medium = 1 week\u20131 month, Low = > 1 month",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 5,
+        "y": 5
+      },
+      "targets": [
+        {
+          "expr": "last_over_time(dora_lead_time_p50_hours{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}[$window])",
+          "legendFormat": "{{team}} - {{service}} - {{environment}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#1b7f3a",
+                "value": null
+              },
+              {
+                "color": "#6cc644",
+                "value": 1
+              },
+              {
+                "color": "#d68b00",
+                "value": 24
+              },
+              {
+                "color": "#d63902",
+                "value": 168
+              },
+              {
+                "color": "#b71c1c",
+                "value": 720
+              }
+            ]
+          },
+          "mappings": [],
+          "decimals": 1,
+          "displayName": "Hours (P50)"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "value": "dora_lead_time_p50_hours"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Lead Time P50 (hours)"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "interval": "$window",
+      "maxDataPoints": 100
+    },
+    {
+      "id": 5,
+      "title": "Failed Deployment Recovery Time (FDRT)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time from a failed deployment to the next successful deployment of the same service. DORA 2025 reclassified FDRT from Stability to Throughput. DORA 2025: Elite = < 1 hour, High = < 1 day, Medium = 1 day\u20131 week, Low = > 1 week. This is NOT MTTR \u2014 MTTR measured incident resolution time, FDRT measures deployment recovery.",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 10,
+        "y": 5
+      },
+      "targets": [
+        {
+          "expr": "last_over_time(dora_fdrt_p50_hours{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}[$window])",
+          "legendFormat": "{{team}} - {{service}} - {{environment}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#1b7f3a",
+                "value": null
+              },
+              {
+                "color": "#6cc644",
+                "value": 1
+              },
+              {
+                "color": "#d68b00",
+                "value": 24
+              },
+              {
+                "color": "#d63902",
+                "value": 168
+              }
+            ]
+          },
+          "mappings": [],
+          "decimals": 1,
+          "displayName": "Hours (P50)",
+          "description": "\ud83d\udccc DORA 2025: FDRT is a Throughput metric. Fast recovery enables faster re-deployment."
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "value": "dora_fdrt_p50_hours"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FDRT P50 (hours)"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "interval": "$window",
+      "maxDataPoints": 100
+    },
+    {
+      "id": 6,
+      "title": "Change Failure Rate",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Percentage of deployments causing a production failure requiring remediation. DORA 2025: Elite = 0\u20135%, High = 5\u201310%, Medium = 10\u201315%, Low = > 15%",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 15,
+        "y": 5
+      },
+      "targets": [
+        {
+          "expr": "last_over_time(dora_cfr_pct{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}[$window]) * 100",
+          "legendFormat": "{{team}} - {{service}} - {{environment}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#1b7f3a",
+                "value": null
+              },
+              {
+                "color": "#6cc644",
+                "value": 5
+              },
+              {
+                "color": "#d68b00",
+                "value": 10
+              },
+              {
+                "color": "#d63902",
+                "value": 15
+              }
+            ]
+          },
+          "mappings": [],
+          "decimals": 1,
+          "max": 100,
+          "min": 0,
+          "displayName": "CFR (%)"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "value": "dora_cfr_pct"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CFR (%)"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "interval": "$window",
+      "maxDataPoints": 100
+    },
+    {
+      "id": 7,
+      "title": "Rework Rate",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Percentage of deployments that are unplanned fixes for user-visible issues from a recent deployment. Only counts user-visible unplanned deployments \u2014 internal hotfixes, dependency updates, and config corrections that do not affect users are excluded.",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 5
+      },
+      "targets": [
+        {
+          "expr": "last_over_time(dora_rework_rate_pct{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}[$window])",
+          "legendFormat": "{{team}} - {{service}} - {{environment}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#1b7f3a",
+                "value": null
+              },
+              {
+                "color": "#6cc644",
+                "value": 0.05
+              },
+              {
+                "color": "#d68b00",
+                "value": 0.1
+              },
+              {
+                "color": "#d63902",
+                "value": 0.15
+              }
+            ]
+          },
+          "mappings": [],
+          "decimals": 1,
+          "max": 1,
+          "min": 0,
+          "displayName": "Rework Rate (%)"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "value": "dora_rework_rate_pct"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Rework Rate (%)"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "interval": "$window",
+      "maxDataPoints": 100
+    },
+    {
+      "id": 8,
+      "title": "Deployment Frequency Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "30/90 day trend",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
+      "targets": [
+        {
+          "expr": "dora_deployment_frequency_per_week{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}",
+          "legendFormat": "{{team}} - {{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "dark-green",
+                "value": 7
+              }
+            ]
+          },
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "interval": "$window"
+    },
+    {
+      "id": 9,
+      "title": "Lead Time Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "P50 and P95 lead time trend",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 11
+      },
+      "targets": [
+        {
+          "expr": "dora_lead_time_p50_hours{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}",
+          "legendFormat": "P50 - {{team}} - {{service}}",
+          "refId": "A"
+        },
+        {
+          "expr": "dora_lead_time_p95_hours{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}",
+          "legendFormat": "P95 - {{team}} - {{service}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 24
+              },
+              {
+                "color": "red",
+                "value": 168
+              },
+              {
+                "color": "dark-red",
+                "value": 720
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "interval": "$window"
+    },
+    {
+      "id": 10,
+      "title": "FDRT Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Failed Deployment Recovery Time trend. FDRT is a Throughput metric per DORA 2025 \u2014 fast recovery enables faster re-deployment. This is NOT MTTR.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "targets": [
+        {
+          "expr": "dora_fdrt_p50_hours{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}",
+          "legendFormat": "P50 - {{team}} - {{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 24
+              },
+              {
+                "color": "red",
+                "value": 168
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "interval": "$window"
+    },
+    {
+      "id": 11,
+      "title": "CFR Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Change Failure Rate trend",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "targets": [
+        {
+          "expr": "dora_cfr_pct{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"} * 100",
+          "legendFormat": "{{team}} - {{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 5
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          },
+          "decimals": 1,
+          "max": 100,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "interval": "$window"
+    },
+    {
+      "id": 12,
+      "title": "Rework Rate Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rework Rate trend \u2014 only counts user-visible unplanned deployments. This is the primary signal for AI-assisted development quality: AI-generated code with higher churn pushes Rework Rate up before CFR spikes.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "targets": [
+        {
+          "expr": "dora_rework_rate_pct{team=~\"$team\", service=~\"$service\", environment=~\"$environment\"}",
+          "legendFormat": "{{team}} - {{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 0.05
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.15
+              }
+            ]
+          },
+          "decimals": 2,
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "interval": "$window"
+    },
+    {
+      "id": 13,
+      "title": "FDRT Stage Breakdown",
+      "type": "table",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Recent FDRT snapshots from Postgres \u2014 each row is a computed snapshot showing deployment recovery time per team/service",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    recorded_at,\n    team_id,\n    deployment_frequency AS deploys_per_week,\n    lead_time_hours AS lead_time_h,\n    fdrt_hours AS fdrt_h,\n    change_failure_rate * 100 AS cfr_pct,\n    rework_rate_pct * 100 AS rework_pct,\n    dora_tier,\n    CASE WHEN proxy_metrics THEN '\u26a0 proxy' ELSE '' END AS proxy\nFROM dora_snapshots\nWHERE team_id = '$team'\n  AND recorded_at >= now() - interval '90 days'\nORDER BY recorded_at DESC\nLIMIT 25;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "decimals": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "value": "dora_tier"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background-solid"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#1b7f3a",
+                      "value": null
+                    },
+                    {
+                      "color": "#6cc644",
+                      "value": 1
+                    },
+                    {
+                      "color": "#d68b00",
+                      "value": 2
+                    },
+                    {
+                      "color": "#d63902",
+                      "value": 3
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "value": "elite",
+                    "text": "Elite",
+                    "color": "#1b7f3a"
+                  },
+                  {
+                    "type": "value",
+                    "value": "high",
+                    "text": "High",
+                    "color": "#6cc644"
+                  },
+                  {
+                    "type": "value",
+                    "value": "medium",
+                    "text": "Medium",
+                    "color": "#d68b00"
+                  },
+                  {
+                    "type": "value",
+                    "value": "low",
+                    "text": "Low",
+                    "color": "#d63902"
+                  },
+                  {
+                    "type": "value",
+                    "value": "unknown",
+                    "text": "Unknown",
+                    "color": "#888888"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "recorded_at"
+          }
+        ]
+      },
+      "interval": "$window",
+      "maxDataPoints": 100
+    },
+    {
+      "id": 14,
+      "type": "row",
+      "title": "Tier Legend",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "collapsed": true,
+      "panels": [
+        {
+          "id": 15,
+          "title": "DORA 2025 Tier Thresholds",
+          "type": "table",
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "targets": [
+            {
+              "format": "table",
+              "group": [],
+              "metricColumn": "none",
+              "rawQuery": true,
+              "rawSql": "SELECT 'Deployment Frequency' AS metric, 'On-demand (multiple/day)' AS elite, '1/week \u2013 1/day' AS high, '1/month \u2013 1/week' AS medium, '< 1/month' AS low\nUNION ALL\nSELECT 'Lead Time for Changes', '< 1 hour', '1 day \u2013 1 week', '1 week \u2013 1 month', '> 1 month'\nUNION ALL\nSELECT 'FDRT', '< 1 hour', '< 1 day', '1 day \u2013 1 week', '> 1 week'\nUNION ALL\nSELECT 'Change Failure Rate', '0 \u2013 5%', '5 \u2013 10%', '10 \u2013 15%', '> 15%'\nUNION ALL\nSELECT 'Rework Rate', 'TBD [VERIFY at dora.dev]', 'TBD [VERIFY]', 'TBD [VERIFY]', 'TBD [VERIFY]'",
+              "refId": "A",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "id"
+                    ],
+                    "type": "column"
+                  }
+                ]
+              ],
+              "timeColumn": "recorded_at",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "left",
+                "displayMode": "auto",
+                "filterable": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "show": false,
+              "countRows": false,
+              "fields": ""
+            },
+            "showHeader": true
+          }
+        }
+      ]
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "links": [
+    {
+      "title": "Leading Indicators",
+      "type": "link",
+      "url": "/d/leading-indicators/leading-indicators",
+      "tags": [],
+      "asDropdown": false,
+      "icon": "external link"
+    },
+    {
+      "title": "DORA spec",
+      "type": "link",
+      "targetBlank": true,
+      "url": "https://github.com/paruff/uFawkesDORA/blob/main/docs/spec/specification.md",
+      "tags": [],
+      "asDropdown": false,
+      "icon": "document"
+    }
+  ],
+  "id": null
+}

--- a/dashboards/platform/dora-value-stream.json
+++ b/dashboards/platform/dora-value-stream.json
@@ -1,0 +1,914 @@
+{
+  "title": "Value Stream Indicators",
+  "uid": "ufawkesobs-dora-value-stream",
+  "version": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "ufawkesobs",
+    "dora",
+    "ufawkes",
+    "value-stream",
+    "vsm"
+  ],
+  "description": "Value Stream Indicators (VSM) dashboard showing stage-level lead time breakdown, bottleneck identification, and efficiency trends \u2014 powered by DORA 2025 research on value stream mapping.",
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "refresh": "5m",
+  "editable": true,
+  "graphTooltip": 0,
+  "templating": {
+    "list": [
+      {
+        "name": "team",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "ufawkesres-postgres"
+        },
+        "query": "SELECT DISTINCT source FROM raw_events ORDER BY source",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": "%",
+        "sort": 1,
+        "label": "Repo",
+        "multi": false
+      },
+      {
+        "name": "window",
+        "type": "interval",
+        "query": "7d,30d,90d",
+        "auto": false,
+        "auto_step": 30,
+        "refresh": 1,
+        "label": "Window",
+        "current": {
+          "text": "30d",
+          "value": "30d"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "",
+      "type": "text",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "transparent": true,
+      "options": {
+        "content": "<div style=\"display: flex; justify-content: space-between; align-items: center; padding: 8px 16px;\"><div><h1 style=\"margin: 0;\">Value Stream Indicators</h1><span style=\"color: #888; font-size: 0.9em;\">Stage-level lead time breakdown \u2014 identify constraints and where AI productivity gains are being absorbed</span></div><div style=\"text-align: right;\"><span style=\"color: #aaa; font-size: 0.85em;\">Data from vsi_stage_breakdown (PostgreSQL) \u2014 DORA 2025 VSM model</span></div></div>",
+        "mode": "html"
+      }
+    },
+    {
+      "id": 2,
+      "title": "VSM Efficiency",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "VSM Efficiency = value-add time (coding + deploy) / total lead time \u00d7 100. Higher is better. Low efficiency means work is spending too much time in wait stages (review, queue).",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "WITH stage_totals AS (\n  SELECT\n    s.deployment_id,\n    SUM(s.duration_seconds) FILTER (WHERE s.stage_name IN ('coding', 'deploy')) AS value_add_s,\n    SUM(s.duration_seconds) FILTER (WHERE s.stage_name = 'review') AS wait_s\n  FROM vsi_stage_breakdown s\n  JOIN raw_events r ON r.id = (s.metadata->>'pr_number')::int\n  WHERE s.recorded_at >= NOW() - INTERVAL '1 $window'\n    AND s.duration_seconds > 0\n  GROUP BY s.deployment_id\n)\nSELECT\n  ROUND(\n    SUM(value_add_s) * 100.0 / NULLIF(SUM(value_add_s + wait_s), 0),\n    1\n  ) AS vsm_efficiency_pct\nFROM stage_totals\nWHERE (value_add_s + wait_s) > 0;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 30
+              },
+              {
+                "color": "#6cc644",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 70
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "null": {
+                  "text": "No data"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "hide": false
+    },
+    {
+      "id": 3,
+      "title": "Primary Bottleneck",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "The stage with the highest median duration \u2014 this is your primary constraint. Focus improvement efforts here first.",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "WITH stage_medians AS (\n  SELECT\n    stage_name,\n    percentile_cont(0.50) WITHIN GROUP (ORDER BY duration_seconds) AS p50_s\n  FROM vsi_stage_breakdown s\n  WHERE s.recorded_at >= NOW() - INTERVAL '1 $window'\n    AND s.duration_seconds > 0\n  GROUP BY s.stage_name\n)\nSELECT stage_name AS bottleneck\nFROM stage_medians\nORDER BY p50_s DESC\nLIMIT 1;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "#6cc644",
+                "value": 2
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "null": {
+                  "text": "No data"
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "coding": {
+                  "text": "Coding \u270d\ufe0f",
+                  "color": "orange"
+                },
+                "review": {
+                  "text": "Review \ud83d\udcdd",
+                  "color": "red"
+                },
+                "deploy": {
+                  "text": "Deploy \ud83d\ude80",
+                  "color": "green"
+                },
+                "ci": {
+                  "text": "CI \u2699\ufe0f",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "hide": false
+    },
+    {
+      "id": 4,
+      "title": "Total Journeys",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Number of commit-to-deploy journeys in the current window.",
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT COUNT(DISTINCT deployment_id) AS journey_count\nFROM vsi_stage_breakdown s\nWHERE s.recorded_at >= NOW() - INTERVAL '1 $window';",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "null": {
+                  "text": "No data"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "hide": false
+    },
+    {
+      "id": 5,
+      "title": "Avg Total Lead Time",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Average total lead time (coding + review + deploy) across all journeys.",
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  ROUND(AVG(stage_sum)::numeric, 0) AS avg_total_seconds\nFROM (\n  SELECT\n    deployment_id,\n    SUM(duration_seconds) AS stage_sum\n  FROM vsi_stage_breakdown s\n  WHERE s.recorded_at >= NOW() - INTERVAL '1 $window'\n    AND s.duration_seconds > 0\n  GROUP BY s.deployment_id\n) journey_totals;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 172800
+              },
+              {
+                "color": "red",
+                "value": 604800
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "null": {
+                  "text": "No data"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "hide": false
+    },
+    {
+      "id": 6,
+      "title": "Value-Add vs Wait Time",
+      "type": "stat",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Breakdown of total time into value-add (coding + deploy) and wait (review + queue).",
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 3
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  ROUND(SUM(duration_seconds) FILTER (WHERE stage_name IN ('coding', 'deploy'))::numeric, 0) AS value_add_s,\n  ROUND(SUM(duration_seconds) FILTER (WHERE stage_name = 'review')::numeric, 0) AS wait_s\nFROM vsi_stage_breakdown s\nWHERE s.recorded_at >= NOW() - INTERVAL '1 $window'\n  AND s.duration_seconds > 0;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "null": {
+                  "text": "No data"
+                }
+              }
+            }
+          ],
+          "custom": {
+            "displayMode": "list"
+          },
+          "reduceOptions": {
+            "values": true,
+            "calcs": []
+          }
+        },
+        "overrides": []
+      },
+      "hide": false
+    },
+    {
+      "id": 7,
+      "title": "Stage Duration Waterfall",
+      "type": "bargauge",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Median duration per stage. Red/orange stages are constraints \u2014 the tallest bar is your primary bottleneck.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  s.stage_name,\n  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY s.duration_seconds)::numeric, 0) AS p50_seconds,\n  ROUND(AVG(s.duration_seconds)::numeric, 0) AS avg_seconds,\n  ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY s.duration_seconds)::numeric, 0) AS p95_seconds,\n  COUNT(*)::int AS sample_count\nFROM vsi_stage_breakdown s\nWHERE s.recorded_at >= NOW() - INTERVAL '1 $window'\n  AND s.duration_seconds > 0\nGROUP BY s.stage_name\nORDER BY p50_seconds DESC;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 43200
+              },
+              {
+                "color": "red",
+                "value": 172800
+              }
+            ]
+          },
+          "mappings": [],
+          "min": 0,
+          "custom": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "stage_name"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Stage"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50_seconds"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "P50 Duration (s)"
+              }
+            ]
+          }
+        ]
+      },
+      "hide": false
+    },
+    {
+      "id": 8,
+      "title": "Stage Duration Details",
+      "type": "table",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Detailed stage statistics including sample count, average, P50, and P95 durations.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  s.stage_name AS \"Stage\",\n  COUNT(*)::int AS \"Count\",\n  ROUND(AVG(s.duration_seconds)::numeric, 0) AS \"Avg (s)\",\n  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY s.duration_seconds)::numeric, 0) AS \"P50 (s)\",\n  ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY s.duration_seconds)::numeric, 0) AS \"P95 (s)\",\n  CASE\n    WHEN s.stage_name IN ('coding', 'deploy') THEN 'Value-add'\n    WHEN s.stage_name = 'review' THEN 'Wait'\n    ELSE 'Other'\n  END AS \"Type\"\nFROM vsi_stage_breakdown s\nWHERE s.recorded_at >= NOW() - INTERVAL '1 $window'\n  AND s.duration_seconds > 0\nGROUP BY s.stage_name\nORDER BY s.stage_name;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "custom": {}
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Stage"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Type"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 80
+              }
+            ]
+          }
+        ]
+      },
+      "hide": false
+    },
+    {
+      "id": 9,
+      "title": "VSM Efficiency Trend",
+      "type": "timeseries",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "VSM efficiency trend over time \u2014 upward trend means more time is spent on value-add work vs waiting.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "WITH weekly AS (\n  SELECT\n    date_trunc('week', s.recorded_at) AS week,\n    s.deployment_id,\n    SUM(s.duration_seconds) FILTER (WHERE s.stage_name IN ('coding', 'deploy')) AS value_add_s,\n    SUM(s.duration_seconds) FILTER (WHERE s.stage_name = 'review') AS wait_s\n  FROM vsi_stage_breakdown s\n  WHERE s.recorded_at >= NOW() - INTERVAL '90 days'\n    AND s.duration_seconds > 0\n  GROUP BY date_trunc('week', s.recorded_at), s.deployment_id\n)\nSELECT\n  week AS \"time\",\n  ROUND(\n    SUM(value_add_s) * 100.0 / NULLIF(SUM(value_add_s + wait_s), 0),\n    1\n  ) AS value\nFROM weekly\nWHERE (value_add_s + wait_s) > 0\nGROUP BY week\nORDER BY week;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "lineInterpolation": "smooth",
+            "spanNulls": true,
+            "showPoints": "never",
+            "fillOpacity": 20
+          }
+        },
+        "overrides": []
+      },
+      "hide": false,
+      "maxDataPoints": 100
+    },
+    {
+      "id": 10,
+      "title": "Bottleneck Highlight",
+      "type": "table",
+      "datasource": {
+        "type": "postgres",
+        "uid": "ufawkesres-postgres"
+      },
+      "description": "Journeys where the bottleneck stage is above threshold \u2014 actionable list of deployments to investigate.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "WITH journey_stages AS (\n  SELECT\n    s.deployment_id,\n    s.stage_name,\n    s.duration_seconds,\n    MAX(s.duration_seconds) OVER (PARTITION BY s.deployment_id) AS max_duration\n  FROM vsi_stage_breakdown s\n  WHERE s.recorded_at >= NOW() - INTERVAL '1 $window'\n    AND s.duration_seconds > 0\n)\nSELECT\n  deployment_id AS \"Deployment\",\n  stage_name AS \"Bottleneck Stage\",\n  duration_seconds AS \"Duration (s)\",\n  ROUND(duration_seconds / 3600.0, 1) AS \"Duration (h)\"\nFROM journey_stages\nWHERE duration_seconds = max_duration\nORDER BY duration_seconds DESC\nLIMIT 20;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "recorded_at",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 86400
+              },
+              {
+                "color": "red",
+                "value": 604800
+              }
+            ]
+          },
+          "custom": {}
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Bottleneck Stage"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 2
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "review": {
+                        "color": "red",
+                        "text": "\ud83d\udcdd Review"
+                      },
+                      "coding": {
+                        "color": "orange",
+                        "text": "\u270d\ufe0f Coding"
+                      },
+                      "deploy": {
+                        "color": "green",
+                        "text": "\ud83d\ude80 Deploy"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "hide": false
+    },
+    {
+      "id": 11,
+      "title": "About Value Stream Indicators",
+      "type": "text",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "transparent": true,
+      "options": {
+        "content": "<div style=\"padding: 8px 16px;\">\n<h3>About This Dashboard</h3>\n<p>\nValue Stream Indicators (VSM) break down total lead time into five stages to identify where time is actually spent \u2014 and where AI productivity gains are being absorbed rather than delivered. \nBased on the <strong>2025 DORA research on Value Stream Mapping</strong>, this is the diagnostic layer above the five delivery metrics.\n</p>\n<table style=\"width: 100%; border-collapse: collapse; margin-top: 8px;\">\n<tr style=\"border-bottom: 1px solid #444;\">\n<th style=\"padding: 4px 8px; text-align: left;\">Stage</th>\n<th style=\"padding: 4px 8px; text-align: left;\">Type</th>\n<th style=\"padding: 4px 8px; text-align: left;\">Measurement</th>\n<th style=\"padding: 4px 8px; text-align: left;\">Requires</th>\n</tr>\n<tr style=\"border-bottom: 1px solid #333;\">\n<td style=\"padding: 4px 8px;\">Coding</td>\n<td style=\"padding: 4px 8px;\">Value-add</td>\n<td style=\"padding: 4px 8px;\">pr_opened_at - first_commit_at</td>\n<td style=\"padding: 4px 8px;\">first_commit_at in PR event</td>\n</tr>\n<tr style=\"border-bottom: 1px solid #333;\">\n<td style=\"padding: 4px 8px;\">Review</td>\n<td style=\"padding: 4px 8px;\">Wait</td>\n<td style=\"padding: 4px 8px;\">pr_merged_at - pr_opened_at</td>\n<td style=\"padding: 4px 8px;\">PR events (opened + merged)</td>\n</tr>\n<tr style=\"border-bottom: 1px solid #333;\">\n<td style=\"padding: 4px 8px;\">CI</td>\n<td style=\"padding: 4px 8px;\">Value-add</td>\n<td style=\"padding: 4px 8px;\">ci_completed_at - pr_merged_at</td>\n<td style=\"padding: 4px 8px;\">CI pipeline events (v0.2+)</td>\n</tr>\n<tr style=\"border-bottom: 1px solid #333;\">\n<td style=\"padding: 4px 8px;\">Deploy</td>\n<td style=\"padding: 4px 8px;\">Value-add</td>\n<td style=\"padding: 4px 8px;\">deployed_at - pr_merged_at</td>\n<td style=\"padding: 4px 8px;\">Deployment events</td>\n</tr>\n<tr style=\"border-bottom: 1px solid #333;\">\n<td style=\"padding: 4px 8px;\">Rework</td>\n<td style=\"padding: 4px 8px;\">Wait</td>\n<td style=\"padding: 4px 8px;\">rework_triggered_at - deployed_at</td>\n<td style=\"padding: 4px 8px;\">Rework events (v0.2+)</td>\n</tr>\n</table>\n<p style=\"margin-top: 8px; color: #888; font-size: 0.9em;\">\n<strong>VSM Efficiency</strong> = (coding + CI + deploy) / total lead time \u00d7 100. \nCI stage is null for v0.1 (requires CI event schema). Rework stage is null for v0.1 (requires linked rework events).\n</p>\n</div>",
+        "mode": "html"
+      }
+    }
+  ],
+  "id": null
+}

--- a/tests/unit/test_dora_dashboards.py
+++ b/tests/unit/test_dora_dashboards.py
@@ -1,0 +1,63 @@
+"""
+Unit tests for the 5 DORA dashboards merged from uFawkesDORA (issue #203).
+
+General Grafana conventions (uid prefix, no numeric datasource IDs,
+schemaVersion) are already covered generically for every file under
+dashboards/ by tests/unit/test_grafana_dashboards.py. These tests check
+the DORA-specific expectations: the 5 dashboards exist with the right
+uids, and none of them reference the source repo's placeholder
+"PostgreSQL" datasource uid instead of this repo's "ufawkesres-postgres".
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+DASHBOARDS_DIR = pathlib.Path(__file__).resolve().parents[2] / "dashboards" / "platform"
+
+EXPECTED_DASHBOARDS = {
+    "dora-ai-impact.json": "ufawkesobs-dora-ai-impact",
+    "dora-archetype-profile.json": "ufawkesobs-dora-archetype-profile",
+    "dora-overview.json": "ufawkesobs-dora-overview",
+    "dora-leading-indicators.json": "ufawkesobs-dora-leading-indicators",
+    "dora-value-stream.json": "ufawkesobs-dora-value-stream",
+}
+
+
+class TestDoraDashboardsMerged:
+    @pytest.mark.parametrize(
+        "filename,expected_uid",
+        EXPECTED_DASHBOARDS.items(),
+        ids=list(EXPECTED_DASHBOARDS),
+    )
+    def test_dashboard_exists_with_expected_uid(self, filename, expected_uid):
+        path = DASHBOARDS_DIR / filename
+        assert path.exists(), f"Dashboard not found: {path}"
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data.get("uid") == expected_uid
+
+    @pytest.mark.parametrize(
+        "filename", list(EXPECTED_DASHBOARDS), ids=list(EXPECTED_DASHBOARDS)
+    )
+    def test_dashboard_uses_repo_postgres_datasource(self, filename):
+        """Source dashboards use a placeholder "PostgreSQL" uid — must be
+        rewritten to this repo's "ufawkesres-postgres" datasource uid."""
+        path = DASHBOARDS_DIR / filename
+        raw = path.read_text(encoding="utf-8")
+        assert '"PostgreSQL"' not in raw, (
+            f"{filename} still references the placeholder PostgreSQL "
+            "datasource uid instead of ufawkesres-postgres"
+        )
+
+    @pytest.mark.parametrize(
+        "filename", list(EXPECTED_DASHBOARDS), ids=list(EXPECTED_DASHBOARDS)
+    )
+    def test_dashboard_tagged_ufawkesobs(self, filename):
+        path = DASHBOARDS_DIR / filename
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        assert "ufawkesobs" in data.get("tags", [])


### PR DESCRIPTION
Closes #203.

Merges the 5 Grafana dashboards from uFawkesDORA into `dashboards/platform/`:
`dora-ai-impact.json`, `dora-archetype-profile.json`, `dora-overview.json`,
`dora-leading-indicators.json`, `dora-value-stream.json`.

## AI-Assisted Review Block

**What does this PR do?**
Copies 5 DORA dashboards from uFawkesDORA into this repo's `dashboards/platform/`
directory, rewriting them to match this repo's conventions: uid prefix changed to
`ufawkesobs-dora-*`, `ufawkesobs` tag added, and the source repo's placeholder
`"PostgreSQL"` datasource uid rewritten to `ufawkesres-postgres` (this repo's actual
Postgres datasource, shared with uFawkesRes).

**What could go wrong?**
A dashboard could reference a datasource uid or metric name that doesn't exist in
this stack, causing empty panels at runtime. This PR only validates JSON structure
and uid/tag conventions via automated tests — it does not load the dashboards into
a running Grafana instance to confirm every panel renders.

**What tests cover this change?**
- `tests/unit/test_dora_dashboards.py` (new): confirms all 5 dashboards exist with
  expected uids, none reference the placeholder `"PostgreSQL"` uid, and all carry
  the `ufawkesobs` tag.
- `tests/unit/test_grafana_dashboards.py` (existing, generic): confirms uid prefix,
  no numeric datasource IDs, schemaVersion 39, across all dashboards including these.
- 85 tests passing across both files.

**Architecture check:**
- Layer touched: `dashboards/platform/` only, per §4 of AGENTS.md. No changes to
  `compose.yaml`, Prometheus config, or scripts.
- Cross-plane impact: these dashboards reference the `ufawkesres-postgres`
  datasource uid, consistent with uFawkesRes's shared DORA metric snapshots
  integration described in §10.

**What I was NOT sure about:**
Whether every panel query in these dashboards resolves cleanly against this stack's
actual Prometheus/Postgres data — that requires loading them into a running Grafana
instance, which is out of scope for this PR (JSON/convention validation only).