### PR TITLE
docs(dora): merge uFawkesDORA spec/design/decisions/discovery (#207)

### DIFF
--- a/docs/dora/decisions/003-pipeline-trigger-map.md
+++ b/docs/dora/decisions/003-pipeline-trigger-map.md
@@ -1,0 +1,183 @@
+# Decision 003 — Pipeline Trigger Map (current state)
+
+**Date:** 2026-06-25
+**Context:** Ground-truth audit of all 18 workflow files in `.github/workflows/`. Establishes which files trigger on which events, how jobs depend on each other, and where overlaps exist — before any restructuring begins.
+
+---
+
+## 1. Trigger Map
+
+| # | File | Trigger Events | Jobs Defined | Calls / U uses |
+| --- | ------ | --------------- | -------------- | ---------------- |
+| 1 | `pipeline.yml` | `pull_request [main]`, `push [main]`, `workflow_dispatch` | `pre-commit`, `post-commit`, `pre-deployment`, `deploy`, `post-deployment`, `pipeline-complete` | → `pre-commit.yml`, `post-commit.yml`, `pre-deployment.yml`, `deploy.yml`, `post-deployment.yml` |
+| 2 | `ci.yml` | `pull_request [main]`, `push [main]`, `workflow_dispatch` | `validate` (pre-commit hooks only) | — (inline only) |
+| 3 | `compute-metrics.yml` | `schedule (0 6 \* \* \*)`, `workflow_dispatch` | `compute-metrics` | — (inline only) |
+| 4 | `pre-commit.yml` | `workflow_call`, `workflow_dispatch` | `preflight`, `docs-lint`, `lint`, `unit-tests`, `security`, `pre-commit-summary` | → `reusable-preflight.yml`, `docs-lint.yml`, `reusable-lint.yml`, `reusable-security-scanning.yml` |
+| 5 | `post-commit.yml` | `workflow_call`, `workflow_dispatch` | `build-validate`, `post-commit-summary` | → `reusable-build.yml` |
+| 6 | `pre-deployment.yml` | `workflow_call`, `workflow_dispatch` | `full-tests`, `security`, `dependency-review`, `pre-deployment-summary` | → `ci-tests.yml`, `reusable-security-scanning.yml`, `reusable-dependency-review.yml` |
+| 7 | `deploy.yml` | `workflow_call` | `deploy` (inline) | — (inline steps) |
+| 8 | `post-deployment.yml` | `workflow_call` | `health-check`, `smoke-tests`, `prometheus-verify`, `dora-metric`, `post-deployment-summary` | — (inline steps) |
+| 9 | `reusable-preflight.yml` | `workflow_call` | `preflight` (inline) | — (inline steps) |
+| 10 | `reusable-lint.yml` | `workflow_call` | `detect-changes`, `python-lint`, `shell-lint`, `yaml-lint`, `typescript-lint`, `go-lint`, `lint-summary` | — (inline steps) |
+| 11 | `reusable-build.yml` | `workflow_call` | `build-validate` (inline) | — (inline steps) |
+| 12 | `reusable-security-scanning.yml` | `workflow_call` | `security-scan` (inline) | — (inline steps) |
+| 13 | `reusable-dependency-review.yml` | `workflow_call` | `dependency-review` (inline) | — (inline steps) |
+| 14 | `reusable-tests.yml` | `workflow_call` | `unit-tests`, `compose-smoke`, `integration-tests`, `golden-path`, `test-summary` | — (inline steps) |
+| 15 | `reusable-deploy.yml` | `workflow_call` | `deploy` (inline) | — (inline steps, NOT currently called by any orchestrator) |
+| 16 | `reusable-post-deploy.yml` | `workflow_call` | `post-deploy-verify` (inline) | — (inline steps, NOT currently called by any orchestrator) |
+| 17 | `ci-tests.yml` | `workflow_call` | `unit-tests`, `integration-tests`, `smoke-tests`, `e2e-tests`, `test-summary` | — (inline steps) |
+| 18 | `docs-lint.yml` | `workflow_call` | `required-files`, `markdown-lint`, `link-check` | — (inline steps) |
+
+---
+
+## 2. Job Dependency Graph
+
+### Orchestrator (pipeline.yml)
+
+```
+pipeline.yml (PR/push/workflow_dispatch)
+│
+├── pre-commit.yml  ─── parallel ─── preflight, docs-lint, lint, unit-tests, security
+│                                      │
+│                                      └── pre-commit-summary (needs: all above)
+│
+├── post-commit.yml ─── sequential ─── build-validate → post-commit-summary
+│
+├── pre-deployment.yml ─── parallel ─── full-tests, security, dependency-review
+│                                         │
+│                                         └── pre-deployment-summary (needs: all above)
+│
+├── deploy.yml ─── sequential (only if workflow_dispatch + inputs.run-deploy)
+│   └── deploy (inline steps)
+│
+├── post-deployment.yml ─── needs: [deploy] (only if deploy ran)
+│   │
+│   ├── health-check (standalone)
+│   ├── smoke-tests (needs: health-check)
+│   ├── prometheus-verify (standalone)
+│   └── dora-metric (standalone)
+│       │
+│       └── post-deployment-summary (needs: all above)
+│
+└── pipeline-complete (needs: all 5 phases)
+```
+
+### ci-tests.yml (called by pre-deployment.yml)
+
+```
+ci-tests.yml
+│
+├── unit-tests (if inputs.run-unit)
+├── integration-tests
+├── smoke-tests (needs: integration-tests)
+├── e2e-tests (needs: smoke-tests)
+│
+└── test-summary (needs: all above)
+```
+
+### reusable-lint.yml (called by pre-commit.yml)
+
+```
+detect-changes
+│
+├── python-lint (needs: detect-changes, conditional on python detected)
+├── shell-lint (needs: detect-changes, conditional on shell detected)
+├── yaml-lint (needs: detect-changes, conditional on yaml detected)
+├── typescript-lint (needs: detect-changes, conditional on ts detected)
+├── go-lint (needs: detect-changes, conditional on go detected)
+│
+└── lint-summary (needs: detect-changes + all lint jobs)
+```
+
+### reusable-tests.yml (NOT currently called by any orchestrator)
+
+```
+unit-tests, compose-smoke (parallel)
+│
+├── integration-tests (needs: compose-smoke)
+├── golden-path (needs: compose-smoke)
+│
+└── test-summary (needs: all above)
+```
+
+---
+
+## 3. Call Chain Summary
+
+```
+pipeline.yml
+  ├── pre-commit.yml
+  │     ├── reusable-preflight.yml
+  │     ├── docs-lint.yml
+  │     ├── reusable-lint.yml
+  │     │     └── (detect-changes → per-language lint jobs → lint-summary)
+  │     ├── inline unit tests
+  │     └── reusable-security-scanning.yml (scan-type: secrets)
+  │
+  ├── post-commit.yml
+  │     └── reusable-build.yml
+  │
+  ├── pre-deployment.yml
+  │     ├── ci-tests.yml (unit → integration → smoke → E2E)
+  │     ├── reusable-security-scanning.yml (scan-type: all)
+  │     └── reusable-dependency-review.yml
+  │
+  ├── deploy.yml (gated: workflow_dispatch + run-deploy)
+  │
+  └── post-deployment.yml (gated: deploy success)
+```
+
+---
+
+## 4. Overlap & Anomaly Flags
+
+### 🔴 Overlapping Trigger: `ci.yml` runs alongside `pipeline.yml`
+
+Both `ci.yml` and `pipeline.yml` trigger on `pull_request [main]` and `push [main]`. They run in parallel, duplicating pre-commit hook execution. `ci.yml` is a legacy remnant that was never removed when `pipeline.yml` was created.
+
+**Recommendation:** Remove `ci.yml` — its single job (`pre-commit run --all-files`) is already performed by `reusable-preflight.yml` within `pre-commit.yml` (Phase 1).
+
+### 🟡 Phase workflows with dual triggers
+
+`pre-commit.yml`, `post-commit.yml`, and `pre-deployment.yml` each have both `workflow_call` and `workflow_dispatch`. The `workflow_dispatch` allows standalone execution for debugging but is not wired into any automatic trigger — they can only be triggered manually or via `pipeline.yml`.
+
+### 🟡 Orphaned reusable workflows
+
+`reusable-deploy.yml` and `reusable-post-deploy.yml` exist but are **not currently called by any orchestrator**. `deploy.yml` and `post-deployment.yml` implement similar logic inline. These duplicate workflows represent technical debt.
+
+**Recommendation:** Either consolidate into the inline versions or switch `pipeline.yml` to call the reusable versions.
+
+### 🟡 Orphaned reusable-tests.yml
+
+`reusable-tests.yml` exists but is **not currently called by any orchestrator**. The test pipeline uses `ci-tests.yml` instead (wired into `pre-deployment.yml`). `reusable-tests.yml` uses a different test structure (compose-smoke + golden-path) vs `ci-tests.yml` (integration → smoke → E2E).
+
+**Recommendation:** Either consolidate the two test approaches or remove the unused workflow.
+
+### 🟢 `compute-metrics.yml` is standalone
+
+This is a scheduled cron job for DORA metric computation. It has no overlap with other workflows and operates independently.
+
+---
+
+## 5. Which file is the primary PR gate?
+
+**`pipeline.yml`** — It orchestrates the full 5-phase lifecycle. Phases 1-3 (pre-commit, post-commit, pre-deployment) run on every PR and push to main and must pass before a PR is mergeable. Phases 4-5 (deploy, post-deployment) only run on manual `workflow_dispatch` with `inputs.run-deploy: true`.
+
+## 6. Which file deploys?
+
+**`deploy.yml`** — Called by `pipeline.yml` Phase 4, gated behind `workflow_dispatch + inputs.run-deploy`. Handles GitOps CD promotion: updates image tags in kustomization manifests, commits, pushes, waits for reconciliation, and supports rollback.
+
+A secondary deploy workflow exists (`reusable-deploy.yml`) but is not currently wired into any orchestrator.
+
+---
+
+## Appendix: Quick Reference
+
+```
+Trigger types:          push [main], pull_request [main], workflow_dispatch, schedule, workflow_call
+Standalone triggers:    pipeline.yml, ci.yml, compute-metrics.yml
+workflow_call only:     15 files (all reusable* and phase workflows)
+workflow_dispatch also: pipeline.yml, ci.yml, pre-commit.yml, post-commit.yml, pre-deployment.yml, compute-metrics.yml
+Schedule only:          compute-metrics.yml
+Solely workflow_call:   12 files (all reusable, deploy, post-deployment, ci-tests, docs-lint)
+```

--- a/docs/dora/decisions/004-hook-versions.md
+++ b/docs/dora/decisions/004-hook-versions.md
@@ -1,0 +1,10 @@
+# Decision 004 — Pre-commit Hook Versions Updated
+
+| Hook | Old Version | New Version | Date |
+| ------ | ------------ | ------------ | ------ |
+| pre-commit-hooks | v4.5.0 | v6.0.0 | 2026-06-25 |
+| ruff-pre-commit | v0.4.0 | v0.15.19 | 2026-06-25 |
+| yamllint | v1.33.0 | v1.38.0 | 2026-06-25 |
+| markdownlint-cli | v0.38.0 | v0.49.0 | 2026-06-25 |
+| gitleaks | v8.18.1 | v8.30.0 | 2026-06-25 |
+| detect-secrets | v1.4.0 | v1.5.0 | 2026-06-25 |

--- a/docs/dora/design/design.md
+++ b/docs/dora/design/design.md
@@ -1,0 +1,347 @@
+# Design: uFawkesDORA Two-Plane Architecture
+
+## 1. Architectural Philosophy: The Two-Plane Model
+
+To satisfy the requirement that uFawkesDORA supports reliable, long-term storage of DORA event data while allowing the compute layer to be freely redeployed, the design follows a strict two-plane separation:
+
+1. **The Compute Plane (Stateless)**:
+   - Freely redeployable components: ingestion API, event processor, metric compute jobs
+   - No persistent state storage - all state lives in the resource plane
+   - Designed for horizontal scaling and frequent updates
+
+2. **The Resource Plane (Stateful)**:
+   - Persistent data storage: PostgreSQL with TimescaleDB extension
+   - Contains all historical event data, computed metrics, and metadata
+   - Independent lifecycle - survives compute plane redeployments
+   - Shared with other uFawkes* services (uFawkesObs, Infisical, DefectDojo) via database-per-service pattern
+
+This separation ensures that historical DORA data is preserved even when the compute layer is updated or recreated.
+
+## 2. System Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  EVENT SOURCES                                                              │
+│                                                                             │
+│  GitHub ────────────────────────────(HTTP POST, canonical schema)───────┐  │
+│  Woodpecker CI ──────────────────(HTTP POST, canonical schema)──────────┤  │
+│  Portainer webhooks ─(HTTP POST, canonical schema)──────────────────────┤  │
+│  Incident webhook ───(HTTP POST, canonical schema)──────────────────────┘  │
+│  (Grafana OnCall / PagerDuty / manual curl)                               │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  uFawkesDORA COMPUTE PLANE  (stateless — freely redeployable)              │
+│                                                                             │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │  Event Queue  (Postgres table, SKIP LOCKED pattern)                  │  │
+│  │  Absorbs events during ingestion engine restarts. No event loss.     │  │
+│  └────────────────────────────┬─────────────────────────────────────────┘  │
+│                               │                                             │
+│  ┌────────────────────────────▼─────────────────────────────────────────┐  │
+│  │  Ingestion API  (FastAPI, stateless)                                 │  │
+│  │  - Validates canonical event schema                                  │  │
+│  │  - Enqueues to Event Queue                                           │  │
+│  │  - Returns 422 with detail on schema violation                       │  │
+│  └────────────────────────────┬─────────────────────────────────────────┘  │
+│                               │                                             │
+│  ┌────────────────────────────▼─────────────────────────────────────────┐  │
+│  │  Event Processor  (background worker, stateless)                     │  │
+│  │  - Dequeues from Event Queue                                         │  │
+│  │  - Writes raw events → Resource Plane PostgreSQL (raw_events table)  │  │
+│  │  - Pushes OTel counters → uFawkesObs OTel Collector                 │  │
+│  │  - Writes structured logs → uFawkesObs Loki                         │  │
+│  └────────────────────────────┬─────────────────────────────────────────┘  │
+│                               │                                             │
+│  ┌────────────────────────────▼─────────────────────────────────────────┐  │
+│  │  Metric Compute Job  (cron, stateless)                               │  │
+│  │  - Reads raw events from PostgreSQL                                  │  │
+│  │  - Computes all 5 DORA metrics + Rework Rate + VSM indicators        │  │
+│  │  - Writes derived metrics → PostgreSQL (dora_snapshots table)        │  │
+│  │  - Pushes metrics → uFawkesObs Prometheus via pushgateway            │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+                  │                              │
+                  │ (SQL queries,               │ (PromQL, Loki queries)
+                  │  long-retention data)        │
+                  ▼                              ▼
+┌────────────────────────────┐    ┌─────────────────────────────────────────┐
+│  RESOURCE PLANE            │    │  uFawkesObs                             │
+│                            │    │                                         │
+│  PostgreSQL 16 +           │    │  Prometheus ← OTel Collector            │
+│  TimescaleDB extension     │    │  (derived metrics, time-series,         │
+│                            │    │   alerting rules, Grafana source)       │
+│  Schemas:                  │    │                                         │
+│  - dora_metrics (events,   │    │  Loki                                   │
+│    snapshots, archetypes,  │    │  (raw event logs, debug, audit trail)   │
+│    wellbeing surveys)      │    │                                         │
+│  - infisical                │    │  Grafana                                │
+│  - defectdojo               │    │  (reads BOTH Prometheus AND Postgres    │
+│                            │    │   via Postgres datasource plugin)       │
+│  Network: fawkes-resource- │    │                                         │
+│  net (isolated)            │    │  Alertmanager                           │
+│                            │    │  (routes notifications OUT — Slack,     │
+│                            │    │   email, PagerDuty — never feeds IN)    │
+└────────────────────────────┘    └─────────────────────────────────────────┘
+                  ▲                              ▲
+                  └──────────────┬───────────────┘
+                                 │
+                     ┌───────────▼──────────────┐
+                     │  uFawkesObs Grafana       │
+                     │  (single rendering point  │
+                     │  for all DORA dashboards) │
+                     │                           │
+                     │  DORA Overview            │
+                     │  Leading Indicators       │
+                     │  AI Impact                │
+                     │  Archetype Profile        │
+                     │  Value Stream             │
+                     └───────────────────────────┘
+                                 │
+                     ┌───────────▼──────────────┐
+                     │  DELIVERY BEYOND          │
+                     │  DASHBOARDS               │
+                     │                           │
+                     │  Alertmanager → Slack     │
+                     │  Weekly digest → Markdown │
+                     │  PR annotations           │
+                     └───────────────────────────┘
+```
+
+## 3. Detailed Component Design
+
+### 3.1 Ingestion API (stateless)
+
+- **Technology**: FastAPI
+- **Endpoint**: `POST /event` for receiving canonical events
+- **Responsibilities**:
+  - Validate incoming events against JSON schemas
+  - Enqueue valid events to PostgreSQL `event_queue` table using SKIP LOCKED pattern
+  - Return appropriate HTTP status codes (201 for success, 422 for validation errors)
+  - Health check endpoint (`GET /health`) reporting queue depth
+- **Stateless**: No local storage; all state managed via resource plane PostgreSQL
+
+### 3.2 Event Processor (stateless background worker)
+
+- **Technology**: Python worker with asyncpg
+- **Responsibilities**:
+  - Dequeue events from `event_queue` using `SELECT FOR UPDATE SKIP LOCKED`
+  - Persist events to `raw_events` table in PostgreSQL
+  - Emit OpenTelemetry counters to uFawkesObs OTel Collector
+  - Forward structured logs to uFawkesObs Loki
+  - Handle retry logic (max 3 attempts before marking as failed)
+- **Event Loss Prevention**: SKIP LOCKED pattern ensures no events lost during redeployments
+
+### 3.3 Metric Compute Job (cron-based, stateless)
+
+- **Technology**: Python script executed via cron (GitHub Actions scheduled workflow)
+- **Responsibilities**:
+  - Compute all five DORA metrics from `raw_events` using TimescaleDB SQL functions
+  - Calculate Rework Rate and Value Stream Indicators
+  - Write results to `dora_snapshots` table
+  - Push metrics to uFawkesObs Prometheus pushgateway for alerting and Grafana visualization
+  - Set `proxy_metrics` flag when fallback data sources are used
+- **Key Computations**:
+  - Deployment Frequency: Count of successful deployments per week
+  - Lead Time: `deployed_at - first_commit_at` (falls back to PR open time if needed)
+  - FDRT: Time between failed deployment and next successful deployment of same service (NOT incident resolution time)
+  - Change Failure Rate: Percentage of deployments with status 'failed' or 'rollback'
+  - Rework Rate: Percentage of deployments with associated user-visible rework events
+
+### 3.4 Resource Plane (Stateful Storage)
+
+- **Technology**: PostgreSQL 16 with TimescaleDB extension
+- **Databases**:
+  - `dora_metrics`: Contains all uFawkesDORA data
+  - `infisical`: For secret management (shared service)
+  - `defectdojo`: For security tracking (shared service)
+- **Key Tables**:
+  - `event_queue`: SKIP LOCKED queue for zero event loss
+  - `raw_events`: Immutable event store (converted to hypertable)
+  - `dora_snapshots`: Computed metrics (converted to hypertable)
+  - `archetype_history`: Team classifications over time
+  - `wellbeing_surveys`: Quarterly survey responses
+  - `vsi_stage_breakdown`: Value stream stage timing data
+- **Access Pattern**:
+  - Compute plane reads/writes via SQL
+  - Grafana reads via PostgreSQL datasource plugin (for snapshots, archetypes, etc.)
+  - Prometheus scrapes metrics pushed by compute job (for time-series dashboards/alerts)
+
+### 3.5 Communication Patterns
+
+- **Event Ingestion**: HTTP POST to `/event` (JSON payload)
+- **Internal Communication**: Database tables (event queue → raw events → snapshots)
+- **Telemetry Output**:
+  - OpenTelemetry counters → uFawkesObs OTel Collector → Tempo/Prometheus
+  - Structured logs → uFawkesObs Loki
+  - Prometheus metrics → uFawkesObs Prometheus (via pushgateway)
+- **Alerting**: Prometheus Alertmanager → Notification channels (Slack, email, etc.) - **OUTBOUND ONLY**
+- **Dashboard Data**:
+  - Time-series panels: Prometheus (metrics pushed by compute job)
+  - Current value/table panels: PostgreSQL (via Grafana datasource plugin)
+
+## 4. Key Design Decisions
+
+### Decision 1: PostgreSQL with TimescaleDB as Primary Store
+
+- **Why**: Raw events require relational joins (rework→deployment via deployment_sha, PR→deployment via commit_sha) that Prometheus cannot express
+- **TimescaleDB Benefits**:
+  - Automatic partitioning via hypertables for time-series data
+  - SQL-native time_bucket() and percentile_agg() functions for efficient aggregations
+  - Full SQL expressiveness for complex queries and joins
+- **Trade-off**: Slightly more complex operational model vs pure Prometheus, but necessary for correctness
+
+### Decision 2: SKIP LOCKED Event Queue for Zero Event Loss
+
+- **Why**: Stateless compute nodes lose events during redeployments without buffering
+- **Implementation**:
+  - `event_queue` table with status column (pending/processing/done/failed)
+  - Workers claim work with `SELECT FOR UPDATE SKIP LOCKED LIMIT 1`
+  - No external queueing infrastructure needed (uses existing PostgreSQL)
+- **Throughput**: ~500 events/second - sufficient for platform scale (<100 deploys/day across all services)
+
+### Decision 3: Strict Separation of Concerns in Alerting
+
+- **Why**: Alertmanager is a notification router that must never feed data back into the system
+- **Implementation**:
+  - Incident events come from incident management sources (Grafana OnCall, PagerDuty, manual curl)
+  - Alertmanager only sends notifications OUT to Slack, email, PagerDuty, etc.
+  - No paths exist from Alertmanager back to the ingestion API
+- **Benefit**: Prevents feedback loops and maintains clear data flow boundaries
+
+### Decision 4: Multi-Database PostgreSQL via Init Scripts
+
+- **Why**: `POSTGRES_MULTIPLE_DATABASES` is not a standard Postgres environment variable
+- **Implementation**:
+  - Init script in `/docker-entrypoint-initdb.d/` creates additional databases
+  - Uses least-privilege roles per service with minimum necessary permissions
+  - Idempotent design safe for re-runs
+- **Benefit**: Proper isolation between services while sharing the same PostgreSQL instance
+
+## 5. Data Flow Examples
+
+### 5.1 Normal Deployment Event Flow
+
+1. GitHub Action → POST `/event` {event_type: "deployment", status: "success"}
+2. Ingestion API validates schema, enqueues to `event_queue`
+3. Event Processor dequeues, writes to `raw_events`, pushes OTel counter, pushes Loki log
+4. Metric Compute Job (cron) reads from `raw_events`, computes metrics
+5. Writes to `dora_snapshots`, pushes Prometheus metrics to uFawkesObs pushgateway
+6. Grafana displays:
+   - Time-series panels: Prometheus (from pushgateway)
+   - Current value panels: PostgreSQL (dora_snapshots table)
+   - Tables: PostgreSQL (via datasource plugin)
+
+### 5.2 Incident Event Flow (for FDRT Calculation)
+
+1. PagerDuty/webhook → POST `/event` {event_type: "incident", status: "opened"}
+2. Same ingestion/processing pipeline as above
+3. Later: GitHub Action → POST `/event` {event_type: "deployment", status: "success"}
+4. Metric Compute Job calculates FDRT as: `next_successful_deploy_time - failed_deploy_time`
+   - **NOT** incident resolution time (that would be old MTTR definition)
+   - This is the 2025 DORA reclassification: FDRT is a Throughput metric
+5. Result stored in `dora_snapshots.fdrt_p50_hours`
+
+### 5.3 Rework Event Flow (for Rework Rate Calculation)
+
+1. Monitoring system/webhook → POST `/event` {event_type: "rework", user_visible: true}
+2. Same ingestion/processing pipeline
+3. Metric Compute Job calculates:
+   `rework_rate = COUNT(rework WHERE user_visible=true) / COUNT(deployment WHERE status='success') * 100`
+4. Result stored in `dora_snapshots.rework_rate_pct`
+
+## 6. Security and Compliance Considerations
+
+### 6.1 Data Protection
+
+- All event data stored in PostgreSQL with standard database security
+- Wellbeing survey data access restricted to `dora_app` role only
+- No individual response data exposed in Grafana or dashboards
+- Database credentials managed via Infisical (separate service in resource plane)
+
+### 6.2 Network Security
+
+- Compute plane and resource plane communicate over isolated Docker network (`fawkes-resource-net`)
+- No direct external access to resource plane databases
+- Ingestion API is the only externally exposed component (HTTPS terminated at ingress)
+
+### 6.3 Audit and Traceability
+
+- All events immutable once written to `raw_events` (append-only design)
+- Complete lineage from event source to computed metric
+- Structured logging to Loki enables forensic analysis
+- OTel traces show end-to-end processing latency
+
+## 7. Scalability and Performance Considerations
+
+### 7.1 Horizontal Scaling
+
+- Ingestion API: stateless, can run multiple instances behind load balancer
+- Event Processor: multiple instances safe due to SKIP LOCKED queue locking
+- Metric Compute Job: singleton by design (cron job), but could be sharded by repo
+- Resource Plane: PostgreSQL vertical scaling (read replicas for heavy dashboard usage)
+
+### 7.2 Performance Optimizations
+
+- TimescaleDB hypertables automatically partition time-series data
+- Indexes on `repo` and `occurred_at` for efficient tenant-scoped queries
+- Materialized views could be added for expensive aggregations (future work)
+- Connection pooling via `asyncpg` in all Python components
+
+### 7.3 Resource Requirements
+
+- Compute Plane: Minimal CPU/memory (mostly I/O wait on database/network)
+- Resource Plane: Scales with event storage requirements (approx 1KB per event, 100 bytes per snapshot)
+- For 1000 events/day: ~365MB/year raw events, negligible snapshot storage
+- Wellbeing surveys: minimal storage (quarterly surveys, <1KB each)
+
+## 8. Extensibility Points
+
+### 8.1 Adding New Metric Types
+
+- Extend `compute/metrics.py` with new SQL queries
+- Add columns to `dora_snapshots` table
+- Update Grafana dashboards with new panels
+- Add Prometheus pushgateway metrics
+
+### 8.2 New Event Sources
+
+- Implement new collector (GitHub Action, webhook snippet, etc.)
+- Validate against existing schemas in `events/` directory
+- No changes needed to core ingestion or processing pipelines
+
+### 8.3 New Dashboard Types
+
+- Create new Grafana JSON in `dashboards/` directory
+- Use existing datasources (Prometheus for time-series, Postgres for current values)
+- Add to provisioning in uFawkesObs
+
+### 8.4 Additional Notification Channels
+
+- Extend `notifications/` directory with new delivery mechanisms
+- Update Alertmanager routing or create new workflows
+- Maintain separation between alerting (OUTBOUND only) and data flow
+
+## 9. Relationship to Other uFawkes* Services
+
+### 9.1 uFawkesObs (Observability Platform)
+
+- Provides: Prometheus, Loki, Tempo, OTel Collector, Grafana
+- Receives from uFawkesDORA: OTel counters, Loki logs, Prometheus metrics
+- Provides to uFawkesDORA: Queryable metrics/logs for debugging and alerting
+- Shared resource plane: PostgreSQL databases (different schemas/databases)
+
+### 9.2 Infisical (Secret Management)
+
+- Provides: Dynamic secrets, certificate management, encryption as a service
+- Used by: All services for credential rotation and secure secret distribution
+- Integrated via: Standard API calls from application code
+
+### 9.3 DefectDojo (Security Program Management)
+
+- Provides: Vulnerability management, compliance tracking, security testing
+- Receives from uFawkesDORA: Security event data (if implemented)
+- Shared resource plane: PostgreSQL database (separate schema)
+
+This two-plane architecture provides a solid foundation for a reliable, scalable DORA metrics system that preserves data integrity while allowing rapid innovation in the compute layer.

--- a/docs/dora/discovery/discovery-brief.md
+++ b/docs/dora/discovery/discovery-brief.md
@@ -1,0 +1,59 @@
+---
+date: 2026-06-23
+persona: platform-engineer
+jtbd: "When I configure the uFawkesDORA pipeline, I want to implement a comprehensive 5-stage GitOps-aligned engineering lifecycle (Pre-Commit, Post-Commit, Pre-Deploy, Deploy, Post-Deploy) in this repo, so I can guarantee high-quality releases, zero regressions, and complete confidence with robust automated gates before any code hits production."
+riskiest_assumption: "We assume that running full local docker-compose stacks (including TimescaleDB, the FastAPI ingestion engine, worker threads, and Playwright browsers) inside standard GitHub Actions runners is resource-performant, does not hit rate/resource limits, and can run deterministically without flake."
+acceptance_criterion: "Given a PR is opened in the uFawkesDORA repo, when the CI Pipeline runs, then all 5 stages (Pre-Commit, Post-Commit, Pre-Deployment Validation, Deployment, Post-Deployment Verification) execute successfully, producing test, security, and quality gate reports, and gating the PR until all stages pass."
+dora_ai_capability: "Cap7: Quality internal platforms"
+dora_core_capability: "Continuous Integration & Deployment Automation"
+metric: "change_failure_rate_pct"
+measurement_source: "uFawkesDORA computed metrics"
+baseline: "1.2% (2026-06-01)"
+prior_art: "uFawkesPipe defines lightweight CI/CD with Woodpecker + Portainer. Existing reusable workflows in this repo define basic lint/security/test stages, but lack full 5-stage alignment with smoke/integration/E2E test stacks."
+status: ready-for-spec
+---
+
+# Discovery Brief: 5-Stage GitOps-Aligned Engineering Lifecycle Pipeline
+
+## Job to Be Done
+
+"When I configure the uFawkesDORA pipeline, I want to implement a comprehensive 5-stage GitOps-aligned engineering lifecycle (Pre-Commit, Post-Commit, Pre-Deploy, Deploy, Post-Deploy) in this repo, so I can guarantee high-quality releases, zero regressions, and complete confidence with robust automated gates before any code hits production."
+
+## Riskiest Assumption
+
+**We assume that running full local docker-compose stacks (including TimescaleDB, the FastAPI ingestion engine, worker threads, and Playwright browsers) inside standard GitHub Actions runners is resource-performant, does not hit rate/resource limits, and can run deterministically without flake.**
+
+_Mitigation:_
+
+1. Use distinct, isolated Docker Compose configurations (`docker-compose.integration.yml` and `docker-compose.test.yml`) with minimal, tailored service profiles.
+2. Ensure database-ready checks (`pg_isready` / `healthy` container states) are explicitly coded so tests never run against uninitialized services.
+3. Clean up Docker volumes, networks, and containers aggressively between test jobs using `docker compose down -v`.
+
+## Acceptance Criterion
+
+> **Given** a PR is opened in the uFawkesDORA repo,
+> **when** the CI Pipeline runs,
+> **then** all 5 stages (Pre-Commit, Post-Commit, Pre-Deployment Validation, Deployment, Post-Deployment Verification) execute successfully:
+>
+> - Pre-Commit: Linting, formatting, type-checking, and secret scanning pass.
+> - Post-Commit: App builds successfully, fast unit tests execute and pass, security SAST/SCA and license compliance verify.
+> - Pre-Deployment Validation: An isolated integration stack starts up, runs database schema tests against real TimescaleDB, executes smoke tests verifying `/health` endpoints via curl, and runs E2E tests verifying the full ingestion-to-metric flow.
+> - Deployment & Post-Deployment: Simulates progressive/CD promotion and verifies rollback safety.
+
+## DORA Outcome Target
+
+- **Capability:** Cap7: Quality internal platforms
+- **Metric:** change_failure_rate_pct
+- **Current baseline:** 1.2%
+- **Target:** 0.0% (Zero regressions reaching main)
+- **Measurement:** uFawkesDORA metrics computation
+
+## Prior Art
+
+- **Existing Workflows:** We have `reusable-preflight.yml`, `reusable-lint.yml`, `reusable-security-scanning.yml`, `reusable-dependency-review.yml`, `reusable-build.yml`, and `ci-tests.yml` in `.github/workflows/`.
+- **Missing Elements:** The existing `ci-tests.yml` splits unit and integration tests, but lacks a complete pre-deployment validation layout with smoke tests and E2E playbooks, as well as post-deployment verification. There is no automated curl smoke check on the full compose stack, nor any Playwright E2E automation in place.
+- **Docker Compose:** We only have `docker-compose.dev.yml` for local development. There is no separate `docker-compose.integration.yml` or `docker-compose.test.yml` as described by the user's templates.
+
+## Notes
+
+This discovery brief lays out the specification and design for a state-of-the-art GitOps-aligned CI/CD pipeline that maps directly to the five key lifecycle stages. The implementation will define the necessary Compose files, E2E playbooks, and update the CI workflows.

--- a/docs/dora/spec/specification.md
+++ b/docs/dora/spec/specification.md
@@ -1,0 +1,523 @@
+# uFawkesDORA — Specification
+
+*Version: 0.1.0-draft*
+*Status: Pre-implementation — reviewed against DORA 2025/2026 primary sources and verified library APIs*
+*Companion document: DESIGN.md*
+
+---
+
+## Accuracy and verification notes
+
+Several items in this specification are based on secondary sources or inference
+from the DORA research corpus. Where I cannot confirm a value or name from a
+primary source, it is marked **[VERIFY]**. Do not implement a **[VERIFY]** item
+without first checking the indicated source.
+
+---
+
+## 1. Purpose
+
+uFawkesDORA is the DORA measurement and delivery layer for the fawkes platform suite.
+Its single job is to answer: **"Is this product delivery team getting better, and how
+do they know?"**
+
+It does this by:
+1. Accepting structured delivery events from any CI/CD system
+2. Computing the five official DORA delivery metrics from those events
+3. Surfacing metrics in multiple delivery formats: dashboards, alerts, weekly digests,
+   PR-level annotations
+4. Classifying teams against the 2025 DORA seven-archetype model
+
+uFawkesDORA is explicitly **not**:
+- A team performance management or ranking tool
+- A replacement for uFawkesObs, which provides the instrumentation substrate
+- A way to measure or compare individual engineers
+- A commercial alternative to LinearB, Swarmia, or DX Platform — it is self-hosted
+  and requires engineering effort to wire to event sources
+
+---
+
+## 2. The five DORA delivery metrics (2025 model)
+
+The following is based on the DORA metric evolution documented on dora.dev. The 2025
+update changed the model from four metrics to five and reclassified one metric.
+
+**[VERIFY]** Confirm all five metric names, definitions, and tier thresholds at
+`dora.dev/guides/dora-metrics` before finalising any compute logic or UI labels.
+Secondary sources are consistent on the names but I cannot confirm tier threshold
+values from a primary DORA source.
+
+### 2.1 Metric definitions
+
+| # | Metric | Category | Definition |
+|---|---|---|---|
+| 1 | **Deployment Frequency** | Throughput | How often code is successfully deployed to production |
+| 2 | **Lead Time for Changes** | Throughput | Time from first commit to running in production (P50 and P95) |
+| 3 | **Failed Deployment Recovery Time (FDRT)** | Throughput | Time from a failed deployment to the next successful deployment of the same service |
+| 4 | **Change Failure Rate (CFR)** | Stability | Percentage of deployments causing a production failure requiring remediation |
+| 5 | **Rework Rate** | Stability | Percentage of deployments that are unplanned fixes for user-visible issues from a recent deployment |
+
+### 2.2 The 2025 reclassification: FDRT is a Throughput metric
+
+FDRT (previously called MTTR — Mean Time to Restore) was reclassified from Stability
+to Throughput in the 2025 model. The reasoning: fast recovery from a failed deployment
+enables faster re-deployment. A high FDRT directly limits deployment frequency and
+overall throughput. This must be reflected in:
+- How FDRT is computed (deployment-gap, not incident-resolution gap — see §5.2)
+- How FDRT alerts are categorised (throughput alerts, not stability alerts)
+- How FDRT is labelled in dashboards (not called "MTTR" anywhere in the UI)
+
+### 2.3 Rework Rate: the fifth metric
+
+Rework Rate captures quality debt from unplanned fix deployments. It counts only
+deployments that fix a **user-visible** issue from a recent deployment —
+internal hotfixes, dependency updates, and configuration corrections that do not
+affect users are excluded.
+
+This metric is the primary signal for AI-assisted development quality: AI-generated
+code has higher churn, and teams using AI without discipline see Rework Rate climb
+before they see CFR spike. The Rework Rate trend is the early warning.
+
+### 2.4 Tier thresholds
+
+**[VERIFY]** The following tier values are drawn from secondary sources summarising
+the DORA 2025 research. Verify at `dora.dev/guides/dora-metrics` before encoding
+in any code, dashboard reference line, or documentation.
+
+| Metric | Elite | High | Medium | Low |
+|---|---|---|---|---|
+| Deployment Frequency | On-demand (multiple/day) | 1/week–1/day | 1/month–1/week | < 1/month |
+| Lead Time | < 1 hour | 1 day–1 week | 1 week–1 month | > 1 month |
+| FDRT | < 1 hour | < 1 day | 1 day–1 week | > 1 week |
+| Change Failure Rate | 0–5% | 5–10% | 10–15% | > 15% |
+| Rework Rate | **[VERIFY]** | **[VERIFY]** | **[VERIFY]** | **[VERIFY]** |
+
+Rework Rate tier thresholds are not confirmed from a primary source.
+
+---
+
+## 3. The seven team archetypes (2025 model)
+
+**[VERIFY]** The seven-archetype model replaced the Elite/High/Medium/Low four-tier
+model in the 2025 DORA State of DevOps Report. The archetype names below are drawn
+from secondary sources. Verify all seven names, definitions, and the classification
+methodology from the primary 2025 DORA report before implementing the classifier.
+I am confident six of seven names are approximately correct; I am not confident
+all names and definitions are exact.
+
+The critical structural points that are confirmed:
+- Classification requires **both** quantitative delivery metrics AND qualitative
+  wellbeing signals
+- A metrics-only classification is possible but has reduced confidence
+- The four-tier model (Elite/High/Medium/Low) is deprecated; do not use it
+
+| Archetype | Approximate signature |
+|---|---|
+| Harmonious high-achievers | High throughput + low instability + high wellbeing |
+| Pragmatic performers | High speed/stability + lower engagement |
+| Stable and methodical | High quality + sustainable pace + lower throughput |
+| Constrained by process | Stable systems + process overhead consuming capacity |
+| Legacy bottleneck | Reactive, unstable systems + low morale |
+| High impact, low cadence | High-value output + low throughput + high instability |
+| *(seventh — name and definition unconfirmed)* | **[VERIFY from primary source]** |
+
+The classifier (`compute/archetype.py`) must:
+- Express a `confidence` score (0–1)
+- Cap confidence at approximately 0.65 when no wellbeing survey data is available
+  (the exact cap value is a design choice, not a DORA-specified value)
+- Document its classification logic inline with citations, not as a black box
+- Never present a metrics-only classification as definitively accurate
+
+---
+
+## 4. Event schema specification
+
+All event sources emit JSON to `POST /event` on the ingestion API. The schema is
+the stable API contract — changes require a version bump and collector updates.
+
+### 4.1 Schema versioning policy
+
+- Field additions that are backward-compatible: increment minor version (1.0 → 1.1)
+- Field removals, renames, or type changes: increment major version (1.0 → 2.0)
+- Major version changes require coordinated updates to all connected collectors
+- The `schema_version` field is required in every event
+
+### 4.2 Common fields (all event types)
+
+```json
+{
+  "schema_version": "1.0",
+  "event_type": "deployment | incident | pr | rework",
+  "repo": "owner/repo-name",
+  "occurred_at": "2026-06-22T14:30:00Z"
+}
+```
+
+`occurred_at` must be ISO 8601 with UTC timezone. Naive timestamps (without timezone)
+are rejected with a 422 error.
+
+### 4.3 Deployment event
+
+```json
+{
+  "schema_version": "1.0",
+  "event_type": "deployment",
+  "repo": "paruff/uFawkesObs",
+  "service": "grafana",
+  "environment": "production",
+  "commit_sha": "aaaa000011112222",
+  "deployed_at": "2026-06-22T14:30:00Z",
+  "occurred_at": "2026-06-22T14:30:00Z",
+  "status": "success | failed | rollback",
+  "pipeline_url": "https://github.com/paruff/uFawkesObs/actions/runs/12345",
+  "deploy_duration_seconds": 127,
+  "ai_assisted": false
+}
+```
+
+Required: `schema_version`, `event_type`, `repo`, `commit_sha`, `deployed_at`,
+`occurred_at`, `status`
+Optional: `service`, `environment`, `pipeline_url`, `deploy_duration_seconds`,
+`ai_assisted`
+
+### 4.4 Incident event
+
+```json
+{
+  "schema_version": "1.0",
+  "event_type": "incident",
+  "repo": "paruff/uFawkesObs",
+  "service": "grafana",
+  "incident_id": "INC-20260622-001",
+  "status": "opened | resolved",
+  "occurred_at": "2026-06-22T15:00:00Z",
+  "linked_deployment_sha": "aaaa000011112222",
+  "severity": "P1 | P2 | P3 | P4"
+}
+```
+
+Required: `schema_version`, `event_type`, `repo`, `incident_id`, `status`,
+`occurred_at`
+Optional: `service`, `linked_deployment_sha`, `severity`
+
+**Important:** Incident events come from the incident management tool (Grafana
+OnCall webhook, PagerDuty webhook, or a manual `curl` command). They never come
+from Alertmanager, which is a notification router downstream of Prometheus, not
+an upstream event source.
+
+### 4.5 PR event
+
+```json
+{
+  "schema_version": "1.0",
+  "event_type": "pr",
+  "repo": "paruff/uFawkesObs",
+  "pr_number": 42,
+  "commit_sha": "aaaa000011112222",
+  "status": "opened | merged | closed",
+  "occurred_at": "2026-06-22T14:30:00Z",
+  "first_commit_at": "2026-06-20T09:15:00Z",
+  "lines_added": 234,
+  "lines_deleted": 18,
+  "ai_assisted": false
+}
+```
+
+Required: `schema_version`, `event_type`, `repo`, `pr_number`, `commit_sha`,
+`status`, `occurred_at`
+Optional: `first_commit_at`, `lines_added`, `lines_deleted`, `ai_assisted`
+
+`first_commit_at` is required for accurate Lead Time computation. When absent,
+Lead Time falls back to PR open time as a proxy; the `proxy_metrics` flag is set
+to `true` in the snapshot.
+
+### 4.6 Rework event
+
+```json
+{
+  "schema_version": "1.0",
+  "event_type": "rework",
+  "repo": "paruff/uFawkesObs",
+  "deployment_sha": "aaaa000011112222",
+  "rework_type": "hotfix | rollback | patch",
+  "triggered_at": "2026-06-22T16:45:00Z",
+  "occurred_at": "2026-06-22T16:45:00Z",
+  "user_visible": true
+}
+```
+
+Required: `schema_version`, `event_type`, `repo`, `deployment_sha`, `rework_type`,
+`triggered_at`, `occurred_at`, `user_visible`
+
+`user_visible: true` is required for the event to count toward Rework Rate.
+`user_visible: false` events are stored but excluded from the Rework Rate numerator.
+
+---
+
+## 5. Metric computation rules
+
+### 5.1 Deployment Frequency
+
+```
+deployments_per_week = COUNT(deployment events WHERE status='success')
+                       / window_days * 7
+```
+
+Window: configurable, default 30 days.
+Grouped by: `repo` and optionally `service` and `environment`.
+
+### 5.2 Lead Time for Changes
+
+```
+lead_time = deployed_at - first_commit_at
+```
+
+When `first_commit_at` is absent: `lead_time = deployed_at - pr_opened_at` (proxy).
+When neither is available: metric is null for that event; set `proxy_metrics: true`.
+
+Report P50 and P95. P95 matters because it captures the "long tail" deployments
+that indicate blocked PRs or complex changes — often where AI-generated code is
+accumulated in a large branch.
+
+### 5.3 Failed Deployment Recovery Time (FDRT)
+
+FDRT is the time between a failed deployment and the **next successful deployment
+of the same service to the same environment**. It is explicitly NOT:
+- Time from incident opened to incident resolved (that is the old MTTR definition)
+- Time from failed deployment to incident resolved
+
+```
+fdrt = next_success_deployed_at - failed_deployed_at
+       WHERE service = service AND environment = environment
+       AND next_success_deployed_at > failed_deployed_at
+```
+
+When no subsequent successful deployment exists within the measurement window,
+FDRT for that failure is null (not zero, not the window duration).
+Report P50. A null FDRT means the failure is either unresolved or resolved outside
+the window — both are documented in the snapshot with a `null_fdrt_count` field.
+
+### 5.4 Change Failure Rate
+
+```
+cfr = COUNT(deployment events WHERE status IN ('failed', 'rollback'))
+      / COUNT(deployment events)
+      * 100
+```
+
+Expressed as a percentage. A deployment with `status='rollback'` counts as a
+failure for CFR purposes — the team determined a prior deployment was bad enough
+to revert.
+
+### 5.5 Rework Rate
+
+```
+rework_rate = COUNT(rework events WHERE user_visible=true)
+              / COUNT(deployment events WHERE status='success')
+              * 100
+```
+
+Expressed as a percentage. Only `user_visible: true` rework events count in the
+numerator. The denominator is successful deployments, not all deployments.
+
+### 5.6 Proxy metrics flag
+
+Any snapshot where one or more metrics used a fallback data source instead of
+the canonical source must set `proxy_metrics: true` in `dora_snapshots` and
+display a visible warning in all dashboards. Do not silently present proxy data
+as if it were primary data.
+
+---
+
+## 6. Leading indicators
+
+Leading indicators are not official DORA metrics. They are delivery signals that
+predict lagging DORA metric degradation before it appears in the five metrics.
+They are derived from PR events and CI pipeline events.
+
+| Leading indicator | Predicts | Source |
+|---|---|---|
+| PR cycle time P90 | Lead time increase | PR events: `occurred_at(merged)` - `occurred_at(opened)` |
+| PR size (lines added) 14-day MA | Rework Rate increase | PR events: `lines_added` |
+| Test/CI duration 7-day MA | Deployment frequency drop | CI pipeline events (future) |
+| Rework rate 14-day MA | CFR trajectory | Rework events |
+| Branch age P90 | Lead time + batch size violation | **[VERIFY source]** — requires GitHub API or gitops signal |
+
+Branch age requires external data (GitHub API for branch listing) that may not
+be available without credentials. Document this limitation clearly in the
+leading indicators dashboard with a fallback display when data is absent.
+
+---
+
+## 7. Value stream indicators
+
+Value stream indicators segment Lead Time into stages to identify where time is
+spent — and where AI productivity gains are being absorbed rather than delivered.
+
+| Stage | Measurement | Requires |
+|---|---|---|
+| Coding time | `pr_opened_at` - `first_commit_at` | `first_commit_at` in PR event |
+| Review time | `pr_merged_at` - `pr_opened_at` | PR events (opened + merged) |
+| CI time | `ci_completed_at` - `pr_merged_at` | CI pipeline events (future) |
+| Deploy time | `deployed_at` - `ci_completed_at` | Deployment events + CI events |
+| Rework time | `rework_triggered_at` - `deployed_at` | Rework events |
+
+VSM requires CI pipeline events that are not defined in the v0.1 schema. The VSM
+stage breakdown (`vsi_stage_breakdown` table) should be written with null CI stages
+for v0.1, with CI stages populated when CI events are added.
+
+---
+
+## 8. Alerting specification
+
+All alerts are regression-based (relative to the team's own 30-day baseline),
+not threshold-based (relative to a fixed industry value). This is a deliberate
+design choice: teams at different performance levels need alerts calibrated to
+their current state, not to someone else's.
+
+### 8.1 Alert conditions
+
+| Alert name | Condition | Severity | Hold duration |
+|---|---|---|---|
+| `DoraDeploymentFrequencyDrop` | Current 7d avg < 70% of 30d avg | warning | 24h |
+| `DoraLeadTimeIncrease` | Current 7d P50 > 150% of 30d P50 | warning | 48h |
+| `DoraFDRTSpike` | Current P50 > 200% of 30d P50 | critical | 6h |
+| `DoraCFRSpike` | Current > 30d avg + 5 percentage points | warning | 24h |
+| `DoraReworkRateClimb` | Current > 30d avg + 3 percentage points | warning | 48h |
+| `DoraLeadingIndicatorPRCycle` | PR cycle time P90 > 24hrs | warning | 72h |
+
+Alert category labels: `dora_throughput` for metrics 1-3, `dora_stability` for
+metrics 4-5. Alertmanager should route DORA alerts to a separate channel from
+infrastructure alerts — teams want DORA alerts in their engineering Slack channel,
+not mixed with "disk full on node-3" alerts.
+
+Every alert must have: `summary`, `description` (including current value and
+baseline for context), `runbook_url` pointing to a stub in `docs/runbooks/`.
+
+### 8.2 What Alertmanager does NOT do
+
+Alertmanager is downstream of Prometheus alerting rules. It routes notifications
+outward (Slack, email, PagerDuty). It never sends data into the uFawkesDORA
+ingestion pipeline. Any diagram or documentation that shows Alertmanager as an
+input to event ingestion is incorrect.
+
+---
+
+## 9. Delivery mechanisms
+
+### 9.1 Grafana dashboards
+
+Dashboards render in the uFawkesObs Grafana instance. Dashboard JSON files live
+in `uFawkesDORA/dashboards/` and are provisioned by being copied to the uFawkesObs
+`grafana/provisioning/dashboards/` directory.
+
+Two datasource types are used:
+- **Prometheus**: for time-series trend panels (data pushed via pushgateway from
+  the compute job)
+- **Postgres**: for current snapshots, archetype history, wellbeing survey data,
+  and VSM stage breakdown tables (via the Grafana PostgreSQL datasource plugin)
+
+### 9.2 Weekly digest
+
+A `notifications/digest/generate_digest.py` script produces a weekly Markdown
+summary. It queries `dora_snapshots` from Postgres for the latest values and
+the prior week's values, then formats them into a human-readable digest.
+
+The digest is delivered via:
+1. A Markdown file committed to the repo (`notifications/digest/weekly-digest-YYYY-WW.md`)
+2. Optionally, a Slack webhook POST if `SLACK_WEBHOOK_URL` is configured
+3. Optionally, any other HTTP endpoint via a configurable `DIGEST_WEBHOOK_URL`
+
+The digest must not require Prometheus or uFawkesObs to be running — it reads
+from Postgres only. This means the digest works even if the observability stack
+is down.
+
+### 9.3 PR-level lead time annotation
+
+A GitHub Actions reusable workflow posts a comment on every merged PR with:
+- Lead time for that specific PR
+- Team 30-day P50 baseline
+- A comparison (faster / slower / at baseline)
+- A coaching note if the PR took more than 2× the team P50
+- An AI flag if `ai_assisted: true` was in the PR event
+
+The annotation is posted by `github-actions[bot]` — not a personal access token.
+The workflow is disabled by setting a repository variable `DORA_PR_ANNOTATIONS`
+to `"false"`.
+
+---
+
+## 10. Wellbeing survey
+
+The wellbeing survey is the data source for archetype classification beyond the
+metrics-only baseline. It is a quarterly exercise, not a continuous instrument.
+
+Four questions:
+1. Burnout score (1–5): "How often do you feel burned out by your work?"
+2. Friction score (1–5): "How much friction do you encounter in your daily work?"
+3. Valuable work percentage (0–100): "What percentage of your time is spent on work
+   you find meaningful?"
+4. Recommend score (1–5): "Would you recommend this team's working practices to a colleague?"
+
+Survey responses are submitted via a `curl` command documented in
+`compute/archetype_survey.md`. They are stored in the `wellbeing_surveys` table
+and linked to a repo and quarter string (e.g., `"2026-Q2"`).
+
+Survey data is sensitive. Access to the `wellbeing_surveys` table must be restricted
+to the `dora_app` role and must never be surfaced in Grafana in a form that could
+identify individual responses.
+
+---
+
+## 11. Constraints and non-requirements
+
+### In scope for v0.1.0
+
+- Five DORA delivery metrics computed from Postgres event store
+- DORA Overview dashboard (Grafana)
+- Regression-based Prometheus alerting rules
+- GitHub Actions collectors for deployment and PR events
+- Generic webhook receiver for Woodpecker/Portainer/other sources
+- Manual incident declaration script
+- README following uFawkes documentation standard
+
+### In scope for v0.2.0
+
+- Leading Indicators dashboard
+- Seven-archetype classifier with wellbeing survey
+- Archetype Profile dashboard and AI Impact dashboard
+- Weekly Slack digest
+- PR-level lead time annotations
+
+### Explicitly out of scope (document clearly in README)
+
+- Kubernetes/cluster-level instrumentation (uFawkesObs handles this)
+- Individual developer metrics (not consistent with DORA's intent)
+- Git blame or author-level attribution of any kind
+- Real-time streaming (all computation is batch, not streaming)
+- Multi-tenancy with access control (single-team, self-hosted)
+- SLA/SLO tracking (uFawkesObs reliability concern, not DORA concern)
+
+---
+
+## 12. Open questions requiring human decision before implementation
+
+1. **DORA tier thresholds for Rework Rate**: not confirmed from primary source.
+   Check `dora.dev/guides/dora-metrics` and set the thresholds explicitly in a
+   constants file, not inline in SQL or Python.
+
+2. **Seventh archetype**: name and definition unconfirmed. Check the primary
+   2025 DORA State of DevOps Report.
+
+3. **Branch age as a leading indicator**: requires GitHub API access to list
+   open branches and their age. Decide whether to include this in v0.1 (requires
+   a GitHub token as a secret) or defer to v0.2.
+
+4. **CI stage in VSM**: requires a CI pipeline event schema not defined in v0.1.
+   Decide whether to define it now (even if unused) or add it in v0.2 when the
+   VSM compute job is implemented.
+
+5. **Grafana PostgreSQL datasource plugin**: confirm this plugin is available in
+   the version of Grafana used in uFawkesObs before building dashboards that
+   depend on it. **[VERIFY the Grafana version in uFawkesObs and check the
+   PostgreSQL datasource availability]**.


### PR DESCRIPTION
## Summary

- Copies `docs/spec`, `docs/design`, `docs/decisions`, and `docs/discovery` from uFawkesDORA (`origin/main`) into `docs/dora/` as part of the DORA consolidation (ADR-007, closes #207).
- Content preserved as-is — it's a historical record of the original uFawkesDORA design, not rewritten for the merged repo.

## AI-Assisted Review Block

**What does this PR do?**
Merges uFawkesDORA's spec/design/decisions/discovery docs into `docs/dora/` in uFawkesObs, per DORA-CONSOLIDATION-07.

**What could go wrong?**
Low risk — docs-only change, no code/config touched. The copied docs reference "uFawkesDORA" by name in places since they describe the original repo's design; left unedited since editing history isn't in scope for this issue.

**What tests cover this change?**
None needed — docs-only, no executable behavior changed.

**Architecture check:**
- What layer(s) touched, and is that correct per §4? Docs only (`docs/dora/`) — not covered by §4's compose/scripts/tests/dashboards rules, no violation.
- Any cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDORA)? None — pure documentation copy, source repo (uFawkesDORA) untouched.

**What I was NOT sure about:**
Whether to add a top-level `docs/dora/README.md` index — left out since the issue only asked for a straight copy; can add if reviewers want a landing page.