### PR TITLE
feat(dora): merge uFawkesDORA collector patterns (#208)

### DIFF
--- a/dora/collectors/generic/README.md
+++ b/dora/collectors/generic/README.md
@@ -1,0 +1,308 @@
+# uFawkesDORA Generic Collectors
+
+Copy-paste-ready integrations for emitting DORA events from **any** CI/CD system
+or from a terminal.
+
+## When to Use These
+
+| Source                                  | When                             | Recommended File                                                |
+| --------------------------------------- | -------------------------------- | --------------------------------------------------------------- |
+| Woodpecker CI (uFawkesPipe)             | Your pipeline runs on Woodpecker | [`pipeline-snippet.yml`](../woodpecker/pipeline-snippet.yml)    |
+| GitLab CI / Jenkins / CircleCI / any CI | Your CI has `curl` and env vars  | [`curl-examples.sh`](curl-examples.sh)                          |
+| Portainer (webhook on stack redeploy)   | You deploy stacks via Portainer  | See [Portainer section](#portainer-webhook) below               |
+| Manual incident (no PagerDuty)          | An engineer gets paged           | [`declare-incident.sh`](../manual-incident/declare-incident.sh) |
+
+---
+
+## Quick Start
+
+```bash
+# 1. Set the ingestion API URL
+export DORA_INGESTION_URL="https://dora.example.com"
+
+# 2. (Optional) Set API key if auth is enabled
+export DORA_API_KEY="your-api-key"  # pragma: allowlist secret
+
+# 3. Send a deployment event
+curl -X POST "${DORA_INGESTION_URL}/event" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schema_version": "1.0",
+    "event_type": "deployment",
+    "repo": "my-org/my-service",
+    "service": "my-service",
+    "environment": "production",
+    "commit_sha": "'"$(git rev-parse HEAD)"'",
+    "deployed_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+    "status": "success"
+  }'
+
+# Verify
+echo "Check raw_events table for the new row"
+```
+
+---
+
+## CI/CD Integration
+
+### Per-Platform Environment Variable Mapping
+
+Use this table to map your CI/CD system's built-in variables to the fields
+required by the canonical event schemas.
+
+| Event Field    | GitLab CI          | CircleCI                  | Jenkins        | Woodpecker         |
+| -------------- | ------------------ | ------------------------- | -------------- | ------------------ |
+| `commit_sha`   | `CI_COMMIT_SHA`    | `CIRCLE_SHA1`             | `GIT_COMMIT`   | `CI_COMMIT_SHA`    |
+| `pipeline_url` | `CI_JOB_URL`       | `CIRCLE_BUILD_URL`        | `BUILD_URL`    | `CI_PIPELINE_URL`  |
+| `repo`         | `CI_PROJECT_PATH`  | `CIRCLE_PROJECT_REPONAME` | From `GIT_URL` | `CI_REPO`          |
+| `service`      | `CI_PROJECT_NAME`  | `CIRCLE_PROJECT_REPONAME` | `JOB_NAME`     | `CI_REPO_NAME`     |
+| `branch`       | `CI_COMMIT_BRANCH` | `CIRCLE_BRANCH`           | `BRANCH_NAME`  | `CI_COMMIT_BRANCH` |
+| `environment`  | Set manually       | Set manually              | Set manually   | Set manually       |
+
+### Woodpecker CI
+
+Add the [pipeline snippet](../woodpecker/pipeline-snippet.yml) to your
+`.woodpecker/*.yml` configuration:
+
+```yaml
+steps:
+  notify-dora:
+    image: curlimages/curl:latest
+    # ... see woodpecker/pipeline-snippet.yml for full example
+```
+
+The snippet uses Woodpecker's `from_secret` for credentials — add these secrets
+in your Woodpecker repo settings:
+
+| Secret Name          | Value                      |
+| -------------------- | -------------------------- |
+| `dora_ingestion_url` | `https://dora.example.com` |
+| `dora_api_key`       | `your-api-key` (optional)  |
+
+### GitLab CI
+
+```yaml
+notify-dora:
+  image: curlimages/curl:latest
+  variables:
+    DORA_INGESTION_URL: $DORA_INGESTION_URL  # set in CI/CD settings
+    DORA_API_KEY: $DORA_API_KEY               # set in CI/CD settings
+  script:
+    - curl -X POST "${DORA_INGESTION_URL}/event"
+        -H "Content-Type: application/json"
+        -d '{
+          "schema_version": "1.0",
+          "event_type": "deployment",
+          "repo": "'"${CI_PROJECT_PATH}"'",
+          "service": "'"${CI_PROJECT_NAME}"'",
+          "commit_sha": "'"${CI_COMMIT_SHA}"'",
+          "deployed_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+          "status": "'"${CI_JOB_STATUS}"'",
+          "pipeline_url": "'"${CI_JOB_URL}"'"
+        }'
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+```
+
+### Jenkins Pipeline
+
+```groovy
+stage('DORA Notification') {
+    steps {
+        sh """
+            curl -X POST "${DORA_INGESTION_URL}/event" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "schema_version": "1.0",
+                    "event_type": "deployment",
+                    "repo": "my-org/my-service",
+                    "service": "my-service",
+                    "commit_sha": "${GIT_COMMIT}",
+                    "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+                    "status": "${currentBuild.result ?: 'success'}",
+                    "pipeline_url": "${BUILD_URL}"
+                }'
+        """
+    }
+}
+```
+
+### CircleCI
+
+```yaml
+version: 2.1
+jobs:
+  deploy:
+    docker:
+      - image: curlimages/curl:latest
+    steps:
+      - run:
+          name: Notify DORA
+          command: |
+            curl -X POST "${DORA_INGESTION_URL}/event" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "schema_version": "1.0",
+                "event_type": "deployment",
+                "repo": "'"${CIRCLE_PROJECT_REPONAME}"'",
+                "service": "'"${CIRCLE_PROJECT_REPONAME}"'",
+                "commit_sha": "'"${CIRCLE_SHA1}"'",
+                "deployed_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+                "status": "success",
+                "pipeline_url": "'"${CIRCLE_BUILD_URL}"'"
+              }'
+```
+
+---
+
+## Portainer Webhook
+
+Portainer supports **outgoing webhooks** that trigger when a stack is redeployed.
+You can configure it to POST a deployment event to the uFawkesDORA ingestion API.
+
+### Portainer Webhook Configuration
+
+1. In Portainer, go to **Settings → Webhooks**
+2. Click **Add webhook**
+3. Configure:
+
+| Field               | Value                                           |
+| ------------------- | ----------------------------------------------- |
+| **Name**            | `uFawkesDORA Deployment Event`                  |
+| **URL**             | `https://your-dora-ingestion.example.com/event` |
+| **Method**          | `POST`                                          |
+| **Request Headers** | `Content-Type: application/json`                |
+| **Event Types**     | `Stack Deployment`                              |
+
+### Portainer Webhook JSON Body
+
+Portainer sends a POST request with the following JSON body when a stack
+is deployed:
+
+```json
+{
+  "event_type": "deployment",
+  "stack_name": "my-stack",
+  "stack_id": 42,
+  "endpoint_id": 1,
+  "environment": "production",
+  "status": "success"
+}
+```
+
+### Mapping to Canonical Schema
+
+Portainer's webhook body doesn't include `commit_sha` or `pipeline_url` by
+default. The ingestion API will accept the event with the fields Portainer
+provides — missing optional fields are acceptable.
+
+If you need `commit_sha`, configure your Portainer stack to include it in
+environment labels, or accept that deployment events from Portainer will lack
+commit-level granularity (set `commit_sha: "unknown"` in the webhook receiver).
+
+### Configuring the Webhook Receiver
+
+Portainer webhooks POST to a fixed URL — you can either:
+
+1. **Point directly at the ingestion API** (`/event` endpoint) if Portainer's
+   JSON body is acceptable as-is
+2. **Use a lightweight transformer** (e.g., an AWS Lambda or a simple proxy)
+   to map Portainer's fields to the canonical schema
+
+For option 1, the payload sent by Portainer will be stored in `raw_events`
+as-is. The DORA metrics computation can still extract meaningful data from
+it (repo, service, status).
+
+---
+
+## Manual Incident Declaration
+
+If your team doesn't use PagerDuty, Grafana OnCall, or any incident management
+platform, use the manual scripts to declare and resolve incidents:
+
+```bash
+# Declare an incident (interactive)
+./collectors/manual-incident/declare-incident.sh
+
+# Declare an incident (flags, for runbooks/automation)
+./collectors/manual-incident/declare-incident.sh \
+    --incident_id=INC-123 \
+    --service=api-gateway \
+    --severity=critical
+
+# Resolve the incident (use the SAME incident_id)
+./collectors/manual-incident/resolve-incident.sh \
+    --incident_id=INC-123
+```
+
+These scripts POST incident events to `$DORA_INGESTION_URL/event`. They are
+critical for FDRT (Failure Deployment Recovery Time) — without incident events,
+FDRT cannot be calculated.
+
+### Incident Response Runbook Template
+
+Add this to your incident response runbook:
+
+```markdown
+## 1. DECLARE the incident
+
+ssh ops-box
+export DORA_INGESTION_URL="https://dora.example.com"
+./collectors/manual-incident/declare-incident.sh
+
+## 2. Debug and fix
+
+[... your debugging steps ...]
+
+## 3. RESOLVE the incident
+
+./collectors/manual-incident/resolve-incident.sh \
+ --incident_id=<same-id-from-step-1>
+```
+
+---
+
+## Troubleshooting
+
+### Check events reached the database
+
+```bash
+# Using Docker Compose
+docker compose -f docker-compose.dev.yml exec -T timescaledb \
+    psql -U postgres -d dora_metrics \
+    -c "SELECT recorded_at, event_type, status, service FROM raw_events ORDER BY recorded_at DESC LIMIT 20;"
+```
+
+### Common Issues
+
+| Symptom                            | Likely Cause                     | Fix                                            |
+| ---------------------------------- | -------------------------------- | ---------------------------------------------- |
+| `curl: (6) Could not resolve host` | Wrong URL                        | Check `DORA_INGESTION_URL` includes `https://` |
+| HTTP 422                           | Invalid JSON payload             | Validate against `events/*.schema.json`        |
+| HTTP 401/403                       | Missing API key                  | Set `DORA_API_KEY`                             |
+| HTTP 500                           | Ingestion API down               | Check API logs                                 |
+| No rows in `raw_events`            | Event not sent or wrong database | Check curl output; verify `DATABASE_URL`       |
+| `command not found: curl`          | No curl in CI image              | Use `curlimages/curl:latest` Docker image      |
+
+### Verify Schema Compliance
+
+```bash
+# Validate a payload against the incident schema
+python3 -c "
+import json, jsonschema
+with open('events/incident-event.schema.json') as f:
+    schema = json.load(f)
+payload = {
+    'schema_version': '1.0',
+    'event_type': 'incident',
+    'incident_id': 'INC-123',
+    'service': 'my-service',
+    'repo': 'my-org/my-service',
+    'status': 'opened',
+    'reported_at': '2026-06-23T12:00:00Z',
+    'severity': 'critical'
+}
+jsonschema.validate(payload, schema)
+print('✅ Payload is valid')
+"
+```

--- a/dora/collectors/generic/curl-examples.sh
+++ b/dora/collectors/generic/curl-examples.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+# ============================================================================
+# curl-examples.sh — uFawkesDORA Generic curl Examples
+# ----------------------------------------------------------------------------
+# Copy-paste-ready curl commands for emitting DORA events to the uFawkesDORA
+# ingestion API. Use these in any CI/CD system (Jenkins, GitLab CI, CircleCI,
+# Woodpecker, etc.) by substituting the appropriate environment variables.
+#
+# Environment:
+#   DORA_INGESTION_URL   Required. URL of the ingestion API
+#   DORA_API_KEY         Optional. Bearer token if auth is enabled
+#
+# Per-platform CI environment variable mappings:
+#
+#   Field              GitLab CI              CircleCI              Jenkins                  Woodpecker
+#   ─────────────────────────────────────────────────────────────────────────────────────────────────────
+#   commit_sha         CI_COMMIT_SHA          CIRCLE_SHA1           GIT_COMMIT               CI_COMMIT_SHA
+#   pipeline_url       CI_JOB_URL             CIRCLE_BUILD_URL      BUILD_URL                CI_PIPELINE_URL
+#   repo               CI_PROJECT_PATH        CIRCLE_PROJECT_REPONAME  (from GIT_URL)      CI_REPO
+#   branch             CI_COMMIT_BRANCH       CIRCLE_BRANCH         BRANCH_NAME              CI_COMMIT_BRANCH
+#   service            CI_PROJECT_NAME        CIRCLE_PROJECT_REPONAME  JOB_NAME             CI_REPO_NAME
+#
+# Reference: events/*.schema.json
+# ============================================================================
+
+# ── Prerequisites ──────────────────────────────────────────────────────────
+# Set these in your CI/CD environment or shell:
+#
+#   export DORA_INGESTION_URL="https://dora.example.com"
+#   export DORA_API_KEY="changeme"  # pragma: allowlist secret
+#
+# ────────────────────────────────────────────────────────────────────────────
+
+# ============================================================================
+# 1. Deployment Event — Success
+# ============================================================================
+# Use this when a deployment completes successfully.
+#
+# CI variable examples:
+#   GitLab CI:   CI_COMMIT_SHA, CI_JOB_URL, CI_PROJECT_PATH
+#   CircleCI:    CIRCLE_SHA1, CIRCLE_BUILD_URL, CIRCLE_PROJECT_REPONAME
+#   Jenkins:     GIT_COMMIT, BUILD_URL, JOB_NAME
+#   Woodpecker:  CI_COMMIT_SHA, CI_PIPELINE_URL, CI_REPO
+# ============================================================================
+
+# curl -X POST "${DORA_INGESTION_URL}/event" \
+#   -H "Content-Type: application/json" \
+#   ${DORA_API_KEY:+-H "Authorization: Bearer ${DORA_API_KEY}"} \
+#   -d '{
+#     "schema_version": "1.0",
+#     "event_type": "deployment",
+#     "repo": "'"${CI_REPO:-unknown}/${CI_REPO_NAME:-unknown}"'",
+#     "service": "'"${CI_REPO_NAME:-unknown}"'",
+#     "environment": "production",
+#     "commit_sha": "'"${CI_COMMIT_SHA:-unknown}"'",
+#     "deployed_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+#     "status": "success",
+#     "pipeline_url": "'"${CI_PIPELINE_URL:-}"'"
+#   }'
+
+# ============================================================================
+# 2. Deployment Event — Failed
+# ============================================================================
+# Use this when a deployment fails (rollback, error, etc.).
+
+# curl -X POST "${DORA_INGESTION_URL}/event" \
+#   -H "Content-Type: application/json" \
+#   ${DORA_API_KEY:+-H "Authorization: Bearer ${DORA_API_KEY}"} \
+#   -d '{
+#     "schema_version": "1.0",
+#     "event_type": "deployment",
+#     "repo": "'"${CI_REPO:-unknown}/${CI_REPO_NAME:-unknown}"'",
+#     "service": "'"${CI_REPO_NAME:-unknown}"'",
+#     "environment": "production",
+#     "commit_sha": "'"${CI_COMMIT_SHA:-unknown}"'",
+#     "deployed_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+#     "status": "failed",
+#     "pipeline_url": "'"${CI_PIPELINE_URL:-}"'"
+#   }'
+
+# ============================================================================
+# 3. Incident Event — Opened
+# ============================================================================
+# Use this when a production incident is declared (pager fires).
+
+# curl -X POST "${DORA_INGESTION_URL}/event" \
+#   -H "Content-Type: application/json" \
+#   ${DORA_API_KEY:+-H "Authorization: Bearer ${DORA_API_KEY}"} \
+#   -d '{
+#     "schema_version": "1.0",
+#     "event_type": "incident",
+#     "repo": "my-org/'"${CI_REPO_NAME:-my-service}"'",
+#     "service": "'"${CI_REPO_NAME:-my-service}"'",
+#     "incident_id": "INC-'"$(date +%s)"'",
+#     "status": "opened",
+#     "reported_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+#     "severity": "critical"
+#   }'
+
+# ============================================================================
+# 4. Incident Event — Resolved
+# ============================================================================
+# Use this when an incident is resolved. FDRT = time between opened and resolved.
+# IMPORTANT: Use the SAME incident_id that was used in the "opened" event.
+
+# curl -X POST "${DORA_INGESTION_URL}/event" \
+#   -H "Content-Type: application/json" \
+#   ${DORA_API_KEY:+-H "Authorization: Bearer ${DORA_API_KEY}"} \
+#   -d '{
+#     "schema_version": "1.0",
+#     "event_type": "incident",
+#     "repo": "my-org/'"${CI_REPO_NAME:-my-service}"'",
+#     "service": "'"${CI_REPO_NAME:-my-service}"'",
+#     "incident_id": "INC-1743206400",
+#     "status": "resolved",
+#     "resolved_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+#     "severity": "critical"
+#   }'
+
+# ============================================================================
+# 5. Rework Event — Hotfix
+# ============================================================================
+# Use this when a user-visible hotfix or rollback is deployed.
+# user_visible=true means this counts toward the Rework Rate metric.
+
+# curl -X POST "${DORA_INGESTION_URL}/event" \
+#   -H "Content-Type: application/json" \
+#   ${DORA_API_KEY:+-H "Authorization: Bearer ${DORA_API_KEY}"} \
+#   -d '{
+#     "schema_version": "1.0",
+#     "event_type": "rework",
+#     "repo": "'"${CI_REPO:-unknown}/${CI_REPO_NAME:-unknown}"'",
+#     "service": "'"${CI_REPO_NAME:-unknown}"'",
+#     "rework_type": "hotfix",
+#     "user_visible": true,
+#     "deployment_sha": "'"${CI_COMMIT_SHA:-unknown}"'",
+#     "deployed_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+#     "description": "Hotfix deployed"
+#   }'
+
+# ============================================================================
+# 6. PR Event — Merged
+# ============================================================================
+# Use this when a pull request is merged. Lead Time = merge time - first commit.
+# Note: Some CI systems don't expose first_commit_at — set it manually if known.
+
+# curl -X POST "${DORA_INGESTION_URL}/event" \
+#   -H "Content-Type: application/json" \
+#   ${DORA_API_KEY:+-H "Authorization: Bearer ${DORA_API_KEY}"} \
+#   -d '{
+#     "schema_version": "1.0",
+#     "event_type": "pr",
+#     "repo": "'"${CI_REPO:-unknown}/${CI_REPO_NAME:-unknown}"'",
+#     "service": "'"${CI_REPO_NAME:-unknown}"'",
+#     "pr_number": 42,
+#     "status": "merged",
+#     "commit_sha": "'"${CI_COMMIT_SHA:-unknown}"'",
+#     "occurred_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+#     "first_commit_at": "2026-06-22T10:00:00Z",
+#     "source": "curl-examples"
+#   }'
+
+# ============================================================================
+# Verifying events reached the database
+# ============================================================================
+# After sending events, verify they arrived by querying the raw_events table:
+#
+#   docker compose -f docker-compose.dev.yml exec -T timescaledb \
+#     psql -U postgres -d dora_metrics \
+#     -c "SELECT event_type, status, COUNT(*) FROM raw_events GROUP BY event_type, status;"
+#
+# Or for the latest events:
+#
+#   docker compose -f docker-compose.dev.yml exec -T timescaledb \
+#     psql -U postgres -d dora_metrics \
+#     -c "SELECT recorded_at, event_type, status FROM raw_events ORDER BY recorded_at DESC LIMIT 10;"
+
+# ============================================================================
+# Troubleshooting
+# ============================================================================
+#
+# Problem: curl: (6) Could not resolve host
+#   Fix: Check DORA_INGESTION_URL — include https:// prefix
+#
+# Problem: HTTP 422
+#   Fix: The JSON payload failed schema validation. Check event_type spelling
+#        and required fields. Reference events/*.schema.json
+#
+# Problem: HTTP 401 or 403
+#   Fix: Set DORA_API_KEY if the ingestion API requires authentication
+#
+# Problem: HTTP 500
+#   Fix: Check the ingestion API logs. The /event endpoint may be down.
+#
+# Problem: "command not found: curl"
+#   Fix: Install curl in your CI runner or use a Docker image with curl
+#        (e.g., curlimages/curl:latest)

--- a/dora/collectors/github/README.md
+++ b/dora/collectors/github/README.md
@@ -1,0 +1,161 @@
+# uFawkesDORA — GitHub Actions Collectors
+
+Emit deployment and pull request events from any GitHub repo to the
+uFawkesDORA ingestion API. Zero new tooling — just add one `uses:` line to
+your workflows.
+
+## Prerequisites
+
+1. You have access to a uFawkesDORA ingestion API endpoint.
+2. Set `DORA_INGESTION_URL` as a [repository variable][gh-vars] in your repo:
+
+   ```
+   DORA_INGESTION_URL = https://dora-ingestion.ufawkes.dev
+   ```
+
+[gh-vars]: https://docs.github.com/en/actions/learn-github-actions/variables
+
+---
+
+## Deployment Events (10-minute wiring)
+
+Add a single job to your existing release or deploy workflow:
+
+```yaml
+emit-deployment:
+  steps:
+    - uses: paruff/uFawkesObs/dora/collectors/github/dora-deployment-event.yml@v1
+      with:
+        status: success
+        environment: production
+        pipeline_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+```
+
+That's it. Every time your workflow runs, a deployment event is sent to
+the ingestion API.
+
+### Inputs
+
+| Input                     | Required | Default                   | Description                          |
+| ------------------------- | -------- | ------------------------- | ------------------------------------ |
+| `status`                  | ✅       | —                         | `success`, `failed`, or `rollback`   |
+| `environment`             | ✅       | —                         | e.g. `production`, `staging`, `dev`  |
+| `pipeline_url`            | ✅       | —                         | Link to the CI/CD pipeline run       |
+| `service`                 | ❌       | repository name           | Service or component name            |
+| `deploy_duration_seconds` | ❌       | —                         | Total deployment duration in seconds |
+| `ai_assisted`             | ❌       | `false`                   | Whether AI tooling was involved      |
+| `ingestion_url`           | ❌       | `vars.DORA_INGESTION_URL` | Override the ingestion API URL       |
+
+---
+
+## PR Events (10-minute wiring)
+
+Add a trigger for PR merges and call the PR collector:
+
+```yaml
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  emit-pr:
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: paruff/uFawkesObs/dora/collectors/github/dora-pr-event.yml@v1
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+```
+
+The collector fetches the PR's commit timeline via the GitHub API to
+determine `first_commit_at` (the oldest commit in the PR branch).
+
+### Inputs
+
+| Input           | Required | Default                   | Description                     |
+| --------------- | -------- | ------------------------- | ------------------------------- |
+| `pr_number`     | ✅       | —                         | Pull request number             |
+| `status`        | ❌       | `merged`                  | `opened`, `merged`, or `closed` |
+| `commit_sha`    | ❌       | fetched from API          | Override merge commit SHA       |
+| `ai_assisted`   | ❌       | `false`                   | Whether AI tooling was used     |
+| `ingestion_url` | ❌       | `vars.DORA_INGESTION_URL` | Override the ingestion API URL  |
+| `repo`          | ❌       | `github.repository`       | Repository identifier           |
+
+> **Permissions note**: The PR collector requires `pull-requests: read`
+> permission to fetch the PR commit timeline. Include this in the caller
+> workflow:
+>
+> ```yaml
+> permissions:
+>   pull-requests: read
+> ```
+
+---
+
+## Testing Locally with cURL
+
+You can test that the ingestion API accepts your events without running a
+full workflow:
+
+```bash
+# Test a deployment event
+curl -X POST "${DORA_INGESTION_URL}/event" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schema_version": "1.0",
+    "event_type": "deployment",
+    "repo": "my-org/my-service",
+    "service": "my-service",
+    "environment": "production",
+    "commit_sha": "abc123def456abc123def456abc123def456abc1",
+    "deployed_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+    "status": "success",
+    "pipeline_url": "https://github.com/my-org/my-service/actions/runs/1"
+  }'
+
+# Test a PR event
+curl -X POST "${DORA_INGESTION_URL}/event" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schema_version": "1.0",
+    "event_type": "pr",
+    "repo": "my-org/my-service",
+    "pr_number": 42,
+    "commit_sha": "abc123def456abc123def456abc123def456abc1",
+    "status": "merged",
+    "occurred_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+    "first_commit_at": "'"$(date -u -d '-3 days' +%Y-%m-%dT%H:%M:%SZ)"'"
+  }'
+```
+
+---
+
+## Event Schemas
+
+Events are validated against canonical Draft-07 JSON schemas:
+
+| Schema             | File                                  |
+| ------------------ | ------------------------------------- |
+| Deployment Event   | `events/deployment-event.schema.json` |
+| Pull Request Event | `events/pr-event.schema.json`         |
+| Incident Event     | `events/incident-event.schema.json`   |
+| Rework Event       | `events/rework-event.schema.json`     |
+
+See [`events/README.md`](../../events/README.md) for the full versioning
+policy and field reference.
+
+---
+
+## Architecture
+
+```
+┌─────────────┐     ┌──────────────────────┐     ┌──────────────┐
+│  Your Repo  │────▶│  uFawkesDORA          │────▶│  TimescaleDB  │
+│  (workflow)  │     │  Ingestion API        │     │  (raw_events) │
+│              │     │  POST /event          │     │               │
+│  uses: ...   │     │  8088                 │     │  DORA metrics │
+└─────────────┘     └──────────────────────┘     └──────────────┘
+```
+
+The collectors act as adapters between GitHub webhook payloads and the
+uFawkesDORA canonical event schemas. They require no changes to your
+existing CI/CD pipelines.

--- a/dora/collectors/github/dora-deployment-event.yml
+++ b/dora/collectors/github/dora-deployment-event.yml
@@ -1,0 +1,141 @@
+# ============================================================================
+# uFawkesDORA — Deployment Event Collector (GitHub Actions)
+# ============================================================================
+#
+# Reusable workflow that emits a deployment event to the uFawkesDORA
+# ingestion API. Any repo in the fawkes suite can call this from its
+# release/deploy workflow to start tracking Deployment Frequency, Lead
+# Time, Change Failure Rate, and FDRT.
+#
+# Usage:
+#   jobs:
+#     emit-deployment:
+#       uses: paruff/uFawkesObs/dora/collectors/github/dora-deployment-event.yml@v1
+#       with:
+#         status: success
+#         environment: production
+#         pipeline_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#       secrets: inherit
+#
+# Required vars:
+#   DORA_INGESTION_URL  — URL of the uFawkesDORA ingestion API
+#                         (e.g. https://dora-ingestion.ufawkes.dev)
+#
+# Schema: deployment-event.schema.json (Draft-07)
+# ============================================================================
+
+name: "uFawkesDORA: Emit Deployment Event"
+
+on:
+  workflow_call:
+    inputs:
+      status:
+        description: "Deployment outcome: success, failed, or rollback"
+        required: true
+        type: string
+      environment:
+        description: "Target environment (e.g. production, staging, dev)"
+        required: true
+        type: string
+      pipeline_url:
+        description: "Link to the CI/CD pipeline run that performed the deployment"
+        required: true
+        type: string
+      service:
+        description: "Service or component name (defaults to repository name)"
+        required: false
+        type: string
+      deploy_duration_seconds:
+        description: "Total wall-clock time the deployment took, in seconds"
+        required: false
+        type: number
+      ai_assisted:
+        description: "Whether AI tooling was involved in the deployment process"
+        required: false
+        type: boolean
+        default: false
+      ingestion_url:
+        description: "Override DORA_INGESTION_URL (for testing/dev)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  emit-deployment:
+    name: Emit Deployment Event
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: DORA job start
+        run: |
+          echo "job-start:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "workflow:collectors/github/dora-deployment-event.yml"
+
+      - name: Build and send deployment event
+        env:
+          INGESTION_URL: ${{ inputs.ingestion_url || vars.DORA_INGESTION_URL }}
+          REPO: ${{ github.repository }}
+          SERVICE: ${{ inputs.service || github.event.repository.name || github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+          DEPLOYED_AT: ${{ github.event.head_commit.timestamp }}
+        run: |
+          set -euo pipefail
+
+          # Validate required inputs
+          if [ -z "$INGESTION_URL" ]; then
+            echo "::error::DORA_INGESTION_URL is required. Set as a repository variable or pass ingestion_url input."
+            exit 1
+          fi
+
+          # Use current UTC timestamp if head_commit timestamp not available
+          if [ -z "$DEPLOYED_AT" ]; then
+            DEPLOYED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          fi
+
+          # Build the canonical deployment event payload
+          PAYLOAD=$(cat <<EOF
+          {
+            "schema_version": "1.0",
+            "event_type": "deployment",
+            "repo": "${REPO}",
+            "service": "${SERVICE}",
+            "environment": "${{ inputs.environment }}",
+            "commit_sha": "${COMMIT_SHA}",
+            "deployed_at": "${DEPLOYED_AT}",
+            "status": "${{ inputs.status }}",
+            "pipeline_url": "${{ inputs.pipeline_url }}",
+            "ai_assisted": ${{ inputs.ai_assisted }}
+          }
+          EOF
+          )
+
+          # Add optional deploy_duration_seconds if provided
+          if [ -n "${{ inputs.deploy_duration_seconds }}" ]; then
+            PAYLOAD=$(echo "$PAYLOAD" | jq \
+              --argjson dur "${{ inputs.deploy_duration_seconds }}" \
+              '.deploy_duration_seconds = $dur')
+          fi
+
+          # POST to the ingestion API
+          echo "Sending deployment event to ${INGESTION_URL}/event ..."
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "${INGESTION_URL}/event" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_STATUS" = "201" ]; then
+            echo "✅ Deployment event accepted (HTTP 201)"
+          elif [ "$HTTP_STATUS" = "422" ]; then
+            echo "::warning::Deployment event rejected by ingestion API (HTTP 422)"
+            echo "Payload:"
+            echo "$PAYLOAD" | jq .
+          else
+            echo "::warning::Deployment event returned HTTP ${HTTP_STATUS}"
+          fi
+
+      - name: DORA job finish
+        if: always()
+        run: echo "job-finish:$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/dora/collectors/github/dora-pr-event.yml
+++ b/dora/collectors/github/dora-pr-event.yml
@@ -1,0 +1,201 @@
+# ============================================================================
+# uFawkesDORA — Pull Request Event Collector (GitHub Actions)
+# ============================================================================
+#
+# Reusable workflow that emits a pull request event to the uFawkesDORA
+# ingestion API. Designed to be called when a PR is merged — the workflow
+# fetches PR details (including first_commit_at via the GitHub API) and
+# sends a canonical pr-event to the ingestion API.
+#
+# Usage:
+#   on:
+#     pull_request:
+#       types: [closed]
+#
+#   jobs:
+#     emit-pr:
+#       if: github.event.pull_request.merged == true
+#       uses: paruff/uFawkesObs/dora/collectors/github/dora-pr-event.yml@v1
+#       with:
+#         pr_number: ${{ github.event.pull_request.number }}
+#       secrets: inherit
+#
+# Required vars:
+#   DORA_INGESTION_URL  — URL of the uFawkesDORA ingestion API
+#
+# Required permissions:
+#   pull-requests: read  (to fetch PR commits timeline)
+#   contents: read
+#
+# Schema: pr-event.schema.json (Draft-07)
+# ============================================================================
+
+name: "uFawkesDORA: Emit PR Event"
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "Pull request number"
+        required: true
+        type: number
+      status:
+        description: "PR lifecycle status (opened, merged, closed)"
+        required: false
+        type: string
+        default: "merged"
+      commit_sha:
+        description: "Override merge commit SHA (fetched from API if omitted)"
+        required: false
+        type: string
+      ai_assisted:
+        description: "Whether AI tooling was used in generating or reviewing the PR"
+        required: false
+        type: boolean
+        default: false
+      ingestion_url:
+        description: "Override DORA_INGESTION_URL (for testing/dev)"
+        required: false
+        type: string
+      repo:
+        description: "Repository identifier (defaults to github.repository)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  emit-pr-event:
+    name: Emit PR Event
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: DORA job start
+        run: |
+          echo "job-start:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "workflow:collectors/github/dora-pr-event.yml"
+          echo "pr-number:${{ inputs.pr_number }}"
+
+      - name: Fetch PR details and compute first_commit_at
+        id: pr-details
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER_REPO: ${{ inputs.repo || github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          echo "Fetching PR #${PR_NUMBER} details from ${OWNER_REPO} ..."
+
+          # Get PR details (merge_commit_sha, merged_at, title)
+          PR_JSON=$(gh api "repos/${OWNER_REPO}/pulls/${PR_NUMBER}" --jq '{
+            merge_commit_sha,
+            merged_at,
+            title,
+            head: { sha: .head.sha }
+          }')
+
+          MERGE_COMMIT_SHA=$(echo "$PR_JSON" | jq -r '.merge_commit_sha // empty')
+          MERGED_AT=$(echo "$PR_JSON" | jq -r '.merged_at // empty')
+          HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha // empty')
+
+          echo "merge_commit_sha=${MERGE_COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "merged_at=${MERGED_AT}" >> "$GITHUB_OUTPUT"
+
+          # Fetch all commits in the PR to find the oldest (first_commit_at)
+          echo "Fetching PR commits to determine first_commit_at ..."
+          COMMITS_JSON=$(gh api "repos/${OWNER_REPO}/pulls/${PR_NUMBER}/commits" --paginate --jq '
+            [.[] | { sha: .sha, date: .commit.committer.date }]
+          ')
+
+          # Find the oldest commit by date (earliest = first commit in the branch)
+          FIRST_COMMIT_AT=$(echo "$COMMITS_JSON" | jq -r '
+            sort_by(.date) | .[0].date // empty
+          ')
+
+          if [ -z "$FIRST_COMMIT_AT" ]; then
+            # Fallback: use head commit date
+            FIRST_COMMIT_AT=$(echo "$COMMITS_JSON" | jq -r '
+              .[] | select(.sha == "'"$HEAD_SHA"'") | .date // empty
+            ')
+          fi
+
+          if [ -z "$FIRST_COMMIT_AT" ]; then
+            # Last resort: use current time minus a nominal lead time
+            echo "::warning::Could not determine first_commit_at, using merged_at as fallback"
+            FIRST_COMMIT_AT="$MERGED_AT"
+          fi
+
+          echo "first_commit_at=${FIRST_COMMIT_AT}" >> "$GITHUB_OUTPUT"
+
+          echo "PR #${PR_NUMBER}: merged at ${MERGED_AT}, first commit at ${FIRST_COMMIT_AT}"
+
+      - name: Build and send PR event
+        env:
+          INGESTION_URL: ${{ inputs.ingestion_url || vars.DORA_INGESTION_URL }}
+          REPO: ${{ inputs.repo || github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          COMMIT_SHA: ${{ inputs.commit_sha || steps.pr-details.outputs.merge_commit_sha }}
+          OCCURRED_AT: ${{ steps.pr-details.outputs.merged_at }}
+          FIRST_COMMIT_AT: ${{ steps.pr-details.outputs.first_commit_at }}
+        run: |
+          set -euo pipefail
+
+          # Validate required inputs
+          if [ -z "$INGESTION_URL" ]; then
+            echo "::error::DORA_INGESTION_URL is required. Set as a repository variable or pass ingestion_url input."
+            exit 1
+          fi
+
+          if [ -z "$COMMIT_SHA" ]; then
+            echo "::error::Could not determine commit_sha for PR #${PR_NUMBER}."
+            exit 1
+          fi
+
+          # Use current timestamp if merged_at not available
+          if [ -z "$OCCURRED_AT" ]; then
+            OCCURRED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          fi
+          if [ -z "$FIRST_COMMIT_AT" ]; then
+            FIRST_COMMIT_AT="$OCCURRED_AT"
+          fi
+
+          # Build the canonical PR event payload
+          PAYLOAD=$(cat <<EOF
+          {
+            "schema_version": "1.0",
+            "event_type": "pr",
+            "repo": "${REPO}",
+            "pr_number": ${PR_NUMBER},
+            "commit_sha": "${COMMIT_SHA}",
+            "status": "${{ inputs.status }}",
+            "occurred_at": "${OCCURRED_AT}",
+            "first_commit_at": "${FIRST_COMMIT_AT}",
+            "ai_assisted": ${{ inputs.ai_assisted }}
+          }
+          EOF
+          )
+
+          # POST to the ingestion API
+          echo "Sending PR event to ${INGESTION_URL}/event ..."
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "${INGESTION_URL}/event" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_STATUS" = "201" ]; then
+            echo "✅ PR event accepted (HTTP 201)"
+          elif [ "$HTTP_STATUS" = "422" ]; then
+            echo "::warning::PR event rejected by ingestion API (HTTP 422)"
+            echo "Payload:"
+            echo "$PAYLOAD" | jq .
+          else
+            echo "::warning::PR event returned HTTP ${HTTP_STATUS}"
+          fi
+
+      - name: DORA job finish
+        if: always()
+        run: echo "job-finish:$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/dora/collectors/github/example-consumer.yml
+++ b/dora/collectors/github/example-consumer.yml
@@ -1,0 +1,60 @@
+# ============================================================================
+# uFawkesDORA — Example Consumer Workflow
+# ============================================================================
+#
+# Complete example showing how any repo in the fawkes suite wires the
+# uFawkesDORA GitHub collectors into its CI/CD pipeline.
+#
+# To use in your repo:
+#   1. Copy this file to .github/workflows/dora-events.yml
+#   2. Set DORA_INGESTION_URL as a repository variable
+#   3. Customize the deployment status trigger
+#
+# Required:
+#   vars.DORA_INGESTION_URL — e.g. https://dora-ingestion.ufawkes.dev
+# ============================================================================
+
+name: Emit DORA Events
+
+on:
+  # ── Trigger on releases (deployment events) ─────────────────────────────
+  release:
+    types: [published]
+
+  # ── Trigger on PR merges (PR events) ─────────────────────────────────────
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read # Required by dora-pr-event.yml to fetch PR commits
+
+jobs:
+  # ─── Deployment Event ────────────────────────────────────────────────────
+  emit-deployment:
+    if: github.event_name == 'release'
+    name: Emit Deployment Event
+    runs-on: ubuntu-latest
+    steps:
+      - name: Emit deployment to uFawkesDORA
+        uses: paruff/uFawkesObs/dora/collectors/github/dora-deployment-event.yml@v1
+        with:
+          status: success
+          environment: production
+          pipeline_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Optional:
+          # ai_assisted: true
+          # deploy_duration_seconds: 120
+
+  # ─── PR Event ────────────────────────────────────────────────────────────
+  emit-pr:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    name: Emit PR Event
+    runs-on: ubuntu-latest
+    steps:
+      - name: Emit PR event to uFawkesDORA
+        uses: paruff/uFawkesObs/dora/collectors/github/dora-pr-event.yml@v1
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+          # Optional:
+          # ai_assisted: true

--- a/dora/collectors/manual-incident/declare-incident.sh
+++ b/dora/collectors/manual-incident/declare-incident.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# ============================================================================
+# declare-incident.sh — uFawkesDORA Manual Incident Declaration
+# ----------------------------------------------------------------------------
+# Run this script when you are paged for a production incident to emit an
+# incident-opened event to the uFawkesDORA ingestion API.
+#
+# Usage:
+#   # Interactive mode (prompts for each field)
+#   ./declare-incident.sh
+#
+#   # Flag mode (non-interactive, for automation)
+#   ./declare-incident.sh --incident_id=INC-123 --service=my-service --severity=critical
+#
+# Environment:
+#   DORA_INGESTION_URL   Required. URL of the ingestion API (e.g. https://dora.example.com)
+#   DORA_API_KEY         Optional. API key if auth is enabled on the ingestion API
+#
+# Exit codes:
+#   0 — Incident event accepted (HTTP 201)
+#   1 — Failed (missing fields, network error, non-201 response)
+#
+# Reference: events/incident-event.schema.json
+# ============================================================================
+
+set -u
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+
+INGESTION_URL="${DORA_INGESTION_URL:-}"
+API_KEY="${DORA_API_KEY:-}"
+INCIDENT_ID=""
+SERVICE=""
+SEVERITY=""
+OCCURRED_AT=""
+
+# ── Flag parsing ────────────────────────────────────────────────────────────
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --incident_id=*)
+            INCIDENT_ID="${1#*=}"
+            ;;
+        --service=*)
+            SERVICE="${1#*=}"
+            ;;
+        --severity=*)
+            SEVERITY="${1#*=}"
+            ;;
+        --help)
+            echo "Usage: $0 [--incident_id=ID] [--service=NAME] [--severity=critical|major|minor]"
+            exit 0
+            ;;
+        *)
+            echo "[dora] ERROR: Unknown option: $1" >&2
+            echo "[dora] Usage: $0 [--incident_id=ID] [--service=NAME] [--severity=critical|major|minor]" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# ── Interactive prompts (fallback when flags are missing) ───────────────────
+
+if [ -z "$INCIDENT_ID" ]; then
+    printf "Incident ID (e.g. INC-123): "
+    read -r INCIDENT_ID
+fi
+
+if [ -z "$SERVICE" ]; then
+    printf "Service name (e.g. api-gateway): "
+    read -r SERVICE
+fi
+
+if [ -z "$SEVERITY" ]; then
+    printf "Severity (critical/major/minor) [critical]: "
+    read -r SEVERITY
+    [ -z "$SEVERITY" ] && SEVERITY="critical"
+fi
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+if [ -z "$INGESTION_URL" ]; then
+    echo "[dora] ERROR: DORA_INGESTION_URL is not set" >&2
+    echo "[dora] Set it as an environment variable or in a .env file" >&2
+    exit 1
+fi
+
+if [ -z "$INCIDENT_ID" ]; then
+    echo "[dora] ERROR: incident_id is required" >&2
+    exit 1
+fi
+
+if [ -z "$SERVICE" ]; then
+    echo "[dora] ERROR: service is required" >&2
+    exit 1
+fi
+
+# Validate severity
+case "$SEVERITY" in
+    critical|major|minor) ;;
+    *)
+        echo "[dora] ERROR: severity must be one of: critical, major, minor (got: $SEVERITY)" >&2
+        exit 1
+        ;;
+esac
+
+# ── Build payload ───────────────────────────────────────────────────────────
+
+OCCURRED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+PAYLOAD=$(cat <<EOF
+{
+  "schema_version": "1.0",
+  "event_type": "incident",
+  "repo": "unknown/${SERVICE}",
+  "service": "${SERVICE}",
+  "incident_id": "${INCIDENT_ID}",
+  "status": "opened",
+  "occurred_at": "${OCCURRED_AT}",
+  "severity": "${SEVERITY}"
+}
+EOF
+)
+
+# ── Send event ─────────────────────────────────────────────────────────────
+
+echo "[dora] Declaring incident ${INCIDENT_ID} on ${SERVICE}..."
+
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "${INGESTION_URL}/event" \
+    -H "Content-Type: application/json" \
+    ${API_KEY:+-H "Authorization: Bearer ${API_KEY}"} \
+    -d "${PAYLOAD}")
+
+if [ "${HTTP_STATUS}" = "201" ]; then
+    echo "[dora] ✅ Incident ${INCIDENT_ID} declared successfully"
+    echo "[dora]    Service: ${SERVICE}"
+    echo "[dora]    Severity: ${SEVERITY}"
+    echo "[dora]    Occurred at: ${OCCURRED_AT}"
+    echo "[dora]    API: ${INGESTION_URL}/event"
+    exit 0
+else
+    echo "[dora] ❌ Failed to declare incident (HTTP ${HTTP_STATUS})" >&2
+    echo "[dora]    Check DORA_INGESTION_URL and network connectivity" >&2
+    exit 1
+fi

--- a/dora/collectors/manual-incident/resolve-incident.sh
+++ b/dora/collectors/manual-incident/resolve-incident.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+# ============================================================================
+# resolve-incident.sh — uFawkesDORA Manual Incident Resolution
+# ----------------------------------------------------------------------------
+# Run this script when an incident has been resolved to emit an
+# incident-resolved event to the uFawkesDORA ingestion API.
+#
+# This is needed for FDRT (Failure Deployment Recovery Time) calculation.
+# FDRT measures the gap between incident-opened and incident-resolved.
+#
+# Usage:
+#   # Interactive mode
+#   ./resolve-incident.sh
+#
+#   # Flag mode
+#   ./resolve-incident.sh --incident_id=INC-123
+#
+# Environment:
+#   DORA_INGESTION_URL   Required. URL of the ingestion API
+#   DORA_API_KEY         Optional. API key if auth is enabled
+#
+# Exit codes:
+#   0 — Resolution event accepted (HTTP 201)
+#   1 — Failed (missing fields, network error, non-201 response)
+#
+# Reference: events/incident-event.schema.json
+# ============================================================================
+
+set -u
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+
+INGESTION_URL="${DORA_INGESTION_URL:-}"
+API_KEY="${DORA_API_KEY:-}"
+INCIDENT_ID=""
+SERVICE=""
+SEVERITY=""
+
+# ── Flag parsing ────────────────────────────────────────────────────────────
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --incident_id=*)
+            INCIDENT_ID="${1#*=}"
+            ;;
+        --service=*)
+            SERVICE="${1#*=}"
+            ;;
+        --severity=*)
+            SEVERITY="${1#*=}"
+            ;;
+        --help)
+            echo "Usage: $0 --incident_id=ID [--service=NAME] [--severity=LEVEL]"
+            exit 0
+            ;;
+        *)
+            echo "[dora] ERROR: Unknown option: $1" >&2
+            echo "[dora] Usage: $0 --incident_id=ID [--service=NAME] [--severity=LEVEL]" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# ── Interactive prompts ─────────────────────────────────────────────────────
+
+if [ -z "$INCIDENT_ID" ]; then
+    printf "Incident ID to resolve (e.g. INC-123): "
+    read -r INCIDENT_ID
+fi
+
+if [ -z "$SERVICE" ]; then
+    printf "Service name (e.g. api-gateway) [unknown]: "
+    read -r SERVICE
+    [ -z "$SERVICE" ] && SERVICE="unknown"
+fi
+
+if [ -z "$SEVERITY" ]; then
+    printf "Severity (critical/major/minor) [critical]: "
+    read -r SEVERITY
+    [ -z "$SEVERITY" ] && SEVERITY="critical"
+fi
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+if [ -z "$INGESTION_URL" ]; then
+    echo "[dora] ERROR: DORA_INGESTION_URL is not set" >&2
+    echo "[dora] Set it as an environment variable or in a .env file" >&2
+    exit 1
+fi
+
+if [ -z "$INCIDENT_ID" ]; then
+    echo "[dora] ERROR: incident_id is required" >&2
+    exit 1
+fi
+
+case "$SEVERITY" in
+    critical|major|minor) ;;
+    *)
+        echo "[dora] ERROR: severity must be one of: critical, major, minor (got: $SEVERITY)" >&2
+        exit 1
+        ;;
+esac
+
+# ── Build payload ───────────────────────────────────────────────────────────
+
+OCCURRED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+PAYLOAD=$(cat <<EOF
+{
+  "schema_version": "1.0",
+  "event_type": "incident",
+  "repo": "unknown/${SERVICE}",
+  "service": "${SERVICE}",
+  "incident_id": "${INCIDENT_ID}",
+  "status": "resolved",
+  "occurred_at": "${OCCURRED_AT}",
+  "severity": "${SEVERITY}"
+}
+EOF
+)
+
+# ── Send event ─────────────────────────────────────────────────────────────
+
+echo "[dora] Resolving incident ${INCIDENT_ID}..."
+
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "${INGESTION_URL}/event" \
+    -H "Content-Type: application/json" \
+    ${API_KEY:+-H "Authorization: Bearer ${API_KEY}"} \
+    -d "${PAYLOAD}")
+
+if [ "${HTTP_STATUS}" = "201" ]; then
+    echo "[dora] ✅ Incident ${INCIDENT_ID} resolved successfully"
+    echo "[dora]    Service: ${SERVICE}"
+    echo "[dora]    Occurred at: ${OCCURRED_AT}"
+    echo "[dora]    API: ${INGESTION_URL}/event"
+    exit 0
+else
+    echo "[dora] ❌ Failed to resolve incident (HTTP ${HTTP_STATUS})" >&2
+    echo "[dora]    Check DORA_INGESTION_URL and network connectivity" >&2
+    exit 1
+fi

--- a/dora/collectors/woodpecker/pipeline-snippet.yml
+++ b/dora/collectors/woodpecker/pipeline-snippet.yml
@@ -1,0 +1,59 @@
+# ============================================================================
+# Woodpecker CI Pipeline Snippet — uFawkesDORA Deployment Event
+# ----------------------------------------------------------------------------
+# Include this step in your Woodpecker pipeline to emit a deployment event
+# to the uFawkesDORA ingestion API on pipeline success or failure.
+#
+# Usage:
+#   1. Add secrets in your Woodpecker repo settings:
+#      - dora_ingestion_url  (e.g. https://dora.example.com)
+#      - dora_api_key        (optional, if auth is enabled)
+#   2. Copy this snippet into your .woodpecker/*.yml
+#   3. The step runs on every push/tag/deployment automatically
+#
+# Reference: https://woodpecker-ci.org/docs/usage/secrets
+# ============================================================================
+
+steps:
+  notify-dora:
+    image: curlimages/curl:latest
+    pull: true
+    commands:
+      # Build JSON payload from Woodpecker CI environment variables.
+      # Uses a heredoc to avoid shell quoting issues in the JSON body.
+      - |
+        PAYLOAD=$(cat <<EOF
+        {
+          "schema_version": "1.0",
+          "event_type": "deployment",
+          "repo": "${CI_REPO}",
+          "service": "${CI_REPO_NAME}",
+          "environment": "production",
+          "commit_sha": "${CI_COMMIT_SHA}",
+          "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+          "status": "${CI_PIPELINE_STATUS}",
+          "pipeline_url": "${CI_PIPELINE_URL}",
+          "source": "woodpecker"
+        }
+        EOF
+        )
+      - |
+        HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+          -X POST "${DORA_INGESTION_URL}/event" \
+          -H "Content-Type: application/json" \
+          ${DORA_API_KEY:+-H "Authorization: Bearer ${DORA_API_KEY}"} \
+          -d "${PAYLOAD}")
+      - |
+        if [ "${HTTP_STATUS}" != "201" ]; then
+          echo "[dora] WARNING: deployment event returned ${HTTP_STATUS} (expected 201)" >&2
+        else
+          echo "[dora] deployment event accepted (${HTTP_STATUS})"
+        fi
+    environment:
+      DORA_INGESTION_URL:
+        from_secret: dora_ingestion_url # pragma: allowlist secret
+      DORA_API_KEY:
+        from_secret: dora_api_key # pragma: allowlist secret
+    when:
+      - event: [push, tag, deployment]
+        status: [success, failure]


### PR DESCRIPTION
## Summary

- Copies `collectors/{generic,github,manual-incident,woodpecker}` from uFawkesDORA (`origin/main`) into `dora/collectors/` as part of the DORA consolidation (ADR-007, partial #208).
- Updates GitHub Actions `uses:` references from `paruff/ufawkesdora/...` to `paruff/uFawkesObs/dora/collectors/github/...` so the example workflows point at the new location instead of a repo that's slated for archival.
- **Scope note:** this PR covers only the collector-move half of #208. The "archive uFawkesDORA repo with deprecation README" half is a separate, cross-repo, hard-to-reverse action and will be done as its own follow-up after explicit sign-off — not bundled here.

## AI-Assisted Review Block

**What does this PR do?**
Merges uFawkesDORA's `collectors/` patterns into `dora/collectors/` in uFawkesObs, per DORA-CONSOLIDATION-08 (collector-move portion only).

**What could go wrong?**
Low risk — no compose/config/code paths touched, just new example files. `shellcheck` passes cleanly on the two `.sh` scripts. One pre-existing path inconsistency in the original repo (one comment referenced `.github/workflows/...` instead of `collectors/github/...`) was normalized to match the actual new location.

**What tests cover this change?**
None needed — these are documentation/example collector patterns (curl examples, shell scripts, GitHub Actions snippets), not executable production code paths.

**Architecture check:**
- What layer(s) touched, and is that correct per §4? `dora/collectors/` — new directory, not previously covered by §4's compose/scripts/tests/dashboards rules. The two `.sh` files use `#!/bin/sh` (pre-existing from uFawkesDORA, left unchanged) rather than `set -euo pipefail`; not rewritten since they're copy-paste consumer examples, not scripts this repo executes.
- Any cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDORA)? Yes — uFawkesDORA remains the copy source until archived; consumers currently pointing at `paruff/ufawkesdora/collectors/github/...@v1` will need to switch to the new `paruff/uFawkesObs/dora/collectors/github/...@v1` path once uFawkesDORA is archived.

**What I was NOT sure about:**
Whether to also rewrite the prose "uFawkesDORA ingestion API" references throughout these files to just "the DORA ingestion API" — left as-is since that's a larger, separate copyedit not requested by this issue.