### PR TITLE
fix(acceptance): resolve query-expr template vars in dashboard panel checks

### DIFF
--- a/tests/acceptance/steps/query_template_vars.py
+++ b/tests/acceptance/steps/query_template_vars.py
@@ -1,0 +1,35 @@
+"""Resolve Grafana query-variable tokens ($var / ${var}) inside a PromQL expr.
+
+Pure, dependency-free (stdlib only) so tests/unit can exercise it without
+pulling in tests.acceptance.workloads' opentelemetry.sdk dependency.
+
+query_dashboard_panels (slo_steps.py) previously only resolved the panel's
+own datasource template variable -- it never substituted query-type
+variables (job=~"$service", instance=~"$instance", etc.) used inside the
+query expression itself. Prometheus receives the literal string "$service"
+as a label matcher, which matches nothing.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def resolve_query_template_vars(expr: str, templating: dict) -> str:
+    """Substitute query-type template variables in a PromQL expr with a
+    match-anything regex, so panels using $var/${var} in label matchers
+    return whatever data actually exists rather than matching nothing.
+
+    Datasource-type variables are handled separately by
+    _resolve_template_datasource_uid and are not touched here.
+    """
+    for var_def in templating.get("list", []):
+        if var_def.get("type") != "query":
+            continue
+        name = var_def.get("name")
+        if not name:
+            continue
+        all_value = var_def.get("allValue") or ".*"
+        pattern = rf"\$\{{{re.escape(name)}\}}|\${re.escape(name)}\b"
+        expr = re.sub(pattern, all_value, expr)
+    return expr

--- a/tests/acceptance/steps/slo_steps.py
+++ b/tests/acceptance/steps/slo_steps.py
@@ -25,6 +25,7 @@ import pytest
 from pytest_bdd import then, when
 
 from tests.acceptance.runtime import ObservabilityStack
+from tests.acceptance.steps.query_template_vars import resolve_query_template_vars
 from tests.acceptance.workloads.synthetic_metric import SyntheticMetricWorkload
 from tests.acceptance.workloads.synthetic_trace import SyntheticTraceWorkload
 from tests.acceptance.workloads.synthetic_log import SyntheticLogWorkload
@@ -662,6 +663,7 @@ def query_dashboard_panels(stack: ObservabilityStack) -> None:
                         for target in targets:
                             expr = target.get("expr", "")
                             if expr:
+                                expr = resolve_query_template_vars(expr, templating)
                                 try:
                                     result = grafana.ds_query(ds_uid, expr)
                                     frames = (

--- a/tests/unit/test_slo_steps_query_template_vars.py
+++ b/tests/unit/test_slo_steps_query_template_vars.py
@@ -1,0 +1,90 @@
+"""Unit tests for resolving Grafana query-variable tokens in PromQL exprs.
+
+Regression coverage for the OBS-SLI-006 investigation: query_dashboard_panels
+in tests/acceptance/steps/slo_steps.py only resolves the panel-level
+datasource template variable (via _resolve_template_datasource_uid) --
+it never substitutes query-type variables (e.g. $service, $instance) that
+appear inside the panel's own PromQL expr, such as
+`http_requests_total{job=~"$service"}`. Confirmed live (2026-08-18)
+against a running stack: every "Services" folder dashboard uses exactly
+this pattern, and Prometheus receiving the literal string "$service" as
+a label matcher value matches zero series -- explaining a 100% failure
+rate across that entire dashboard folder.
+
+Loaded directly via importlib rather than
+`from tests.acceptance.steps.query_template_vars import ...` -- see
+test_dora_acceptance_workload.py for why (avoids pulling in
+tests.acceptance.workloads.__init__'s opentelemetry.sdk dependency via
+package init, which this pure-function module has no need for).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_spec = importlib.util.spec_from_file_location(
+    "query_template_vars_under_test",
+    REPO_ROOT / "tests" / "acceptance" / "steps" / "query_template_vars.py",
+)
+assert _spec and _spec.loader
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+resolve_query_template_vars = _mod.resolve_query_template_vars
+
+
+SERVICE_TEMPLATING = {
+    "list": [
+        {"name": "datasource", "type": "datasource", "query": "prometheus"},
+        {
+            "name": "service",
+            "type": "query",
+            "allValue": ".*",
+            "query": "label_values(up, job)",
+        },
+        {
+            "name": "instance",
+            "type": "query",
+            "allValue": ".*",
+            "query": 'label_values(up{job=~"$service"}, instance)',
+        },
+    ]
+}
+
+
+class TestResolveQueryTemplateVars:
+    def test_substitutes_dollar_brace_form(self) -> None:
+        expr = 'sum(rate(http_requests_total{job=~"${service}"}[5m]))'
+        resolved = resolve_query_template_vars(expr, SERVICE_TEMPLATING)
+        assert "${service}" not in resolved
+        assert 'job=~".*"' in resolved
+
+    def test_substitutes_dollar_bare_form(self) -> None:
+        expr = (
+            'sum(rate(http_requests_total{job=~"$service",instance=~"$instance"}[5m]))'
+        )
+        resolved = resolve_query_template_vars(expr, SERVICE_TEMPLATING)
+        assert "$service" not in resolved
+        assert "$instance" not in resolved
+        assert 'job=~".*"' in resolved
+        assert 'instance=~".*"' in resolved
+
+    def test_leaves_unrelated_dollar_text_alone(self) -> None:
+        expr = 'up{job="$servicewithsuffix"}'
+        resolved = resolve_query_template_vars(expr, SERVICE_TEMPLATING)
+        # "$service" is a prefix of "$servicewithsuffix" but must not match
+        # as a whole-token substitution
+        assert resolved == expr
+
+    def test_ignores_datasource_type_variables(self) -> None:
+        expr = 'up{job=~"$datasource"}'
+        resolved = resolve_query_template_vars(expr, SERVICE_TEMPLATING)
+        # datasource-type vars are handled by _resolve_template_datasource_uid
+        # elsewhere, not by this function
+        assert resolved == expr
+
+    def test_no_templating_is_a_noop(self) -> None:
+        expr = 'up{job="static"}'
+        assert resolve_query_template_vars(expr, {}) == expr


### PR DESCRIPTION
## Summary

Third bug in the OBS-SLI-006 investigation, found via live reproduction after Docker was fixed. Builds on #232 (dora profile) and the pushgateway fixes (separate PR).

## Root cause

`query_dashboard_panels` (`tests/acceptance/steps/slo_steps.py`) resolves a panel's *datasource* template variable (`_resolve_template_datasource_uid`) but never substitutes *query-type* template variables — `$service`, `$instance`, etc. — that appear inside the panel's own PromQL `expr`, e.g. `http_requests_total{job=~"$service"}`. Prometheus receives the literal string `"$service"` as a label matcher value, which matches zero series.

Confirmed live against a running stack: every dashboard in the "Services" folder uses exactly this pattern in its queries — explaining a 100% failure rate across that entire folder.

## Fix

New `tests/acceptance/steps/query_template_vars.py` — a pure, dependency-free (stdlib `re` only) function that substitutes query-type template variables with their `allValue` (typically `.*`), wired into `query_dashboard_panels`'s per-target query. Kept as a standalone module (not inline in `slo_steps.py`) so it stays testable from `tests/unit` without pulling in `slo_steps.py`'s `opentelemetry`/`pytest_bdd` dependencies — same split used for `dora_events.py` earlier in this investigation.

## Verified live

Ran the actual `OBS-SLI-006` acceptance scenario against a real running stack (Docker Desktop, full `core + apps + dora` profiles), not just unit tests:
- Before this fix (with the two pushgateway fixes already applied): **15/31** dashboards had data
- After this fix: **20/31** dashboards had data

Remaining 11 empty dashboards (AI Impact, Application Performance, Application Performance - Logs, Archetype Profile, DORA Leading Indicators, IoT Devices & MQTT, Observability Stack Health, Service - Error Analysis, Service - Latency Analysis, Service - SLO, Value Stream Indicators) need synthetic data types this session didn't seed — PR/incident/rework DORA events, wellbeing survey data, IoT/MQTT-specific telemetry. Not further code bugs as far as I could verify; flagging as a data-completeness gap for a future session rather than guessing at more fixes.

## AI-Assisted Review Block

**What does this PR do?** Fixes a confirmed test-code bug causing every "Services" folder dashboard to fail data-freshness checks regardless of whether real data exists.

**What could go wrong?** This only affects acceptance-test evaluation logic (`tests/acceptance/`), not any production/application code — zero runtime risk. The substitution is deliberately permissive (`.*` match-anything) rather than attempting full Grafana variable-resolution fidelity (multi-value vars, format specifiers) — acceptable for "does this dashboard have any data" checks, would need more work for exact-value assertions.

**What tests cover this change?** 5 new unit tests in `tests/unit/test_slo_steps_query_template_vars.py` (brace form, bare form, no-false-positive-on-prefix-match, datasource-vars correctly ignored, no-templating no-op). Full suite: 661 passed. Live-verified against a real stack (see above), not just mocked.

**Architecture check:** Touches only acceptance-test infrastructure, no service/dependency changes.

**What I was NOT sure about:** Whether the remaining 11 dashboards need code fixes or just more synthetic test data — investigated as far as live reproduction allowed within this session, concluded it's the latter for the ones checked, but didn't exhaustively verify every remaining dashboard's specific query.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pytest tests/unit/` — 661 passed (5 new)
- [x] Live: ran the actual `OBS-SLI-006` scenario against a real stack, confirmed 15/31 -> 20/31 improvement