### PR TITLE
fix(dora): stop dora-db-init from breaking compose parsing without resource-plan

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -538,7 +538,7 @@ services:
     container_name: ufawkesdora-db-init
     restart: "no"
     environment:
-      - DORA_POSTGRES_URL=${DORA_POSTGRES_URL:?Set DORA_POSTGRES_URL in .env (see .env.example) — no credential default is provided in compose.yaml}
+      - DORA_POSTGRES_URL=${DORA_POSTGRES_URL:-}
     volumes:
       - ./dora/database:/migrations:ro
     entrypoint: ["/bin/sh", "/migrations/migrate.sh"]

--- a/tests/unit/test_dora_consolidation.py
+++ b/tests/unit/test_dora_consolidation.py
@@ -259,6 +259,39 @@ class TestComposeDoraDbInit:
             "— only compose.resource-plan.override.yaml adds that dependency"
         )
 
+    def test_database_url_not_required_at_compose_parse_time(
+        self, compose_data: dict
+    ) -> None:
+        """Regression test for the 2026-08-17 Chaos Nightly outage: Docker
+        Compose evaluates ``${VAR:?...}`` required-variable interpolation for
+        every service in the file at parse time, regardless of which
+        --profile flags are active. dora-db-init previously hard-required
+        DORA_POSTGRES_URL this way, which broke `--profile core`-only
+        invocations even though dora-db-init never runs outside the
+        resource-plane profile. The required-var check belongs in
+        dora/database/migrate.sh (see test_migrate_sh_still_requires_url
+        below), which only executes when the container actually starts.
+        """
+        svc = compose_data["services"]["dora-db-init"]
+        env = svc.get("environment", [])
+        entry = next(e for e in env if e.startswith("DORA_POSTGRES_URL="))
+        assert ":?" not in entry, (
+            "dora-db-init's DORA_POSTGRES_URL must use a soft default (:-), "
+            "not required (:?) interpolation — see docstring for why"
+        )
+
+    def test_migrate_sh_still_requires_url(self) -> None:
+        """dora-db-init's compose.yaml env var is a soft default (see test
+        above) precisely because dora/database/migrate.sh enforces the
+        actual requirement at container-start time — this test guards that
+        the fail-closed check doesn't silently disappear from both places.
+        """
+        migrate_sh = (DORA_DIR / "database" / "migrate.sh").read_text()
+        assert "DORA_POSTGRES_URL:?" in migrate_sh, (
+            "migrate.sh must still hard-require DORA_POSTGRES_URL at "
+            "container start, now that compose.yaml no longer does"
+        )
+
 
 # ---------------------------------------------------------------------------
 # compose.resource-plan.override.yaml — Postgres backend for the dora profile


### PR DESCRIPTION
## Summary

Fixes the **Chaos Nightly** workflow, which has failed every night since 2026-08-15 (annotation: `error while interpolating services.dora-db-init.environment.[]: required variable DORA_POSTGRES_URL is missing a value`).

## Root cause

`dora-db-init`'s `DORA_POSTGRES_URL` env var used required (`:?`) interpolation. Docker Compose evaluates `${VAR:?...}` for **every service in the file at parse time**, regardless of which `--profile` flags are active — it's not profile-aware. So `docker compose --profile core up` (Chaos Nightly's exact invocation, no `resource-plan` profile) failed before any container even started, even though `dora-db-init` is gated behind `profiles: ["resource-plan"]` and never actually runs in that invocation.

Confirmed by reproducing locally:
```
$ docker compose --profile core -f compose.yaml --env-file /dev/null config -q
error while interpolating services.dora-db-init.environment.[]: required variable DORA_POSTGRES_URL is missing a value...
```

Three other workflows (`ci-acceptance-full.yml`, `ci-acceptance-smoke.yml`, `ci-tests.yml`) already work around this exact issue by injecting a dummy `DORA_POSTGRES_URL: postgresql://ci-unused:...` — `ci-chaos-nightly.yml` is simply missing that same copy-pasted workaround. Rather than add a fourth copy of the same patch (which just defers the next incident to workflow #5), this fixes the actual root cause.

## Fix

`dora-db-init`'s `DORA_POSTGRES_URL` now uses a soft default (`${DORA_POSTGRES_URL:-}`) instead of hard-required (`:?`). The fail-closed guarantee isn't lost — `dora/database/migrate.sh:11` already has its own `: "${DORA_POSTGRES_URL:?...}"` check that runs at container start, and that only executes when `dora-db-init` actually runs (i.e., when the `resource-plane`/`resource-plan` profile is active). The requirement now lives exactly where it's needed instead of blocking every compose invocation regardless of profile.

## AI-Assisted Review Block

**What does this PR do?**
Root-causes and fixes the Chaos Nightly outage: moves DORA_POSTGRES_URL's required-variable check from compose-parse time (profile-unaware) to container-start time (profile-aware), where it already existed redundantly.

**What could go wrong?**
None identified — verified locally that (1) `--profile core` alone now parses cleanly with no env set, (2) the full `dora + resource-plane` profile combo still parses cleanly with the var set, and (3) `dora-db-init` still fails loudly via `migrate.sh` if it's ever actually started without `DORA_POSTGRES_URL`. The existing dummy-value workarounds in the other three workflows become unnecessary but are left in place (out of scope for this fix, harmless to leave).

**What tests cover this change?**
Added `test_database_url_not_required_at_compose_parse_time` (regression test pinning the fix) and `test_migrate_sh_still_requires_url` (guards the runtime check doesn't disappear too) to `tests/unit/test_dora_consolidation.py`. Full suite: 79 passed.

**Architecture check:**
- Touches only `compose.yaml` (one line) and its test coverage — no service/dependency changes, per AGENTS.md §4.
- No cross-plane impact — `dora-db-init` behavior when it actually runs (resource-plane profile, DORA_POSTGRES_URL set) is unchanged.

**What I was NOT sure about:**
Whether to also strip the now-redundant dummy `DORA_POSTGRES_URL` env vars from the three workflows that were working around this. Left them in place since they're harmless and out of scope for an urgent CI fix — happy to clean up separately if wanted.

## Test plan

- [x] Reproduced the exact CI failure locally (`docker compose --profile core --env-file /dev/null config -q`), confirmed it's fixed
- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pytest tests/unit/test_dora_consolidation.py` — 79 passed (2 new)
- [x] Manually triggered Chaos Nightly against current `main` (pre-fix) to confirm this exact failure reproduces in CI: https://github.com/paruff/uFawkesObs/actions/runs/32028450988
- [ ] Re-trigger Chaos Nightly against this branch/PR merge to confirm the fix in CI (recommend before/after merge)