### PR TITLE
docs: reposition uFawkesAI as a template, remove duplicate stack table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 
 - **Repo:** paruff/uFawkesObs
 - **What this is:** The observability plane of the Fawkes IDP family — OpenTelemetry, Prometheus, Tempo, Loki, Grafana, and Alloy delivered as Docker Compose with GitOps reconciliation over SSH.
-- **Suite membership:** uFawkesAI
+- **Suite membership:** uFawkes (Compose tier) — active suite is Obs, Pipe, DevX, Dojo. This repo's `AGENTS.md`/agent conventions are scaffolded from the [uFawkesAI](https://github.com/paruff/uFawkesAI) template, which is tooling shared across the family, not a suite-tier peer.
 
 ## 2. Where the Agents Live
 
@@ -223,7 +223,7 @@ See `docs/KNOWN_LIMITATIONS.md` — known issues across storage, networking, pro
 
 ## 10. Suite Integration
 
-uFawkesObs is part of the **uFawkesAI** suite and the **Fawkes IDP** ecosystem. The active uFawkes (Compose-tier) suite is Obs, Pipe, DevX, and Dojo — see `README.md` § Part of the Fawkes IDP.
+uFawkesObs is part of the **uFawkes** (Compose-tier) suite and the **Fawkes IDP** ecosystem. The active uFawkes suite is Obs, Pipe, DevX, and Dojo — see `README.md` § Part of the Fawkes IDP. (uFawkesAI is the shared `AGENTS.md` template this repo and its siblings are scaffolded from, not a suite-tier peer — see §1.)
 
 **Depends on:** nothing required by default. uFawkesRes (shared PostgreSQL) is an optional dependency, only pulled in when the `resource-plane` Compose profile is explicitly activated (`compose.resource-plane.override.yaml`; `datasources.yaml` UID: `ufawkesres-postgres`) — the `dora` profile is self-contained (SQLite) otherwise. uFawkesRes was retired from the active uFawkes suite on 2026-08-18 (product decision, see `docs/notes/res-status.md`); this repo's optional integration with it is unaffected and still works.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ uFawkesObs is the **observability plane** in the [Fawkes IDP](https://github.com
 | **uFawkesPipe** | CI/CD — pipeline orchestration, deployment events | [GitHub](https://github.com/paruff/ufawkespipe) |
 | **uFawkesDevX** | Developer experience — golden paths, IDP templates | [GitHub](https://github.com/paruff/ufawkesdevx) |
 | **uFawkesDojo** | Learning — belt-level curriculum for uFawkes and Fawkes | [GitHub](https://github.com/paruff/uFawkesDojo) |
-| **uFawkesAI** | AI agent templates — golden path scaffolding | [GitHub](https://github.com/paruff/ufawkesai) |
+
+**Not a suite plane — the template used to build all of the above:**
+
+- **uFawkesAI** — an `AGENTS.md`/agent-instruction template (Copilot, Claude Code, Cursor, Codex, etc.) implementing the DORA AI Capabilities Model, not a deployable service. Every repo in the uFawkes/Fawkes family — including this one — is scaffolded from it, which is what "part of the uFawkesAI suite" means in `AGENTS.md` §1: not a runtime dependency, a shared starting template. See [uFawkesAI](https://github.com/paruff/uFawkesAI).
 
 **Retired from the active uFawkes suite** (2026-08-18 product decision):
 
@@ -573,15 +576,6 @@ PR description format).
 
 ## uFawkes Stack Ecosystem
 
-uFawkesObs is part of the [uFawkes](https://ufawkes.dev) platform engineering ecosystem:
-
-| Stack           | Description                                          | Link                                            |
-| --------------- | ---------------------------------------------------- | ----------------------------------------------- |
-| **uFawkesObs**  | Observability — Prometheus, Grafana, AI dashboards   | [GitHub](https://github.com/paruff/uFawkesObs)  |
-| **uFawkesPipe** | CI/CD — Jenkins, Buildpacks, DevSecOps               | [GitHub](https://github.com/paruff/ufawkespipe) |
-| **uFawkesDORA** | DORA metrics — dashboards, VSM, delivery performance | [GitHub](https://github.com/paruff/ufawkesdora) |
-| **uFawkesSec**  | Security — policy-as-code, supply chain, guardrails  | [GitHub](https://github.com/paruff/ufawkessec)  |
-| **uFawkesDevX** | Developer experience — golden paths, IDP templates   | [GitHub](https://github.com/paruff/ufawkesdevx) |
-| **uFawkesAI**   | AI agent templates — golden path scaffolding         | [GitHub](https://github.com/paruff/ufawkesai)   |
+See [Part of the Fawkes IDP](#part-of-the-fawkes-idp) above for the current suite family table — this section used to duplicate it with stale entries (uFawkesDORA, uFawkesSec still shown active, no uFawkesDojo) and has been removed rather than kept in sync in two places.
 
 **Product Suite Roadmap**: [fawkes/ROADMAP.md](https://github.com/paruff/fawkes/blob/main/ROADMAP.md)


### PR DESCRIPTION
## Summary

Answers "what is uFawkesAI's role, it seems out of place?" — verified via `uFawkesAI`'s own README: it's an `AGENTS.md`/agent-instruction template (Copilot, Claude Code, Cursor, Codex) implementing the DORA AI Capabilities Model, not a deployable service. Every repo in the family (including this one) is scaffolded from it — that's what "part of the uFawkesAI suite" in `AGENTS.md` was trying to say, but the phrasing (and the family table listing it as a peer row) implied a runtime dependency instead.

Also found and removed a second, fully redundant `## uFawkes Stack Ecosystem` table further down `README.md` — missed by every prior suite-alignment PR (#224, #226, #230) because they only searched the "Part of the Fawkes IDP" table. It still listed uFawkesDORA and uFawkesSec as active and had no uFawkesDojo row at all.

## What was verified vs. assumed

Verified: read `uFawkesAI`'s actual README content directly to confirm its role (not assumed from the name). Confirmed via `grep` that `catalog-info.yaml` has no uFawkesAI reference needing a parallel fix.

## AI-Assisted Review Block

**What does this PR do?** Recategorizes uFawkesAI as "template, not suite plane" in README.md and AGENTS.md; deletes a stale duplicate ecosystem table.
**What could go wrong?** Pure docs change, no functional risk.
**What tests cover this change?** None needed — docs-only.
**Architecture check:** Documentation layer only, no service/dependency changes.
**What I was NOT sure about:** Nothing — this is a factual correction based on reading the actual uFawkesAI repo.