### PR TITLE
fix(ci): resolve OBS-SLI-006 DORA dashboards by starting dora profile in Acceptance Full

### DIFF
--- a/.github/workflows/ci-acceptance-full.yml
+++ b/.github/workflows/ci-acceptance-full.yml
@@ -28,6 +28,10 @@ jobs:
       # under --profile core/--profile apps). Never actually used here. See
       # docs/IMPLEMENTATION_PLAN.md finding D1.
       DORA_POSTGRES_URL: postgresql://ci-unused:ci-unused@localhost:5432/ci-unused # pragma: allowlist secret
+      # Short recompute interval so dora-compute picks up the deployment
+      # event OBS-SLI-006 seeds within the existing steady-state window,
+      # instead of only computing once at container start (default: 3600s).
+      DORA_COMPUTE_INTERVAL_SECONDS: "15"
 
     steps:
       - name: Checkout repository
@@ -45,12 +49,12 @@ jobs:
 
       - name: Create data directories
         run: |
-          mkdir -p data/{tempo,loki,alloy,prometheus,alertmanager,grafana}
+          mkdir -p data/{tempo,loki,alloy,prometheus,alertmanager,grafana,dora}
           chmod -R 777 data/
 
       - name: Start full stack with telemetry generator
         run: |
-          docker compose --profile core --profile apps up -d
+          docker compose --profile core --profile apps --profile dora up -d
           echo "Stack started, waiting for services to stabilize..."
 
       - name: Wait for all services healthy
@@ -66,6 +70,7 @@ jobs:
             ('OTel Collector', 'http://localhost:8888/metrics'),
             ('Alloy', 'http://localhost:12345/-/ready'),
             ('Telemetry Generator', 'http://localhost:5001/'),
+            ('DORA Ingestion API', 'http://localhost:8088/health'),
           ]
           for name, url in services:
             for i in range(60):
@@ -126,7 +131,7 @@ jobs:
 
       - name: Shutdown stack
         if: always()
-        run: docker compose --profile core --profile apps down -v
+        run: docker compose --profile core --profile apps --profile dora down -v
 
       - name: Check test results
         if: always()

--- a/tests/acceptance/features/slo_gates.feature
+++ b/tests/acceptance/features/slo_gates.feature
@@ -38,5 +38,6 @@ Feature: SLI/SLO Test Gates (OBS-SLI-001-006)
 
   @full
   Scenario: OBS-SLI-006 — Dashboard data freshness (SLO: all dashboards show data within 5m)
+    Given a DORA deployment event has been recorded
     When I query each provisioned Grafana dashboard for panel data
     Then at least one panel per dashboard should return non-empty results

--- a/tests/acceptance/workloads/__init__.py
+++ b/tests/acceptance/workloads/__init__.py
@@ -6,12 +6,14 @@ Provides a registry of available workload generators for use in acceptance tests
   - Web API simulation (web_api module)
   - Batch job simulation (batch_job module)
   - Log emitter (log_emitter module)
-  - DORA events (dora_events module)
 - Directly exported:
   - SyntheticTraceWorkload (web api + batch job simulation)
   - SyntheticMetricWorkload (health check metrics)
   - SyntheticLogWorkload (log emission)
-  - DORAWorkload (deployment, incident, lead-time traces)
+
+DORA deployment events (dora_events module) are seeded directly via a
+pytest-bdd @given step (REST POST to dora-api), not through this registry
+-- see tests/acceptance/workloads/dora_events.py.
 
 Usage::
 
@@ -29,7 +31,6 @@ Usage::
 from tests.acceptance.workloads.synthetic_trace import SyntheticTraceWorkload
 from tests.acceptance.workloads.synthetic_metric import SyntheticMetricWorkload
 from tests.acceptance.workloads.synthetic_log import SyntheticLogWorkload
-from tests.acceptance.workloads.dora_events import DORAWorkload
 
 
 # Workload registry for discovery and factory patterns
@@ -54,8 +55,6 @@ def get_workload(workload_type: str, **kwargs):
         "batch": SyntheticTraceWorkload,  # Alias
         "log_emitter": SyntheticLogWorkload,
         "log": SyntheticLogWorkload,  # Alias
-        "dora": DORAWorkload,
-        "dora_events": DORAWorkload,
     }
 
     if workload_type not in workload_registry:
@@ -73,7 +72,6 @@ __all__ = [
     "SyntheticTraceWorkload",
     "SyntheticMetricWorkload",
     "SyntheticLogWorkload",
-    "DORAWorkload",
     # Registry function
     "get_workload",
 ]
@@ -83,13 +81,11 @@ __all__ = [
 WebApiWorkload = SyntheticTraceWorkload
 BatchJobWorkload = SyntheticTraceWorkload
 LogEmitterWorkload = SyntheticLogWorkload
-DORAEventWorkload = DORAWorkload
 
 __all__.extend(
     [
         "WebApiWorkload",
         "BatchJobWorkload",
         "LogEmitterWorkload",
-        "DORAEventWorkload",
     ]
 )

--- a/tests/acceptance/workloads/dora_events.py
+++ b/tests/acceptance/workloads/dora_events.py
@@ -1,137 +1,62 @@
-"""
-DORA Event Generator for uFawkesObs Acceptance Tests
+"""DORA event seeder for uFawkesObs acceptance tests.
 
-Simulates deployment, incident, and lead-time spans for DORA metrics testing.
-
-Each scenario generates realistic OTLP traces with semantic attributes for DORA evaluation.
+Sends real deployment events over REST to dora-api's /event endpoint so
+dora-compute has something to compute DORA metrics from. Replaces a
+previous DORAWorkload class that sent OTLP trace spans instead -- the same
+"OTLP instead of REST" mismatch found and fixed in uFawkesPipe's
+notify-obs step (PR #70) -- and was never actually invoked by any
+scenario (dead code; see OBS-SLI-006 investigation, 2026-08-18).
 """
 
 from __future__ import annotations
 
-import time
 import uuid
+from datetime import UTC, datetime
+from typing import Any
 
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.sdk.resources import Resource
-
-
-def _get_exporter(protocol: str, endpoint: str):
-    """Lazy-load the appropriate OTLP exporter based on protocol."""
-    if protocol == "http":
-        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-            OTLPSpanExporter,
-        )
-
-        return BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces"))
-    else:
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-            OTLPSpanExporter,
-        )
-
-        return BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+import requests
+from pytest_bdd import given
 
 
-class DORAWorkload:
-    """Generates traces for DORA metrics (deployment, incident, lead-time).
+def build_deployment_event(
+    repo: str = "paruff/uFawkesObs",
+    service: str = "acceptance-test-plane",
+    environment: str = "test",
+    status: str = "success",
+) -> dict[str, Any]:
+    """Build a deployment event payload matching deployment-event.schema.json."""
+    return {
+        "schema_version": "1.0",
+        "event_type": "deployment",
+        "repo": repo,
+        "service": service,
+        "environment": environment,
+        "commit_sha": uuid.uuid4().hex + uuid.uuid4().hex[:8],
+        "deployed_at": datetime.now(UTC).isoformat(),
+        "status": status,
+        "pipeline_url": "https://github.com/paruff/uFawkesObs/actions/runs/0",
+    }
 
-    Usage::
 
-        workload = DORAWorkload(otlp_endpoint="localhost:4317", protocol="grpc")
-        trace_id = workload.simulate_deployment(instance="prod-001")
-        trace_id = workload.simulate_incident(severity="major")
-        trace_id = workload.simulate_lead_time(duration_ms=60000)
+def seed_deployment_event(
+    dora_api_base_url: str = "http://localhost:8088", **overrides: Any
+) -> dict[str, Any]:
+    """POST a deployment event to dora-api and return the response body."""
+    event = build_deployment_event(**overrides)
+    resp = requests.post(
+        f"{dora_api_base_url.rstrip('/')}/event", json=event, timeout=10
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+@given("a DORA deployment event has been recorded")
+def seeded_dora_deployment_event() -> None:
+    """Seed one successful deployment event via the real REST ingestion path.
+
+    dora-compute runs its first compute cycle immediately on container
+    start (see dora/compute/run.sh) and then on DORA_COMPUTE_INTERVAL_SECONDS
+    -- CI sets that short so a cycle after this seed has a chance to pick
+    the event up before OBS-SLI-006 queries Prometheus.
     """
-
-    def __init__(
-        self,
-        otlp_endpoint: str = "http://localhost:4318",
-        protocol: str = "http",
-        service_name: str = "acceptance-test-plane",
-    ):
-        self.otlp_endpoint = otlp_endpoint.rstrip("/")
-        self.protocol = protocol
-        self.service_name = service_name
-        self._tracer = None
-
-    def _init_tracing(self) -> None:
-        """Configure the OTel tracer with DORA attributes."""
-        resource = Resource.create(
-            {
-                "service.name": self.service_name,
-                "service.version": "1.0.0",
-                "deployment.environment": "test",
-            }
-        )
-        exporter = _get_exporter(self.protocol, self.otlp_endpoint)
-        provider = TracerProvider(resource=resource)
-        provider.add_span_processor(exporter)
-        self._tracer = provider.get_tracer(__name__)
-
-    def simulate_deployment(self, instance: str = "default") -> str:
-        """Generate a deployment trace with instance-specific attributes.
-
-        Args:
-            instance: Target deployment instance identifier.
-
-        Returns:
-            The 32-character hex trace_id.
-        """
-        if self._tracer is None:
-            self._init_tracing()
-
-        trace_id = str(uuid.uuid4())
-        with self._tracer.start_as_current_span(
-            "deployment",
-            attributes={"phase": "rolling", "instance": instance},
-        ) as span:
-            time.sleep(0.05)
-            span.set_attributes({"status": "success"})
-
-        return trace_id
-
-    def simulate_incident(self, severity: str = "minor", impact: str = "low") -> str:
-        """Generate an incident trace with severity and impact attributes.
-
-        Args:
-            severity: Incident severity (minor, major, critical).
-            impact: Impact level (low, medium, high).
-
-        Returns:
-            The 32-character hex trace_id.
-        """
-        if self._tracer is None:
-            self._init_tracing()
-
-        trace_id = str(uuid.uuid4())
-        with self._tracer.start_as_current_span(
-            "incident",
-            attributes={"severity": severity, "impact": impact},
-        ) as span:
-            time.sleep(0.1 if severity == "critical" else 0.01)
-            if severity == "critical":
-                span.set_attributes({"outcome": "resolved"})
-
-        return trace_id
-
-    def simulate_lead_time(self, duration_ms: int = 300) -> str:
-        """Generate a lead-time span for change-to-deployment time.
-
-        Args:
-            duration_ms: Simulated lead time in milliseconds.
-
-        Returns:
-            The 32-character hex trace_id.
-        """
-        if self._tracer is None:
-            self._init_tracing()
-
-        trace_id = str(uuid.uuid4())
-        with self._tracer.start_as_current_span(
-            "lead_time_span",
-            attributes={"change_id": str(uuid.uuid4()), "duration_ms": duration_ms},
-        ) as span:
-            time.sleep(duration_ms / 1000)
-            span.set_attributes({"duration_ms": duration_ms})
-
-        return trace_id
+    seed_deployment_event()

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -10,3 +10,5 @@ asyncpg>=0.30
 aiohttp>=3.14
 aiosqlite>=0.20
 fastapi>=0.110
+pytest-bdd>=8.0
+requests>=2.31

--- a/tests/unit/test_ci_workflow_env_validation.py
+++ b/tests/unit/test_ci_workflow_env_validation.py
@@ -20,3 +20,42 @@ def test_acceptance_full_workflow_sets_dora_postgres_url(project_root: Path) -> 
         "can interpolate required vars from compose.yaml in CI"
     )
     assert str(env["DORA_POSTGRES_URL"]).strip(), "DORA_POSTGRES_URL must not be empty"
+
+
+def test_acceptance_full_workflow_starts_dora_profile(project_root: Path) -> None:
+    """OBS-SLI-006 needs dora-api/dora-compute/pushgateway running to have
+    any DORA dashboard data at all -- regression test for the 2026-08-18
+    investigation (see docs/notes if present, or PR description)."""
+    workflow_path = project_root / ".github" / "workflows" / "ci-acceptance-full.yml"
+
+    with open(workflow_path, encoding="utf-8") as fh:
+        content = fh.read()
+
+    assert "--profile dora" in content, (
+        "ci-acceptance-full.yml must start the dora profile "
+        "(docker compose --profile core --profile apps --profile dora up -d) "
+        "or DORA dashboards can never have data in this job"
+    )
+
+
+def test_acceptance_full_workflow_sets_short_dora_compute_interval(
+    project_root: Path,
+) -> None:
+    """A short DORA_COMPUTE_INTERVAL_SECONDS gives dora-compute a chance to
+    pick up a seeded event within the job's steady-state window, instead of
+    only computing once at container start (default interval is 3600s)."""
+    workflow_path = project_root / ".github" / "workflows" / "ci-acceptance-full.yml"
+
+    with open(workflow_path, encoding="utf-8") as fh:
+        workflow = yaml.safe_load(fh)
+
+    env = workflow["jobs"]["acceptance-full"]["env"]
+    assert "DORA_COMPUTE_INTERVAL_SECONDS" in env, (
+        "ci-acceptance-full.yml must set a short DORA_COMPUTE_INTERVAL_SECONDS "
+        "so a seeded deployment event is picked up before OBS-SLI-006 runs"
+    )
+    interval = int(env["DORA_COMPUTE_INTERVAL_SECONDS"])
+    assert 0 < interval <= 30, (
+        f"DORA_COMPUTE_INTERVAL_SECONDS={interval} is too long for the "
+        "existing 60s steady-state window to reliably include a recompute"
+    )

--- a/tests/unit/test_dora_acceptance_workload.py
+++ b/tests/unit/test_dora_acceptance_workload.py
@@ -1,0 +1,60 @@
+"""Unit tests for the acceptance-test DORA event workload generator.
+
+Regression coverage for the OBS-SLI-006 investigation: the previous
+tests/acceptance/workloads/dora_events.py sent OTLP trace spans (via
+DORAWorkload) that never reached uFawkesObs's own dora/ingestion REST API
+-- the same "OTLP instead of REST" mismatch found and fixed in uFawkesPipe
+PR #70 -- and was never actually invoked by any scenario (dead code). These
+tests pin the replacement: a REST payload that validates against the real
+deployment-event.schema.json.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from tests.acceptance.workloads.dora_events import build_deployment_event
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "dora" / "events" / "deployment-event.schema.json"
+
+
+@pytest.fixture(scope="module")
+def deployment_schema() -> dict:
+    with open(SCHEMA_PATH, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+class TestBuildDeploymentEvent:
+    def test_validates_against_deployment_event_schema(
+        self, deployment_schema: dict
+    ) -> None:
+        event = build_deployment_event()
+        jsonschema.validate(event, deployment_schema)
+
+    def test_defaults_to_success_status(self) -> None:
+        event = build_deployment_event()
+        assert event["status"] == "success"
+
+    def test_honors_overrides(self) -> None:
+        event = build_deployment_event(
+            repo="paruff/example",
+            service="checkout",
+            environment="staging",
+            status="failed",
+        )
+        assert event["repo"] == "paruff/example"
+        assert event["service"] == "checkout"
+        assert event["environment"] == "staging"
+        assert event["status"] == "failed"
+
+    def test_rejects_invalid_status_at_schema_validation(
+        self, deployment_schema: dict
+    ) -> None:
+        event = build_deployment_event(status="not-a-real-status")
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(event, deployment_schema)

--- a/tests/unit/test_dora_acceptance_workload.py
+++ b/tests/unit/test_dora_acceptance_workload.py
@@ -11,16 +11,31 @@ deployment-event.schema.json.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
 import jsonschema
 import pytest
 
-from tests.acceptance.workloads.dora_events import build_deployment_event
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_PATH = REPO_ROOT / "dora" / "events" / "deployment-event.schema.json"
+
+# Load dora_events.py directly by file path rather than
+# `from tests.acceptance.workloads.dora_events import ...` -- that import
+# path executes tests/acceptance/workloads/__init__.py first, which eagerly
+# imports opentelemetry.sdk (from sibling workload modules unrelated to
+# this test) -- a dependency the tests/unit CI job's minimal environment
+# doesn't install and shouldn't need to, just to test a pure REST payload
+# builder.
+_spec = importlib.util.spec_from_file_location(
+    "dora_events_under_test",
+    REPO_ROOT / "tests" / "acceptance" / "workloads" / "dora_events.py",
+)
+assert _spec and _spec.loader
+_dora_events = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_dora_events)
+build_deployment_event = _dora_events.build_deployment_event
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

Root-causes and fixes part of `OBS-SLI-006` (dashboard data freshness), which has failed on `main` repeatedly this session (every run observed, across unrelated docs PRs).

## Root cause

`ci-acceptance-full.yml` only ran `docker compose --profile core --profile apps up -d` — **`--profile dora` was never started**, so `dora-api`, `dora-compute`, and `pushgateway` never ran in this job. The 4 DORA dashboards (DORA Overview, DORA Leading Indicators, Archetype Profile, Value Stream Indicators) could structurally never have data.

Separately, while investigating, found `tests/acceptance/workloads/dora_events.py`'s `DORAWorkload` class sent synthetic "DORA events" as **OTLP trace spans** — the exact same "OTLP instead of REST" architectural mismatch already found and fixed in uFawkesPipe's `notify-obs` step (PR #70 in that repo) — and was **never actually invoked by any scenario** (confirmed via repo-wide grep: zero real callers, only referenced in its own docstring example). Even with `--profile dora` running, there would have been no real deployment data for `dora-compute` to compute from.

## Fix

1. **`.github/workflows/ci-acceptance-full.yml`**: starts `--profile dora`, waits on `dora-api`'s `/health` before proceeding, creates the missing `data/dora` directory, sets `DORA_COMPUTE_INTERVAL_SECONDS=15` (down from the 3600s default) so `dora-compute` recomputes within the existing 60s steady-state window, tears the profile down cleanly on shutdown.
2. **`tests/acceptance/workloads/dora_events.py`**: replaced the dead OTLP-based `DORAWorkload` with `build_deployment_event`/`seed_deployment_event`, which `POST` a real deployment event matching `dora/events/deployment-event.schema.json` to `dora-api`'s actual `/event` endpoint, plus a `@given("a DORA deployment event has been recorded")` step wired into the `OBS-SLI-006` scenario. Cleaned up the now-dead `DORAWorkload` references from `tests/acceptance/workloads/__init__.py`'s registry/exports/legacy-aliases.

## What this does NOT fix

**All 15 dashboards** (not just the 4 DORA ones) failed identically in every observed run this session — this PR only addresses the DORA-specific gap. The remaining ~11 non-DORA dashboards (which should have data from the `apps` profile's telemetry-generator, already running before this PR) failing too suggests a separate cause. Prime suspect, not confirmed: `tests/acceptance/steps/slo_steps.py`'s `query_dashboard_panels` only evaluates panels whose datasource type is exactly `"prometheus"` (`if ds_type == "prometheus" and ds_uid:`), silently treating Loki/Tempo panels as "no data" regardless of their actual state — but I could not verify this end-to-end because local Docker was unavailable to me during this session (hung/unresponsive `docker ps`). Flagging as an honest, unverified follow-up rather than guessing a fix for it here.

## AI-Assisted Review Block

**What does this PR do?** Fixes the confirmed, evidence-based causes of DORA dashboards having no data in the post-merge acceptance suite.

**What could go wrong?** `DORA_COMPUTE_INTERVAL_SECONDS=15` is CI-only (set in the workflow's `env:`, not touching `.env.example`'s default of 3600s) — no risk to local/prod usage. Starting an additional profile adds ~modest resource/time to the CI job; `timeout-minutes: 20` should still be comfortable given `dora-api`/`dora-compute` are lightweight.

**What tests cover this change?** `tests/unit/test_ci_workflow_env_validation.py` (2 new tests: asserts `--profile dora` is started, asserts a short recompute interval is set) and `tests/unit/test_dora_acceptance_workload.py` (4 new tests: the new event builder validates against the real JSON Schema, honors overrides, rejects invalid status). Full unit suite: 656 passed, no regressions. `docker compose --profile core --profile apps --profile dora --env-file /dev/null config` validated locally (parses cleanly with zero env vars set, matching the CI environment).

**Architecture check:** Touches only CI workflow config and acceptance-test infrastructure — no production service/dependency changes, per `AGENTS.md` §4.

**What I was NOT sure about:** Whether this fully resolves `OBS-SLI-006` end-to-end — I could not run the full stack locally to verify (Docker was unresponsive in my environment this session), so this is based on static code analysis, not a live reproduction. Recommend watching the next `Acceptance Full` run after merge to confirm the DORA dashboards specifically now pass, and to get fresh evidence on whether the non-DORA dashboards' failure is the Prometheus-only-filter theory or something else.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pytest tests/unit/` — 656 passed (6 new: 2 workflow-config tests, 4 event-builder tests)
- [x] `docker compose --profile core --profile apps --profile dora --env-file /dev/null config` — validated
- [ ] Live `Acceptance Full` run post-merge — recommend watching this to confirm/refute the remaining non-DORA dashboard theory