### PR TITLE
docs: add uFawkesDojo, fix stale DORA/Sec family table entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,17 @@ uFawkesObs is the **observability plane** in the [Fawkes IDP](https://github.com
 | Plane | Role | Repository |
 |---|---|---|
 | **uFawkesObs** | Observability — metrics, logs, traces, dashboards | [GitHub](https://github.com/paruff/uFawkesObs) |
+<!-- uFawkesRes status unresolved — see docs/notes/res-status.md, do not edit this row pending a product-tier decision -->
 | **uFawkesRes** | Resources — ingress, SSO, Postgres, Valkey | [GitHub](https://github.com/paruff/uFawkesRes) |
 | **uFawkesPipe** | CI/CD — pipeline orchestration, deployment events | [GitHub](https://github.com/paruff/ufawkespipe) |
 | **uFawkesDevX** | Developer experience — golden paths, IDP templates | [GitHub](https://github.com/paruff/ufawkesdevx) |
-| **uFawkesDORA** | DORA metrics — dashboards, VSM, delivery performance | [GitHub](https://github.com/paruff/ufawkesdora) |
-| **uFawkesSec** | Security — policy-as-code, supply chain, guardrails | [GitHub](https://github.com/paruff/ufawkessec) |
+| **uFawkesDojo** | Learning — belt-level curriculum for uFawkes and Fawkes | [GitHub](https://github.com/paruff/uFawkesDojo) |
 | **uFawkesAI** | AI agent templates — golden path scaffolding | [GitHub](https://github.com/paruff/ufawkesai) |
+
+**Merged into other planes** (no longer standalone repos):
+
+- **DORA metrics** — was uFawkesDORA; merged into uFawkesObs's `dora/` directory. [uFawkesDORA](https://github.com/paruff/ufawkesdora) is archived. See `AGENTS.md` §10.
+- **Security — policy-as-code, supply chain, guardrails** — was uFawkesSec; merged into uFawkesPipe's `security` Compose profile (DefectDojo, Infisical, Trivy server, Falco). Per uFawkesPipe's README, this is "formerly the standalone uFawkesSec repo." Note: unlike uFawkesDORA, the [uFawkesSec](https://github.com/paruff/ufawkessec) repo itself has not been archived as of this writing (still receiving dependabot updates) — the merge is confirmed functionally, but the source repo's own lifecycle status is unresolved.
 
 In this architecture, uFawkesObs provides the telemetry substrate consumed by all other planes. The OTLP API (`otel-collector:4317`/`4318`) is how every plane ships metrics, logs, and traces to uFawkesObs for centralized observability.
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -33,9 +33,12 @@ metadata:
     - url: https://github.com/paruff/uFawkesRes
       title: uFawkesRes — Resource Plane
       icon: github
-    - url: https://github.com/paruff/ufawkesdora
-      title: uFawkesDORA — DORA Metrics Plane
+    - url: https://github.com/paruff/uFawkesDojo
+      title: uFawkesDojo — Learning Plane
       icon: github
+    # uFawkesDORA is archived — its DORA compute/ingestion code was merged
+    # into this repo's dora/ directory (see AGENTS.md §10). No longer a
+    # separate system dependency.
 spec:
   type: observability
   owner: paruff
@@ -44,7 +47,6 @@ spec:
     - system:ufawkespipe
     - system:ufawkesdevx
     - system:ufawkesres
-    - system:ufawkesdora
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
## Summary

Task 2 of the suite-alignment brief, plus related family-table cleanup flagged in the brief's context section.

- **Confirmed and added uFawkesDojo**: `paruff/uFawkesDojo` is a real, live repo — "Fawkes Dojo — belt-level platform engineering curriculum," deployed at https://paruff.github.io/uFawkesDojo/, not archived, with substantial content (belt modules White→Black, labs, assessments, its own `AGENTS.md`/`catalog-info.yaml`). Its own README already lists uFawkesObs, uFawkesPipe, and fawkes as related repos. Added to README's family table and `catalog-info.yaml`'s `links:` (not `dependsOn:` — Dojo doesn't produce telemetry uFawkesObs consumes, so it's not a system dependency, just a related link).
- **Fixed stale uFawkesDORA references**: `paruff/uFawkesDORA` is archived on GitHub; its DORA compute/ingestion code was merged into this repo's own `dora/` directory. Removed from `catalog-info.yaml`'s `links:` and `spec.dependsOn:` (it's internal now, not an external dependency), annotated (not silently deleted) in the README.
- **Fixed stale uFawkesSec reference**: confirmed via uFawkesPipe's own README — literally states "**Security Plane (merged from uFawkesSec)**" and "formerly the standalone uFawkesSec repo" — that its responsibilities were merged into uFawkesPipe's `security` Compose profile. Annotated in the README family table.

## What was verified vs. assumed

**Verified directly:**
- uFawkesDojo's existence, activity, and content via `gh repo view`/`gh api repos/.../readme` — not assumed from the brief's naming guess.
- uFawkesDORA's archived status via `gh repo view paruff/uFawkesDORA` (`isArchived: true`).
- The uFawkesSec merge claim via uFawkesPipe's own README content, not taken on the brief's word alone — the brief asserted this as established fact, but I checked `gh repo view paruff/ufawkessec` first and found `isArchived: false` with recent dependabot activity (pushed 2026-07-30), which *contradicted* the brief at first glance. Went to the primary source (uFawkesPipe's README) to resolve the discrepancy rather than picking a side.

**Flagged, not resolved:**
- The `ufawkessec` repo itself has **not** been archived, unlike `ufawkesdora`. The merge is functionally real (confirmed in uFawkesPipe's docs), but the source repo's own lifecycle/archival status is a separate open question — noted explicitly in the README rather than asserted either way.
- uFawkesRes is **deliberately untouched** — that's a separate, still-open product-tier decision (companion PR adds `docs/notes/res-status.md` with options for a human to decide between).

## Architecture check

Docs-only change (README.md, catalog-info.yaml) — no service/compose changes, per AGENTS.md §4. No cross-plane runtime impact; this only corrects how the suite's structure is *described*.

## What I was NOT sure about

Whether uFawkesDojo belongs in `catalog-info.yaml`'s `spec.dependsOn:` list. Left it out — Obs doesn't depend on Dojo functionally (Dojo depends on/references Obs as teaching material, not the reverse) — but flagging in case reviewers see it differently.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass (markdownlint, yamllint, gitleaks)
- [x] `catalog-info.yaml` validated as parseable YAML
- [x] No code/config changes — docs-only, no functional test surface