### PR TITLE
fix(dora): correct pushgateway job name and payload trailing newline

### DIFF
--- a/dora/compute/metrics.py
+++ b/dora/compute/metrics.py
@@ -311,8 +311,8 @@ async def _push_metrics(
             record.get("dora_tier_rework_rate"),
         )
 
-        payload = "\n".join(lines)
-        job_name = f"ufawkesdora/{tid.replace('/', '_')}"
+        payload = "\n".join(lines) + "\n"
+        job_name = f"ufawkesdora_{tid.replace('/', '_')}"
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/tests/unit/test_dora_metrics.py
+++ b/tests/unit/test_dora_metrics.py
@@ -322,6 +322,43 @@ class TestPushMetrics:
             )
 
     @pytest.mark.asyncio
+    async def test_push_metrics_payload_ends_with_newline(self):
+        """Regression test: payload previously had no trailing newline
+        ("\n".join(lines) with nothing after the last line). Prometheus's
+        text exposition format requires every metric line -- including the
+        last -- to be newline-terminated; without it Pushgateway rejects
+        the whole push with 400 "unexpected end of input stream". Confirmed
+        live against a real Pushgateway 1.11.0 response body (2026-08-18):
+        this bug meant DORA metrics had never successfully reached
+        Prometheus via pushgateway, even after the job-name slash fix.
+        """
+        record = {
+            "team_id": "org/repo",
+            "deployment_frequency": 10.0,
+            "proxy_metrics": False,
+            "dora_tier_deployment_frequency": "elite",
+        }
+
+        with patch("aiohttp.ClientSession") as mock_client_session:
+            mock_session = MagicMock()
+            mock_client_session.return_value.__aenter__.return_value = mock_session
+
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_session.put.return_value.__aenter__.return_value = mock_resp
+
+            await _push_metrics([record], "http://localhost:9091")
+
+            sent_payload = (
+                mock_session.put.call_args.kwargs.get("data")
+                or mock_session.put.call_args.args[1]
+            )
+            assert sent_payload.endswith("\n"), (
+                "pushgateway payload must end with a newline or Prometheus's "
+                "text-format parser rejects the whole push with a 400"
+            )
+
+    @pytest.mark.asyncio
     async def test_push_metrics_handles_pushgateway_error(self):
         """Pushgateway failure should log warning, not crash."""
         record = {

--- a/tests/unit/test_dora_metrics.py
+++ b/tests/unit/test_dora_metrics.py
@@ -287,6 +287,41 @@ class TestPushMetrics:
             mock_session.put.assert_called()
 
     @pytest.mark.asyncio
+    async def test_push_metrics_job_name_has_no_slash_in_url(self):
+        """Regression test: job_name previously included a literal '/'
+        (f"ufawkesdora/{tid}") embedded directly in the pushgateway URL
+        path (.../metrics/job/{job_name}). Pushgateway parses path segments
+        after /job/<name> as alternating grouping-key label/value pairs, so
+        an embedded '/' produces a dangling unpaired segment and a 400
+        Bad Request -- confirmed live against a running pushgateway
+        (2026-08-18). The job name segment of the URL must not contain '/'.
+        """
+        record = {
+            "team_id": "paruff/uFawkesObs",
+            "deployment_frequency": 1.0,
+            "proxy_metrics": False,
+        }
+
+        with patch("aiohttp.ClientSession") as mock_client_session:
+            mock_session = MagicMock()
+            mock_client_session.return_value.__aenter__.return_value = mock_session
+
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_session.put.return_value.__aenter__.return_value = mock_resp
+
+            await _push_metrics([record], "http://localhost:9091")
+
+            called_url = (
+                mock_session.put.call_args.kwargs.get("url")
+                or mock_session.put.call_args.args[0]
+            )
+            job_segment = called_url.split("/metrics/job/", 1)[1]
+            assert "/" not in job_segment, (
+                f"pushgateway job name segment must not contain '/': {called_url!r}"
+            )
+
+    @pytest.mark.asyncio
     async def test_push_metrics_handles_pushgateway_error(self):
         """Pushgateway failure should log warning, not crash."""
         record = {


### PR DESCRIPTION
## Summary

The most significant finding from this session's live Docker reproduction: **DORA metrics have likely never successfully reached Prometheus via pushgateway**, due to two independent bugs in `_push_metrics` (`dora/compute/metrics.py`), both required to be fixed simultaneously to observe either clearly.

## Root causes (both confirmed live against a real Pushgateway 1.11.0)

**Bug 1 — job name embeds a literal `/`:**
```python
job_name = f"ufawkesdora/{tid.replace('/', '_')}"
url = f"{pushgateway_url.rstrip('/')}/metrics/job/{job_name}"
```
Pushgateway's URL scheme parses path segments after `/job/<name>` as alternating grouping-key label/value pairs. An embedded `/` in `job_name` produces a dangling, unpaired segment — Pushgateway returns `400 Bad Request`.

**Bug 2 — payload missing a trailing newline:**
```python
payload = "\n".join(lines)
```
Prometheus's text exposition format requires every metric line — including the last — to be newline-terminated. Without it, Pushgateway rejects the entire push: `400 "text format parsing error in line N: unexpected end of input stream"` (exact error captured live, see commit message).

## How this was found

Reproduced live: seeded a real deployment event via the REST fix (PR #232), watched `dora-compute` actually compute correct metrics (`DF/week = 0.23`), then hit `Pushgateway returned 400`. Reproduced the exact failing request via a raw Python/aiohttp script inside the container to capture Pushgateway's real response body, which named the exact parsing error.

## Verified live

After both fixes: `dora_deployment_frequency_per_week` appeared in Prometheus for the first time, confirmed via direct `curl` query against `http://localhost:9090/api/v1/query`.

## AI-Assisted Review Block

**What does this PR do?** Fixes two confirmed bugs preventing any DORA metric from ever reaching Prometheus.

**What could go wrong?** Both changes are narrowly scoped string-construction fixes in one function. No behavior change for any other code path.

**What tests cover this change?** Two new regression tests in `tests/unit/test_dora_metrics.py` (`test_push_metrics_job_name_has_no_slash_in_url`, `test_push_metrics_payload_ends_with_newline`) — both reproduce the exact failure mode observed live, both were RED before the fix, both GREEN after. Full suite: 41/41 in this file, 661 overall.

**Architecture check:** Touches only `dora/compute/metrics.py`'s pushgateway push logic, no service/dependency changes.

**What I was NOT sure about:** Whether this bug has existed since the original DORA metrics implementation or was introduced at some point — didn't dig into `git blame` history, out of scope for the fix itself.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pytest tests/unit/` — 661 passed (2 new)
- [x] Live-verified: `dora_deployment_frequency_per_week` confirmed present in Prometheus after this fix, absent before