### PR TITLE
fix(dashboards): resolve remaining OBS-SLI-006 findings surfaced by exception logging

### DIFF
--- a/config/grafana/dashboards/application-performance-logs.json
+++ b/config/grafana/dashboards/application-performance-logs.json
@@ -39,7 +39,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "loki"
       },
       "description": "View logs from Media-Refinery application",
       "fieldConfig": {
@@ -101,7 +101,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "loki"
       },
       "description": "All application stack services available for filtering. Click on service name in the legend to filter.",
       "fieldConfig": {
@@ -199,7 +199,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "loki"
       },
       "description": "All error and stderr logs across services",
       "fieldConfig": {
@@ -305,7 +305,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -357,7 +357,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -405,7 +405,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "loki"
       },
       "fieldConfig": {
         "defaults": {

--- a/config/grafana/dashboards/application-performance.json
+++ b/config/grafana/dashboards/application-performance.json
@@ -196,7 +196,7 @@
       "pluginVersion": "10.4.2",
       "targets": [
         {
-          "expr": "count(count_over_time({compose_service=~\".+\"}[5m]) by (compose_service))",
+          "expr": "count by (compose_service) (count_over_time({compose_service=~\".+\"}[5m]))",
           "refId": "A"
         }
       ],

--- a/config/grafana/dashboards/infrastructure-overview.json
+++ b/config/grafana/dashboards/infrastructure-overview.json
@@ -469,7 +469,7 @@
       "pluginVersion": "10.4.2",
       "targets": [
         {
-          "expr": "count(count_over_time({compose_service=~\".+\"}[5m]) by (compose_service))",
+          "expr": "count by (compose_service) (count_over_time({compose_service=~\".+\"}[5m]))",
           "refId": "A"
         }
       ],

--- a/config/grafana/dashboards/observability-stack-health.json
+++ b/config/grafana/dashboards/observability-stack-health.json
@@ -39,7 +39,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "Is Prometheus running and accessible?",
       "fieldConfig": {
@@ -113,7 +113,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "Is OTel Collector running?",
       "fieldConfig": {
@@ -187,7 +187,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "Is Alertmanager running?",
       "fieldConfig": {
@@ -261,7 +261,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "Active Alerts",
       "fieldConfig": {
@@ -336,7 +336,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "Queue depth for exporters",
       "fieldConfig": {
@@ -420,7 +420,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "HTTP requests to OTel Collector",
       "fieldConfig": {
@@ -517,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -600,7 +600,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {

--- a/tests/acceptance/steps/query_template_vars.py
+++ b/tests/acceptance/steps/query_template_vars.py
@@ -16,20 +16,36 @@ import re
 
 
 def resolve_query_template_vars(expr: str, templating: dict) -> str:
-    """Substitute query-type template variables in a PromQL expr with a
-    match-anything regex, so panels using $var/${var} in label matchers
-    return whatever data actually exists rather than matching nothing.
+    """Substitute Grafana template variable tokens in a PromQL/LogQL expr.
+
+    - "query"-type variables (label matchers, e.g. job=~"$service") are
+      replaced with a match-at-least-one-char regex. ".+" rather than
+      ".*": Loki rejects a stream selector whose only matcher is
+      equivalent to matching everything including empty (400 "queries
+      require at least one regexp or equality matcher that does not
+      match empty") -- ".+" satisfies both Loki and Prometheus.
+    - "interval"-type variables (range vector durations, e.g.
+      [$window]) are replaced with their current selected value --
+      these aren't label matchers, so a regex substitution would
+      produce invalid syntax (e.g. "[.+]" is not a valid duration).
 
     Datasource-type variables are handled separately by
     _resolve_template_datasource_uid and are not touched here.
     """
     for var_def in templating.get("list", []):
-        if var_def.get("type") != "query":
-            continue
         name = var_def.get("name")
         if not name:
             continue
-        all_value = var_def.get("allValue") or ".*"
+        var_type = var_def.get("type")
+        if var_type == "query":
+            replacement = var_def.get("allValue") or ".+"
+        elif var_type == "interval":
+            replacement = (
+                var_def.get("current", {}).get("value")
+                or var_def.get("query", "").split(",")[0]
+            )
+        else:
+            continue
         pattern = rf"\$\{{{re.escape(name)}\}}|\${re.escape(name)}\b"
-        expr = re.sub(pattern, all_value, expr)
+        expr = re.sub(pattern, replacement, expr)
     return expr

--- a/tests/unit/test_grafana_dashboards.py
+++ b/tests/unit/test_grafana_dashboards.py
@@ -157,3 +157,77 @@ class TestGrafanaDashboardConventions:
         # This test always passes — it documents the graceful-skip behavior.
         # The parametrized tests above will have 0 items if no files exist.
         assert count >= 0, "Sanity check: count cannot be negative"
+
+
+# ---------------------------------------------------------------------------
+# Orphaned datasource UID check — also scans config/grafana/dashboards/
+# ---------------------------------------------------------------------------
+# Separate from TestGrafanaDashboardConventions above: that class's UID-prefix
+# and schemaVersion checks are Platform/Services-only conventions (AGENTS.md
+# §4 scopes them to dashboards/platform and dashboards/services). An orphaned
+# datasource UID is a correctness bug regardless of which folder it's in --
+# found live 2026-08-18: two legacy dashboards (application-performance-logs,
+# observability-stack-health) hardcoded Grafana-internal numeric-style
+# datasource UIDs (e.g. "PBFA97CFB590B2093") that don't exist in this
+# instance -- a different failure mode than the deprecated {"id": N} pattern
+# test_no_numeric_datasource_id checks for, and one that only surfaced once
+# query_dashboard_panels stopped swallowing the resulting 404 silently.
+LEGACY_DASHBOARDS_DIR = (
+    pathlib.Path(__file__).resolve().parents[2] / "config" / "grafana" / "dashboards"
+)
+KNOWN_DATASOURCE_UIDS = {
+    "prometheus",
+    "loki",
+    "tempo",
+    "alertmanager",
+    "ufawkesres-postgres",
+    "grafana",  # Grafana's built-in datasource, used by default annotation queries
+    "-- Grafana --",  # older-schema equivalent of the "grafana" built-in UID
+}
+
+
+def _all_dashboard_files() -> list[pathlib.Path]:
+    files = list(_dashboard_files)
+    if LEGACY_DASHBOARDS_DIR.is_dir():
+        files += sorted(LEGACY_DASHBOARDS_DIR.rglob("*.json"))
+    return files
+
+
+def _find_orphaned_datasource_uids(obj: object, path: str = "") -> list[str]:
+    """Find panel-level datasource UIDs that aren't a known real UID or a
+    ${template-variable} reference."""
+    hits: list[str] = []
+    if isinstance(obj, dict):
+        if "datasource" in obj:
+            ds = obj["datasource"]
+            if isinstance(ds, dict):
+                uid = ds.get("uid")
+                if (
+                    isinstance(uid, str)
+                    and uid
+                    and not uid.startswith("$")
+                    and uid not in KNOWN_DATASOURCE_UIDS
+                ):
+                    hits.append(f"{path}.datasource.uid={uid}")
+        for k, v in obj.items():
+            hits.extend(_find_orphaned_datasource_uids(v, f"{path}.{k}"))
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            hits.extend(_find_orphaned_datasource_uids(item, f"{path}[{i}]"))
+    return hits
+
+
+@pytest.mark.parametrize(
+    "path", _all_dashboard_files(), ids=lambda p: p.name if p else "none"
+)
+def test_no_orphaned_datasource_uid(path: pathlib.Path) -> None:
+    """Every panel-level datasource UID must be a real, configured
+    datasource or a template variable -- not a stale/imported reference
+    that doesn't exist in this Grafana instance."""
+    data = _load_dashboard(path)
+    hits = _find_orphaned_datasource_uids(data)
+    assert not hits, (
+        f"{path.name} references {len(hits)} datasource UID(s) not in "
+        f"{sorted(KNOWN_DATASOURCE_UIDS)} and not a template variable: "
+        f"{', '.join(hits[:5])}"
+    )

--- a/tests/unit/test_slo_steps_query_template_vars.py
+++ b/tests/unit/test_slo_steps_query_template_vars.py
@@ -41,14 +41,31 @@ SERVICE_TEMPLATING = {
         {
             "name": "service",
             "type": "query",
-            "allValue": ".*",
+            "allValue": ".+",
             "query": "label_values(up, job)",
         },
         {
             "name": "instance",
             "type": "query",
-            "allValue": ".*",
+            "allValue": ".+",
             "query": 'label_values(up{job=~"$service"}, instance)',
+        },
+    ]
+}
+
+NO_ALLVALUE_TEMPLATING = {
+    "list": [
+        {"name": "service", "type": "query", "query": "label_values(up, job)"},
+    ]
+}
+
+WINDOW_TEMPLATING = {
+    "list": [
+        {
+            "name": "window",
+            "type": "interval",
+            "query": "7d,30d,90d",
+            "current": {"text": "30d", "value": "30d"},
         },
     ]
 }
@@ -59,7 +76,7 @@ class TestResolveQueryTemplateVars:
         expr = 'sum(rate(http_requests_total{job=~"${service}"}[5m]))'
         resolved = resolve_query_template_vars(expr, SERVICE_TEMPLATING)
         assert "${service}" not in resolved
-        assert 'job=~".*"' in resolved
+        assert 'job=~".+"' in resolved
 
     def test_substitutes_dollar_bare_form(self) -> None:
         expr = (
@@ -68,8 +85,30 @@ class TestResolveQueryTemplateVars:
         resolved = resolve_query_template_vars(expr, SERVICE_TEMPLATING)
         assert "$service" not in resolved
         assert "$instance" not in resolved
-        assert 'job=~".*"' in resolved
-        assert 'instance=~".*"' in resolved
+        assert 'job=~".+"' in resolved
+        assert 'instance=~".+"' in resolved
+
+    def test_defaults_to_dot_plus_not_dot_star_when_no_allvalue(self) -> None:
+        """Regression test: Loki rejects a stream selector whose only
+        matcher is equivalent to matching everything including empty
+        (e.g. {compose_service=~".*"}) with 400 "queries require at
+        least one regexp or equality matcher that does not match empty".
+        ".+" (at least one char) satisfies both Prometheus and Loki;
+        ".*" only satisfies Prometheus. Confirmed live 2026-08-18."""
+        expr = 'sum(rate({compose_service=~"$service"}[5m]))'
+        resolved = resolve_query_template_vars(expr, NO_ALLVALUE_TEMPLATING)
+        assert 'compose_service=~".+"' in resolved
+        assert ".*" not in resolved
+
+    def test_substitutes_interval_type_variable_in_range_vector(self) -> None:
+        """Regression test: DORA Overview's Deployment Frequency panel uses
+        an interval-type $window variable inside a range vector duration
+        (last_over_time(...[$window])) -- the query-type-only substitution
+        left "[$window]" as a literal, invalid PromQL duration, causing a
+        400. Confirmed live 2026-08-18."""
+        expr = "last_over_time(dora_deployment_frequency_per_week[$window])"
+        resolved = resolve_query_template_vars(expr, WINDOW_TEMPLATING)
+        assert resolved == "last_over_time(dora_deployment_frequency_per_week[30d])"
 
     def test_leaves_unrelated_dollar_text_alone(self) -> None:
         expr = 'up{job="$servicewithsuffix"}'


### PR DESCRIPTION
## Summary

Direct answer to "what is the impact of running the whole test suite with the new guidance to not swallow exceptions — are there new findings?" — **yes, four more real bugs**, all invisible until the `except Exception: pass` in `query_dashboard_panels` was fixed to log what actually broke.

## Findings, all confirmed live via direct Grafana API reproduction

1. **Two legacy dashboards hardcode stale, nonexistent datasource UIDs** — `application-performance-logs.json` and `observability-stack-health.json` referenced Grafana-internal numeric-style UIDs (`P8E80F9AEF21F6940`, `PBFA97CFB590B2093`) that don't exist in this instance → 404s on every panel. Replaced with the real `loki`/`prometheus` UIDs.
2. **`resolve_query_template_vars` (added in #233) only handled `query`-type variables** — DORA Overview's Deployment Frequency panel uses an `interval`-type `$window` variable inside a range vector duration (`last_over_time(...[$window])`), left as the literal invalid PromQL string `[$window]` → 400. Now substitutes interval-type variables with their current selected value.
3. **The `.*` default (from #233) is rejected by Loki** — `"queries require at least one regexp or equality matcher that does not match empty"` — even though Prometheus accepts it fine. Changed default to `.+`.
4. **Two dashboards have genuinely malformed LogQL**: `count(count_over_time(...) by (...))` — grouping isn't valid directly on `count_over_time`, it belongs on the outer `count()`. Fixed to `count by (...) (count_over_time(...))`. Verified via direct API call before and after (500 "grouping not allowed for count_over_time aggregation" → 200 with real data).

## Also

New `test_no_orphaned_datasource_uid` in `tests/unit/test_grafana_dashboards.py`, scanning both `dashboards/` and the legacy `config/grafana/dashboards/` folder. The *existing* numeric-datasource test only catches the deprecated `{"id": N}` pattern — a different bug class that would **not** have caught finding #1 regardless of directory scope, since these were valid-shaped string UIDs that simply don't exist. This new test would have caught it.

## Verified live

`OBS-SLI-006` went from 20/31 (where this investigation started) → 23/31, with zero remaining "query failed" log lines for the four dashboards fixed here.

## AI-Assisted Review Block

**What does this PR do?** Fixes four real, live-confirmed bugs surfaced directly by the exception-logging change (PR #235), plus closes a test-coverage gap.

**What could go wrong?** Dashboard JSON edits are narrowly scoped (datasource UID string swaps, one query restructure) — verified each fix live against the real API before committing, not just locally reasoned about.

**What tests cover this change?** 2 new unit tests for interval-variable and Loki empty-match handling in `tests/unit/test_slo_steps_query_template_vars.py`; 1 new parametrized test (31 cases) in `tests/unit/test_grafana_dashboards.py`. Full suite: 698 passed.

**Architecture check:** Touches only dashboard JSON content and acceptance-test infrastructure — no service/dependency changes.

**What I was NOT sure about:** Whether other dashboards have similar malformed-query bugs I haven't hit yet — this PR fixes what surfaced in this specific investigation, not an exhaustive LogQL/PromQL audit of every panel in the repo.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pytest tests/unit/` — 698 passed (3 new)
- [x] Live: reproduced each bug's exact failing request via the real Grafana API, confirmed the fix resolves it (200 with real data), reran `OBS-SLI-006` end-to-end (20/31 → 23/31)