### PR TITLE
fix(dora): connect resource-plane services to fawkes-backbone-net

### DIFF
--- a/compose.resource-plane.override.yaml
+++ b/compose.resource-plane.override.yaml
@@ -22,6 +22,8 @@ services:
         condition: service_completed_successfully
     environment:
       - DATABASE_URL=${DORA_POSTGRES_URL:?Set DORA_POSTGRES_URL in .env (see .env.example) — no credential default is provided in compose.yaml}
+    networks:
+      - fawkes-backbone-net
 
   dora-compute:
     depends_on:
@@ -29,3 +31,20 @@ services:
         condition: service_completed_successfully
     environment:
       - DATABASE_URL=${DORA_POSTGRES_URL:?Set DORA_POSTGRES_URL in .env (see .env.example) — no credential default is provided in compose.yaml}
+    networks:
+      - fawkes-backbone-net
+
+  # dora-db-init is defined in the base compose.yaml (gated behind the
+  # resource-plane profile there); this override only adds the network it
+  # needs to actually reach fawkes-postgres to run migrations against it.
+  dora-db-init:
+    networks:
+      - fawkes-backbone-net
+
+networks:
+  # Created by uFawkesRes's own compose stack (name: ufawkes-resources in
+  # its compose.yaml), not by uFawkesObs -- external: true, don't try to
+  # create it here. Requires uFawkesRes's stack to already be running.
+  fawkes-backbone-net:
+    external: true
+    name: ufawkes-resources_fawkes-backbone-net

--- a/tests/unit/test_dora_consolidation.py
+++ b/tests/unit/test_dora_consolidation.py
@@ -327,6 +327,33 @@ class TestComposeResourcePlanOverride:
             "service_completed_successfully"
         ), f"{service} override must wait for dora-db-init to complete"
 
+    @pytest.mark.parametrize("service", ["dora-api", "dora-compute", "dora-db-init"])
+    def test_joins_fawkes_backbone_net(self, override_data: dict, service: str) -> None:
+        """Regression test: found live 2026-08-18 -- none of these services
+        were ever attached to fawkes-backbone-net (the external network
+        uFawkesRes's Postgres actually runs on, per docs/product/design.md
+        §5), so DATABASE_URL pointing at DORA_POSTGRES_URL would still fail
+        to connect even with correct credentials -- the network path
+        literally didn't exist."""
+        networks = override_data["services"][service].get("networks", [])
+        assert "fawkes-backbone-net" in networks, (
+            f"{service} must join fawkes-backbone-net to reach uFawkesRes's "
+            f"fawkes-postgres -- resource-plane mode is unreachable without it"
+        )
+
+    def test_declares_fawkes_backbone_net_as_external(
+        self, override_data: dict
+    ) -> None:
+        net = override_data.get("networks", {}).get("fawkes-backbone-net", {})
+        assert net.get("external") is True, (
+            "fawkes-backbone-net must be declared external -- it's created by "
+            "uFawkesRes's own compose stack, not by uFawkesObs"
+        )
+        assert net.get("name") == "ufawkes-resources_fawkes-backbone-net", (
+            "external network name must match uFawkesRes's actual compose "
+            "project name (name: ufawkes-resources in its compose.yaml)"
+        )
+
 
 class TestDoraDatabaseFiles:
     """DB init/migration/hypertable SQL moved from uFawkesDORA (issue #202)."""


### PR DESCRIPTION
## Summary

Closes the uFawkesRes integration gap identified while working through "close the uFawkesRes/OTLP-metrics gaps": `dora-api`, `dora-compute`, and `dora-db-init` were never attached to `fawkes-backbone-net` — the external network uFawkesRes's Postgres actually runs on (`docs/product/design.md` §5). Even with correct `DORA_POSTGRES_URL` credentials, the network path to `fawkes-postgres` literally didn't exist — resource-plane mode was unreachable regardless of configuration.

## Root cause

`compose.resource-plane.override.yaml` swaps `DATABASE_URL` to point at the shared Postgres instance, but never joined the network that instance actually lives on. `dora-db-init` (defined in the base `compose.yaml`, gated behind the `resource-plane` profile) had the same gap.

## Fix

- Declares `fawkes-backbone-net` as `external: true` (created by uFawkesRes's own compose stack — `name: ufawkes-resources` there, confirmed by reading its `compose.yaml` directly — not by uFawkesObs).
- Adds it to `dora-api`, `dora-compute` (in the override, alongside the existing `DATABASE_URL` swap), and `dora-db-init` (new stanza in the override, since that service only exists in the base file).
- Verified via `docker compose config` that Compose correctly **unions** the network lists (`fawkes-backbone-net` + `observability`, not one replacing the other).

## What this does NOT close

Full live end-to-end connectivity against a running uFawkesRes instance — that needs uFawkesRes's own stack up with matching database/schema provisioning (its own `.env.example` currently provisions a generic `fawkes`/Postgres setup, not obviously the `ufawkesres` user/database this repo's `dora-db-init` migration expects). This PR closes the structural network gap; full cross-repo integration is a separate, larger piece of work.

## AI-Assisted Review Block

**What does this PR do?** Adds the missing network attachment so resource-plane services can reach uFawkesRes's Postgres at all.

**What could go wrong?** `external: true` networks fail `docker compose up` if the named network doesn't exist yet — this is expected/correct (uFawkesRes must be running first), not a bug. No impact on the default SQLite-based `dora` profile, which doesn't use this override file at all.

**What tests cover this change?** New tests in `tests/unit/test_dora_consolidation.py`: `test_joins_fawkes_backbone_net` (parametrized over all 3 services) and `test_declares_fawkes_backbone_net_as_external`, verifying the external network name matches uFawkesRes's actual compose project name exactly.

**Architecture check:** Touches only `compose.resource-plane.override.yaml` — no service/dependency changes, pure network wiring.

**What I was NOT sure about:** Whether uFawkesRes's current Postgres provisioning (user/database/schema) actually matches what `dora-db-init`'s migration expects — its `.env.example` suggests a generic setup, not obviously `ufawkesres`/`dora_metrics`. Flagging for whoever picks up full end-to-end verification.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pytest tests/unit/` — full suite passes, 2 new tests
- [x] `docker compose config` validated the merged network list resolves correctly
- [ ] Live end-to-end against a running uFawkesRes instance — not done, see "What this does NOT close" above