### PR TITLE
docs: retire uFawkesRes/Sec, add Fawkes graduation path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,10 +223,9 @@ See `docs/KNOWN_LIMITATIONS.md` — known issues across storage, networking, pro
 
 ## 10. Suite Integration
 
-uFawkesObs is part of the **uFawkesAI** suite and the **Fawkes IDP** ecosystem.
+uFawkesObs is part of the **uFawkesAI** suite and the **Fawkes IDP** ecosystem. The active uFawkes (Compose-tier) suite is Obs, Pipe, DevX, and Dojo — see `README.md` § Part of the Fawkes IDP.
 
-**Depends on:**
-- **uFawkesRes** — Shared PostgreSQL for DORA metric snapshots (`datasources.yaml` UID: `ufawkesres-postgres`), used only when the `resource-plane` profile is active; the `dora` profile is self-contained (SQLite) by default
+**Depends on:** nothing required by default. uFawkesRes (shared PostgreSQL) is an optional dependency, only pulled in when the `resource-plane` Compose profile is explicitly activated (`compose.resource-plane.override.yaml`; `datasources.yaml` UID: `ufawkesres-postgres`) — the `dora` profile is self-contained (SQLite) otherwise. uFawkesRes was retired from the active uFawkes suite on 2026-08-18 (product decision, see `docs/notes/res-status.md`); this repo's optional integration with it is unaffected and still works.
 
 Note: uFawkesDORA (the standalone repo) is archived — its collector patterns, spec, and design docs were merged into this repo's `dora/` directory (see `feat/dora-consolidation-*` history). DORA compute and ingestion now live in uFawkesObs itself, not as an external dependency.
 

--- a/README.md
+++ b/README.md
@@ -40,27 +40,19 @@ uFawkesObs provides the observability substrate required for DORA measurement �
 
 ## Part of the Fawkes IDP
 
-uFawkesObs is the **observability plane** in the [Fawkes IDP](https://github.com/paruff/fawkes) family — a suite of composable platform engineering stacks.
-
-<!-- TODO(product): uFawkesRes's tier status is unresolved — it's real and
-     wired into this repo's optional resource-plane profile, but is not
-     listed on ufawkes.dev's public stack list. Needs a human decision
-     between promoting it there, scoping it to Fawkes-tier only, or
-     deprecating it. See docs/notes/res-status.md. Table left as-is
-     pending that decision. -->
+uFawkesObs is the **observability plane** in the [Fawkes IDP](https://github.com/paruff/fawkes) family — a suite of composable platform engineering stacks. The active uFawkes (Docker Compose) suite is Obs, Pipe, DevX, and Dojo, plus [ufawkes.dev](https://ufawkes.dev) as the suite's public site — Fawkes itself is the Kubernetes-track graduation target, not a suite-tier peer. See [When to Graduate to Fawkes](docs/fawkes-migration.md) for that path.
 
 | Plane | Role | Repository |
 |---|---|---|
 | **uFawkesObs** | Observability — metrics, logs, traces, dashboards | [GitHub](https://github.com/paruff/uFawkesObs) |
-<!-- uFawkesRes status unresolved — see docs/notes/res-status.md, do not edit this row pending a product-tier decision -->
-| **uFawkesRes** | Resources — ingress, SSO, Postgres, Valkey | [GitHub](https://github.com/paruff/uFawkesRes) |
 | **uFawkesPipe** | CI/CD — pipeline orchestration, deployment events | [GitHub](https://github.com/paruff/ufawkespipe) |
 | **uFawkesDevX** | Developer experience — golden paths, IDP templates | [GitHub](https://github.com/paruff/ufawkesdevx) |
 | **uFawkesDojo** | Learning — belt-level curriculum for uFawkes and Fawkes | [GitHub](https://github.com/paruff/uFawkesDojo) |
 | **uFawkesAI** | AI agent templates — golden path scaffolding | [GitHub](https://github.com/paruff/ufawkesai) |
 
-**Merged into other planes** (no longer standalone repos):
+**Retired from the active uFawkes suite** (2026-08-18 product decision):
 
+- **uFawkesRes** — was the resources plane (ingress, SSO, Postgres, Valkey). The [repo](https://github.com/paruff/uFawkesRes) is still real and active, and this repo's optional `resource-plane` Compose profile (`compose.resource-plane.override.yaml`) still works if you want shared Postgres — but it's no longer a promoted dependency of the small-team uFawkes tier; the `dora` profile is self-contained (SQLite) by default. See [docs/notes/res-status.md](docs/notes/res-status.md) for the full rationale.
 - **DORA metrics** — was uFawkesDORA; merged into uFawkesObs's `dora/` directory. [uFawkesDORA](https://github.com/paruff/ufawkesdora) is archived. See `AGENTS.md` §10.
 - **Security — policy-as-code, supply chain, guardrails** — was uFawkesSec; merged into uFawkesPipe's `security` Compose profile (DefectDojo, Infisical, Trivy server, Falco). Per uFawkesPipe's README, this is "formerly the standalone uFawkesSec repo." Note: unlike uFawkesDORA, the [uFawkesSec](https://github.com/paruff/ufawkessec) repo itself has not been archived as of this writing (still receiving dependabot updates) — the merge is confirmed functionally, but the source repo's own lifecycle status is unresolved.
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -30,15 +30,16 @@ metadata:
     - url: https://github.com/paruff/fawkes
       title: Fawkes IDP (Parent)
       icon: github
-    - url: https://github.com/paruff/uFawkesRes
-      title: uFawkesRes — Resource Plane
-      icon: github
     - url: https://github.com/paruff/uFawkesDojo
       title: uFawkesDojo — Learning Plane
       icon: github
     # uFawkesDORA is archived — its DORA compute/ingestion code was merged
     # into this repo's dora/ directory (see AGENTS.md §10). No longer a
     # separate system dependency.
+    # uFawkesRes retired from the active uFawkes (Compose-tier) suite —
+    # 2026-08-18 product decision, see docs/notes/res-status.md. The
+    # optional resource-plane Compose profile still exists in this repo
+    # for teams that want it, but it is no longer a promoted dependency.
 spec:
   type: observability
   owner: paruff
@@ -46,7 +47,6 @@ spec:
   dependsOn:
     - system:ufawkespipe
     - system:ufawkesdevx
-    - system:ufawkesres
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format
 apiVersion: backstage.io/v1alpha1
@@ -330,5 +330,3 @@ spec:
   consumedBy:
     - system:ufawkespipe
     - system:ufawkesdevx
-    - system:ufawkesres
-    - system:ufawkesdora

--- a/docs/fawkes-migration.md
+++ b/docs/fawkes-migration.md
@@ -131,6 +131,86 @@ use, out of scope for this doc.**
 | Dashboard JSON (Loki panels) | | ✅ (Loki → OpenSearch rework) | |
 | DORA dashboards/pipeline | | | ✅ (architectural — needs product decision) |
 
+## Migration path — step by step
+
+None of these steps have been executed or tested against a live Fawkes
+cluster — this is a sequencing plan built from the findings above, not a
+verified runbook. Each step should be validated in a non-production Fawkes
+namespace before being treated as authoritative.
+
+### Prerequisites
+
+- A running Fawkes cluster with the `fawkes-observability` namespace
+  provisioned (per `paruff/fawkes`'s own setup docs — out of scope here).
+- **Export everything from uFawkesObs before touching anything on the
+  Fawkes side:**
+  - `dashboards/platform/*.json` and `dashboards/services/*.json` (source
+    of truth is already in this repo's git history — no live export
+    needed, but confirm the running Grafana instance hasn't diverged from
+    committed JSON via UI edits: `allowUiUpdates: false` in
+    `config/grafana/provisioning/dashboards/*.yaml` should guarantee this,
+    but verify before relying on it).
+  - `config/prometheus/rules/*.yml` (recording/alert rules — portable
+    content, see table above).
+  - Prometheus's own data if historical metrics need to survive the cut
+    (`docs/KNOWN_LIMITATIONS.md` — 30-day retention only; snapshot
+    `./data/prometheus` or accept the loss).
+  - `dora/` snapshot data (`./data/dora/dora.db` if SQLite, or the
+    `dora_snapshots` table if using the `resource-plane` Postgres profile)
+    if DORA history needs to survive — see the DORA divergence note below
+    before assuming this data has anywhere to go on the Fawkes side.
+- A rollback point: keep the uFawkesObs Compose stack running and
+  untouched until the Fawkes-side stack is validated end-to-end. Don't
+  decommission Compose services as you migrate each piece — decommission
+  only after full cutover validation (see Rollback below).
+
+### Sequence
+
+1. **Prometheus rules first** — port `config/prometheus/rules/*.yml`
+   content into whatever Fawkes's chart expects (static `values.yaml` block
+   or `PrometheusRule` CRD — **needs validation testing** to determine
+   which). PromQL expressions themselves need no rewriting. Lowest-risk
+   step: rules that don't fire yet don't break anything.
+2. **Grafana datasources next** — recreate the datasource *definitions*
+   (not the delivery mechanism, which differs — see Grafana findings
+   above) in Fawkes's Grafana, using the same UID convention
+   (`prometheus`, `tempo`) where Fawkes's own Prometheus/Tempo instances
+   are the targets. Skip `loki` — there is no Fawkes equivalent (see next
+   step).
+3. **Dashboards without Loki panels** — import `dashboards/platform/` and
+   `dashboards/services/` JSON as-is via Fawkes's Grafana provisioning.
+   Before importing, **inventory which dashboards reference the `loki`
+   datasource UID** (not done in this pass — a real gap, see Findings
+   above) and hold those back.
+4. **Loki-backed dashboards last, and only after a panel rewrite** — these
+   need their log panels re-pointed at OpenSearch (Lucene/OpenSearch DSL,
+   not LogQL) before they'll render correctly. Treat this as new panel
+   authoring, not a config port.
+5. **DORA metrics — a product decision, not a migration step.** Fawkes
+   uses DevLake as its DORA engine; uFawkesObs uses its own `dora/`
+   ingestion+compute pipeline. Migrating DORA dashboards means picking one
+   of: (a) run uFawkesObs's `dora/` stack inside the Fawkes cluster
+   alongside DevLake (duplicate pipelines, not currently how Fawkes is
+   architected per its docs), or (b) rebuild the DORA dashboard panels
+   against DevLake's data model and retire uFawkesObs's `dora/` pipeline
+   at cutover. Do not attempt this step without that decision made first.
+6. **Validate against real traffic** in the Fawkes namespace before
+   touching the Compose stack — confirm scrape targets are actually being
+   scraped, alert rules fire correctly, and dashboard panels show live
+   data, not just that the JSON imported without error.
+7. **Decommission the Compose stack** only after step 6 passes. Keep the
+   exported data (step 0) until you're confident nothing needs to be
+   re-imported.
+
+### Rollback
+
+If validation in step 6 fails or stalls partway: uFawkesObs's Compose
+stack was never touched during steps 1–5 (they only add resources to the
+Fawkes side), so rollback is simply "stop migrating, keep running Compose
+as before" — there's no uFawkesObs-side state to revert. The only
+irreversible step is #7 (decommissioning Compose); don't take it until
+Fawkes-side validation is genuinely done, not just "looks right."
+
 ## When to graduate to Fawkes
 
 Reusable as a standalone checklist (e.g. for ufawkes.dev). uFawkesObs is

--- a/docs/notes/res-status.md
+++ b/docs/notes/res-status.md
@@ -1,12 +1,23 @@
 # Findings: uFawkesRes status in the uFawkes suite
 
-> Findings note, not a decision record — no ADR number assigned. Written to
-> resolve a discrepancy flagged in the "Suite Alignment & Dojo Integration"
-> task brief (2026-08-18): this repo's README family table lists
-> `uFawkesRes` as a live plane, but ufawkes.dev's public stack list does not
-> mention it. This note presents options; it does not pick one. The
-> README family table is intentionally left unchanged pending a human
-> decision — see [`../../README.md`](../../README.md#part-of-the-fawkes-idp).
+## Decision (2026-08-18)
+
+**Retired from the active uFawkes (Compose-tier) suite** — option (b) below,
+scoped to Fawkes-tier only. uFawkesRes is no longer a promoted dependency of
+the small-team uFawkes stack; the `dora` profile stays self-contained
+(SQLite) by default. The repo itself is not archived and this repo's
+optional `resource-plane` Compose profile (`compose.resource-plane.override.yaml`)
+still works unchanged for teams that want shared Postgres — retirement is a
+suite-positioning decision, not a deprecation of the integration code. See
+`README.md` § Part of the Fawkes IDP and `AGENTS.md` §10 for where this is
+now reflected.
+
+> Findings note below, not a decision record — no ADR number assigned.
+> Originally written to resolve a discrepancy flagged in the "Suite
+> Alignment & Dojo Integration" task brief (2026-08-18): this repo's README
+> family table listed `uFawkesRes` as a live plane, but ufawkes.dev's public
+> stack list does not mention it. The findings and options below are
+> unchanged from that investigation; only the decision above is new.
 
 ## What was verified
 


### PR DESCRIPTION
## Summary

Records a product decision the user made explicitly in this session: retire uFawkesRes and uFawkesSec from the active uFawkes (Compose-tier) suite, focusing it on Obs, Pipe, DevX, ufawkes.dev, and Dojo. Also expands `docs/fawkes-migration.md` (PR #225) into a fuller "clean path to graduate from uFawkes to Fawkes," per the same request.

**This is docs/positioning-level only** — an explicit interpretation constraint communicated to the user:
- Does **not** archive the `paruff/uFawkesRes` or `paruff/ufawkessec` GitHub repos. Archiving a public repo is a separate, more consequential action — left for an explicit follow-up if that's actually what's wanted.
- Does **not** remove uFawkesObs's `resource-plane` Postgres integration code (`compose.resource-plane.override.yaml`, the `resource-plane` profile, `dora-db-init`). It still works unchanged as an unpromoted opt-in for teams that want shared Postgres instead of the default SQLite backend — ripping out tested infrastructure code wasn't asked for.

## What changed

- **README.md**: family table now lists only the active suite (Obs, Pipe, DevX, Dojo, AI). uFawkesRes moves to a new "Retired from the active uFawkes suite" section alongside the already-merged uFawkesDORA/uFawkesSec entries, resolving the TODO left pending in PR #226/#224.
- **catalog-info.yaml**: removed `system:ufawkesres` from `dependsOn`/`consumedBy`. Also cleaned up a stale `system:ufawkesdora` reference in the OTLP API component's `consumedBy` list — PR #224 fixed this staleness in the top-level System block but missed this second location in the file.
- **AGENTS.md §10**: reflects the same retirement, keeps the `resource-plane` profile documented as a still-working optional integration (not removed).
- **docs/notes/res-status.md**: adds a "Decision (2026-08-18)" section recording that option (b) from the original findings (scope Fawkes-tier-only / retire from the Compose suite) is now decided. The investigative body from PR #226 is unchanged.
- **docs/fawkes-migration.md**: adds a step-by-step migration sequence (prerequisites/export checklist, ordered steps — Prometheus rules → Grafana datasources → non-Loki dashboards → Loki dashboards last → DORA product decision → validate → decommission), and a rollback plan. Every claim not actually verified against a live Fawkes cluster stays marked "needs validation testing" — nothing from the original findings was upgraded to "works" without checking.

## AI-Assisted Review Block

**What does this PR do?**
Implements a suite-positioning decision (retire Res/Sec) the user made explicitly in this session, and deepens the Fawkes graduation path doc from a findings-only doc into an actionable (but still honestly unverified) migration sequence.

**What could go wrong?**
This is docs/catalog metadata only — no compose.yaml, application code, or CI config touched. Main risk is scope creep in the interpretation of "retire"; addressed by explicitly not touching the GitHub repos or the working `resource-plane` integration code, and stating that constraint plainly in this PR.

**What tests cover this change?**
None applicable — docs-only PR. `pre-commit run --all-files` passes (markdownlint, YAML lint, gitleaks).

**Architecture check:**
- Touches only README.md, catalog-info.yaml, AGENTS.md, and docs/ — no service/compose changes, per AGENTS.md §4.
- Cross-plane impact: none functionally — uFawkesRes's optional integration is unchanged in behavior, just no longer promoted in suite documentation.

**What I was NOT sure about:**
Whether the user wants `paruff/uFawkesRes`/`paruff/ufawkessec` actually archived on GitHub as a follow-up — flagged explicitly rather than assumed either way.