### PR TITLE
docs: link CONTRIBUTING.md from README instead of placeholder text

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,9 @@ This project follows these principles:
 
 ## Contributing
 
-[Add contribution guidelines here]
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to report bugs, suggest
+features, and submit pull requests (branch naming, test requirements, and
+PR description format).
 
 ## uFawkes Stack Ecosystem
 


### PR DESCRIPTION
## Summary

Task 5 of the suite-alignment brief: quick cleanup, independent of the other tasks.

The README's Contributing section had a literal `[Add contribution guidelines here]` placeholder despite `CONTRIBUTING.md` already existing with real bug-report, feature-request, and PR submission guidelines (branch naming, test requirements, PR description format).

## What was verified vs. assumed

Verified: `CONTRIBUTING.md` exists and its content directly answers what the README section was missing (reporting bugs, suggesting features, submitting PRs). No assumptions made.

## Open questions

None — this is a one-line, unambiguous fix.