### PR TITLE
fix(dora): rename resource-plan to resource-plane, drop stale uFawkesDORA dep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ headings, update `review.md`'s check to match.
 
 **Architecture check:**
 - What layer(s) were touched and are they correct per §4?
-- Any cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDORA)?
+- Any cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDevX)?
 
 **What I was NOT sure about:**
 [...]
@@ -226,8 +226,9 @@ See `docs/KNOWN_LIMITATIONS.md` — known issues across storage, networking, pro
 uFawkesObs is part of the **uFawkesAI** suite and the **Fawkes IDP** ecosystem.
 
 **Depends on:**
-- **uFawkesRes** — Shared PostgreSQL for DORA metric snapshots (`datasources.yaml` UID: `ufawkesres-postgres`)
-- **uFawkesDORA** — DORA compute engine consuming OTel spans via `otel-collector-dora` profile
+- **uFawkesRes** — Shared PostgreSQL for DORA metric snapshots (`datasources.yaml` UID: `ufawkesres-postgres`), used only when the `resource-plane` profile is active; the `dora` profile is self-contained (SQLite) by default
+
+Note: uFawkesDORA (the standalone repo) is archived — its collector patterns, spec, and design docs were merged into this repo's `dora/` directory (see `feat/dora-consolidation-*` history). DORA compute and ingestion now live in uFawkesObs itself, not as an external dependency.
 
 **Depended on by:**
 - **uFawkesPipe** — Pipeline lifecycle telemetry flows into uFawkesObs Tempo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   FDRT, and DORA-2026's 5th metric — rework rate) with paired alert rules, and
   a provisioned Grafana DORA metrics dashboard (issues #80-83, #51-53; PR #147,
   #148, #154, #149/#155)
-- **`dora` profile is now self-contained by default (SQLite-backed)**: `dora-api` and `dora-compute` store events in a local SQLite file under `./data/dora` with no external database required, matching the same metric math as the Postgres backend. A new `resource-plan` profile plus `compose.resource-plan.override.yaml` swaps in the shared uFawkesRes Postgres instance instead (`make up-dora-resource-plan`), gated behind `DORA_POSTGRES_URL`. See AGENTS.md §10.
+- **`dora` profile is now self-contained by default (SQLite-backed)**: `dora-api` and `dora-compute` store events in a local SQLite file under `./data/dora` with no external database required, matching the same metric math as the Postgres backend. A new `resource-plane` profile plus `compose.resource-plane.override.yaml` swaps in the shared uFawkesRes Postgres instance instead (`make up-dora-resource-plane`), gated behind `DORA_POSTGRES_URL`. See AGENTS.md §10.
 - **Acceptance test suite**: BDD-style acceptance tests across 7 phases (SLOs,
   synthetic workload generators, chaos/failure-injection scenarios, evidence
   capture, CI integration) plus a nightly chaos test workflow

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help init check-env up up-apps up-dora up-dora-resource-plan down logs status test-unit test-acceptance test-acceptance-smoke test-acceptance-full install-acceptance-deps test pr
+.PHONY: help init check-env up up-apps up-dora up-dora-resource-plane down logs status test-unit test-acceptance test-acceptance-smoke test-acceptance-full install-acceptance-deps test pr
 
 # Grafana runs as UID 472
 GRAFANA_UID := 472
@@ -49,10 +49,10 @@ up-apps: check-env
 up-dora: check-env
 	docker compose --profile core --profile dora up -d
 
-## up-dora-resource-plan: start core + DORA metrics backed by shared uFawkesRes Postgres
-up-dora-resource-plan: check-env
-	docker compose --profile core --profile dora --profile resource-plan \
-		-f compose.yaml -f compose.resource-plan.override.yaml up -d
+## up-dora-resource-plane: start core + DORA metrics backed by shared uFawkesRes Postgres
+up-dora-resource-plane: check-env
+	docker compose --profile core --profile dora --profile resource-plane \
+		-f compose.yaml -f compose.resource-plane.override.yaml up -d
 
 ## down: stop all services
 down:

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The system uses Docker Compose profiles to control which services run:
 | `apps`  | telemetry-generator                                                   | Demo telemetry generator |
 | `notifications` | alertmanager-discord                                          | Slack/Discord notification bridge (needs `DISCORD_WEBHOOK_URL` in `.env`) |
 | `dora` | dora-api, dora-compute, pushgateway, otel-collector-dora | DORA metrics — self-contained, SQLite-backed by default |
-| `resource-plan` | dora-db-init | Swaps the `dora` profile's SQLite backend for shared uFawkesRes Postgres |
+| `resource-plane` | dora-db-init | Swaps the `dora` profile's SQLite backend for shared uFawkesRes Postgres |
 
 **To start with a specific profile:**
 
@@ -205,7 +205,7 @@ make up-dora
 
 # Same, but backed by the shared uFawkesRes Postgres instance instead of
 # SQLite — requires DORA_POSTGRES_URL in .env (see .env.example):
-make up-dora-resource-plan
+make up-dora-resource-plane
 ```
 
 ---

--- a/compose.resource-plane.override.yaml
+++ b/compose.resource-plane.override.yaml
@@ -1,8 +1,8 @@
-# compose.resource-plan.override.yaml
+# compose.resource-plane.override.yaml
 #
 # Switches the `dora` profile from its default self-contained SQLite backend
 # to the shared uFawkesRes Postgres instance (AGENTS.md §10). Requires
-# DORA_POSTGRES_URL in .env (see .env.example) and the `resource-plan`
+# DORA_POSTGRES_URL in .env (see .env.example) and the `resource-plane`
 # profile activated alongside `dora`, so dora-db-init's migration job runs
 # before dora-api/dora-compute start.
 #
@@ -12,8 +12,8 @@
 # inherited unchanged from compose.yaml.
 #
 # Usage:
-#   docker compose --profile core --profile dora --profile resource-plan \
-#     -f compose.yaml -f compose.resource-plan.override.yaml up -d
+#   docker compose --profile core --profile dora --profile resource-plane \
+#     -f compose.yaml -f compose.resource-plane.override.yaml up -d
 
 services:
   dora-api:

--- a/compose.yaml
+++ b/compose.yaml
@@ -525,7 +525,7 @@ services:
       - observability
     profiles: ["core"]
 
-# DORA database migration (resource-plan profile only) — one-shot job that
+# DORA database migration (resource-plane profile only) — one-shot job that
 # applies dora/database/*.sql against the existing DORA_POSTGRES_URL database
 # (owned by uFawkesRes; see AGENTS.md §10). Not needed for the base `dora`
 # profile, which is self-contained SQLite by default — see
@@ -555,12 +555,12 @@ services:
       - "profile=dora"
     networks:
       - observability
-    profiles: ["resource-plan"]
+    profiles: ["resource-plane"]
 
 # DORA event ingestion API — accepts events from CI/CD systems, validates against
 # the dora/events schemas, and enqueues to SQLite by default (dora profile,
 # self-contained) or uFawkesRes Postgres when DATABASE_URL is overridden
-# (resource-plan profile — see compose.resource-plan.yaml)
+# (resource-plane profile — see compose.resource-plane.override.yaml)
   dora-api:
     build:
       context: .
@@ -659,7 +659,7 @@ services:
     profiles: ["dora"]
 
 # DORA metrics compute — periodic batch job computing DORA metrics from
-# SQLite by default (dora profile) or DORA_POSTGRES_URL (resource-plan
+# SQLite by default (dora profile) or DORA_POSTGRES_URL (resource-plane
 # profile), pushing results to pushgateway (issue #205; metrics.py is a
 # one-shot CLI, so run.sh loops it — see ADR-007 amendment).
   dora-compute:

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -166,6 +166,32 @@ file is gitignored and will not be committed.
 
 ---
 
+### Duplicate Dashboard Provisioning Path (Legacy Provider)
+
+**Limitation:** Two Grafana dashboard provisioning mechanisms run side by side:
+`config/grafana/provisioning/dashboards/new-dashboards.yaml` provisions
+`dashboards/platform/` and `dashboards/services/` (the structure AGENTS.md §4
+mandates), while `config/grafana/provisioning/dashboards/dashboards.yaml` — a
+provider literally named `"legacy"` — separately provisions 8 JSON files from
+`config/grafana/dashboards/` into an "Application" folder. The legacy
+provisioner was deliberately restored after an earlier attempt to remove it
+(commit `9df6428`), so it is live, not dead code — but it means dashboard
+JSON lives in two directories under two different conventions (UID naming,
+`dashboards/` layout) instead of one.
+
+**Impact:** Contributors adding a dashboard must know which of the two
+mechanisms applies; the "Application" folder's dashboards don't follow the
+`ufawkesobs-<slug>` UID convention AGENTS.md §4 requires for platform
+dashboards.
+
+**Workaround:** None yet. Consolidating `config/grafana/dashboards/*.json`
+into `dashboards/platform/` or `dashboards/services/` (renaming UIDs to the
+`ufawkesobs-<slug>` convention and updating any cross-dashboard links) and
+removing the legacy provisioner is tracked as follow-up work, not yet
+scheduled.
+
+---
+
 ### Dashboard UIDs Must Be Stable
 
 **Limitation:** Cross-dashboard links use UIDs. If a dashboard is re-imported with a

--- a/dora/compute/metrics_db_postgres.py
+++ b/dora/compute/metrics_db_postgres.py
@@ -1,7 +1,7 @@
 """Postgres/TimescaleDB-backed metric queries (asyncpg).
 
 Selected via metrics.py when DATABASE_URL points at Postgres
-(resource-plan / suite mode). See metrics_db_sqlite.py for the default
+(resource-plane / suite mode). See metrics_db_sqlite.py for the default
 self-contained local backend.
 """
 

--- a/dora/compute/metrics_db_sqlite.py
+++ b/dora/compute/metrics_db_sqlite.py
@@ -5,7 +5,7 @@ dependencies. Selected via metrics.py when DATABASE_URL is unset or points at
 SQLite. Postgres computes percentiles and gaps in SQL (percentile_cont,
 LEAD() OVER); SQLite has neither, so this module fetches the raw rows and
 reimplements the same math in Python, returning identical result shapes.
-See metrics_db_postgres.py for the resource-plan / suite-mode backend.
+See metrics_db_postgres.py for the resource-plane / suite-mode backend.
 """
 
 import json

--- a/dora/ingestion/api/queue.py
+++ b/dora/ingestion/api/queue.py
@@ -1,7 +1,7 @@
 """Backend-selecting facade for event_queue operations.
 
 SQLite is the default (self-contained ``dora`` profile). Set DATABASE_URL to
-a postgresql:// DSN to use the resource-plan / suite-mode Postgres backend
+a postgresql:// DSN to use the resource-plane / suite-mode Postgres backend
 instead. main.py and worker.py import from here so they need no changes
 regardless of backend.
 """

--- a/dora/ingestion/api/queue_postgres.py
+++ b/dora/ingestion/api/queue_postgres.py
@@ -2,7 +2,7 @@
 
 Uses asyncpg for connection pooling and the SKIP LOCKED pattern for
 worker-safe dequeueing. Selected via queue.py when DATABASE_URL points at
-Postgres (resource-plan / suite mode). See queue_sqlite.py for the default
+Postgres (resource-plane / suite mode). See queue_sqlite.py for the default
 self-contained local backend.
 """
 

--- a/dora/ingestion/api/queue_sqlite.py
+++ b/dora/ingestion/api/queue_sqlite.py
@@ -5,7 +5,7 @@ dependencies. Selected via queue.py when DATABASE_URL is unset or points at
 SQLite. Runs as a single shared connection since the worker loop executes
 in-process inside dora-api (see main.py's lifespan), so there is no
 multi-writer contention to guard against with row locking. See
-queue_postgres.py for the resource-plan / suite-mode backend.
+queue_postgres.py for the resource-plane / suite-mode backend.
 """
 
 import json

--- a/tests/unit/test_dora_consolidation.py
+++ b/tests/unit/test_dora_consolidation.py
@@ -231,10 +231,10 @@ class TestComposeDoraDbInit:
             "dora-db-init must mount ./dora/database into /migrations"
         )
 
-    def test_resource_plan_profile(self, compose_data: dict) -> None:
+    def test_resource_plane_profile(self, compose_data: dict) -> None:
         svc = compose_data["services"]["dora-db-init"]
-        assert "resource-plan" in svc.get("profiles", []), (
-            "dora-db-init must be gated behind the resource-plan profile"
+        assert "resource-plane" in svc.get("profiles", []), (
+            "dora-db-init must be gated behind the resource-plane profile"
         )
         assert "dora" not in svc.get("profiles", []), (
             "dora-db-init must not run in the base dora profile (SQLite-only)"
@@ -256,18 +256,18 @@ class TestComposeDoraDbInit:
     def test_dora_api_no_migration_dependency_by_default(self, dora_api: dict) -> None:
         assert "dora-db-init" not in dora_api.get("depends_on", {}), (
             "dora-api must not depend on dora-db-init in the base dora profile "
-            "— only compose.resource-plan.override.yaml adds that dependency"
+            "— only compose.resource-plane.override.yaml adds that dependency"
         )
 
 
 # ---------------------------------------------------------------------------
-# compose.resource-plan.override.yaml — Postgres backend for the dora profile
+# compose.resource-plane.override.yaml — Postgres backend for the dora profile
 # ---------------------------------------------------------------------------
 @pytest.fixture(scope="module")
 def override_data() -> dict:
-    """Return the parsed compose.resource-plan.override.yaml document."""
-    path = REPO_ROOT / "compose.resource-plan.override.yaml"
-    assert path.exists(), "compose.resource-plan.override.yaml not found"
+    """Return the parsed compose.resource-plane.override.yaml document."""
+    path = REPO_ROOT / "compose.resource-plane.override.yaml"
+    assert path.exists(), "compose.resource-plane.override.yaml not found"
     with open(path, encoding="utf-8") as fh:
         return yaml.safe_load(fh)
 
@@ -383,7 +383,7 @@ class TestComposeDoraCompute:
         svc = compose_data["services"]["dora-compute"]
         assert "dora-db-init" not in svc.get("depends_on", {}), (
             "dora-compute must not depend on dora-db-init in the base dora "
-            "profile — only compose.resource-plan.override.yaml adds that"
+            "profile — only compose.resource-plane.override.yaml adds that"
         )
 
     def test_pushgateway_url_points_at_pushgateway_service(

--- a/tests/unit/test_dora_metrics_postgres.py
+++ b/tests/unit/test_dora_metrics_postgres.py
@@ -1,7 +1,7 @@
 """Unit tests for compute/metrics_db_postgres.py.
 
 Covers the Postgres/asyncpg-backed MetricsDB implementation used when
-DATABASE_URL points at Postgres (resource-plan / suite mode). See
+DATABASE_URL points at Postgres (resource-plane / suite mode). See
 test_dora_metrics.py for the backend-agnostic orchestration tests and
 test_dora_metrics_sqlite.py for the SQLite backend.
 """


### PR DESCRIPTION
## Summary

This is the follow-up commit from PR #220 that didn't make it into `main` — PR #220 merged the branch tip at `d4558b7`, but this fix commit (`resource-plane` rename + stale `AGENTS.md` dependency removal) was pushed a few minutes later and got stranded on the already-merged branch. Rebasing it onto current `main` and re-opening as its own PR.

- Renames `resource-plan` → `resource-plane` everywhere (compose profile, `compose.resource-plane.override.yaml`, `make up-dora-resource-plane`, docs, tests, docstrings) — "Resource Plane" is this suite's established term for uFawkesRes (`docs/product/design.md`), not "resource plan".
- Removes a stale `AGENTS.md` §7/§10 dependency on **uFawkesDORA**: that repo is archived on GitHub; its collector/spec/design content was merged into this repo's `dora/` directory during `feat/dora-consolidation-*`. uFawkesObs is no longer dependent on it as a separate repo.
- Documents (does not fix) the `config/grafana/dashboards/` "legacy" provisioner duplication as a tracked gap in `docs/KNOWN_LIMITATIONS.md`.

## AI-Assisted Review Block

**What does this PR do?**
Corrects a naming mistake from PR #220 (`resource-plan` → `resource-plane`) and removes a stale suite-dependency reference now that uFawkesDORA's content lives in this repo.

**What could go wrong?**
Purely a rename/doc fix — no runtime behavior change. Risk is a missed reference to the old `resource-plan` name; verified via `git grep` that none remain and `docker compose ... config` still resolves cleanly with the renamed profile/file.

**What tests cover this change?**
`tests/unit/test_dora_consolidation.py` (renamed `test_resource_plane_profile`, updated override-file path assertions) plus the full DORA unit suite — 124 passed. `docker compose --profile core --profile dora --profile resource-plane -f compose.yaml -f compose.resource-plane.override.yaml config` validated locally.

**Architecture check:**
- Touches `compose.yaml` (profile/service naming), `Makefile`/`README.md`/`CHANGELOG.md` (docs), `dora/` Python docstrings, and `AGENTS.md`/`docs/KNOWN_LIMITATIONS.md` (governance docs) — no service/architecture change, per AGENTS.md §4.
- Cross-plane impact: none — corrects documentation to reflect that uFawkesDORA is no longer a separate suite member.

**What I was NOT sure about:**
Nothing outstanding — this is a straightforward rename/doc correction.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass
- [x] `docker compose ... config` validated for `dora` and `dora + resource-plane` profiles
- [x] `pytest tests/unit/test_dora_consolidation.py tests/unit/test_dora_queue_sqlite.py tests/unit/test_dora_metrics_sqlite.py tests/unit/test_dora_queue_postgres.py tests/unit/test_dora_metrics_postgres.py` — 124 passed
- [x] PR size: 61+/34- (14 files) — well under the 400-line gate, no label needed