### PR TITLE
chore(community): add beta feedback channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to report bugs, suggest
 features, and submit pull requests (branch naming, test requirements, and
 PR description format).
 
+## Beta Feedback
+
+We're closing in on calling uFawkesObs "beta" and want to hear from real
+users first — especially if you starred/forked this repo but never
+actually ran it, or you tried it and got stuck. Tell us what happened in
+[**Beta Feedback discussion**](https://github.com/paruff/uFawkesObs/discussions/242)
+— a sentence is enough.
+
 ## uFawkes Stack Ecosystem
 
 See [Part of the Fawkes IDP](#part-of-the-fawkes-idp) above for the current suite family table — this section used to duplicate it with stale entries (uFawkesDORA, uFawkesSec still shown active, no uFawkesDojo) and has been removed rather than kept in sync in two places.

--- a/docs/product/discovery-draft.md
+++ b/docs/product/discovery-draft.md
@@ -153,10 +153,12 @@ first:
    (disk growth, upgrade pain, "how do I back this up" questions). This is
    free, uses data that already exists, and would show early churn signal
    without needing to design a survey.
-3. **If (1) and (2) don't settle it, ask directly.** Post a short
-   discussion/issue template aimed at anyone who starred or forked the repo
-   but never adopted it: "what stopped you?" A handful of real responses
-   would outweigh everything in this brief.
+3. **If (1) and (2) don't settle it, ask directly.** 🔄 In progress — posted
+   [Beta Feedback discussion #242](https://github.com/paruff/uFawkesObs/discussions/242)
+   2026-08-19, aimed at anyone who starred or forked the repo but never
+   adopted it, plus anyone who ran it and got stuck: "what stopped you?"
+   Linked from `README.md`. A handful of real responses would outweigh
+   everything in this brief.
 4. Whichever of the above runs first should update `baseline` in this
    file's frontmatter and flip the riskiest assumption from "asserted" to
    either "supported" or "falsified" — don't let this brief go stale as a


### PR DESCRIPTION
## Summary

Closes #184 (LB-06). GitHub Discussions was already enabled on the repo but only had the unedited default "Welcome to uFawkesObs Discussions!" placeholder — no actual feedback channel existed for the target use case.

- Posted [Beta Feedback discussion #242](https://github.com/paruff/uFawkesObs/discussions/242) in the Q&A category, aimed at the two audiences `docs/product/discovery-draft.md`'s "Next Actual Discovery Experiment" already identified: people who starred/forked the repo but never ran it ("what stopped you?"), and people who ran it and got stuck.
- Added a short "Beta Feedback" section to `README.md` linking to it.
- Marked discovery-draft.md's experiment (3) as in-progress with a link back to the live discussion.

## AI-Assisted Review Block

**What does this PR do?**
Adds a real, discoverable beta-feedback channel: a live GitHub Discussion, a README prompt linking to it, and an updated discovery-draft.md marking that experiment as in-progress instead of a future to-do.

**What could go wrong?**
Essentially nothing — pure docs + one community-content addition. The only judgment call was category choice (Q&A, since "I tried this and got stuck" fits "ask the community for help") over creating a dedicated category, which GitHub's API doesn't support creating programmatically anyway.

**What tests cover this change?**
Manual — no automated test exists for README content or Discussions. Verified the discussion is live and publicly visible at the linked URL, and that `README.md`/`discovery-draft.md` render correctly via markdown lint.

**Architecture check:**
- Docs-only change (`README.md`, `docs/product/discovery-draft.md`) — no AGENTS.md §4 layer touched.
- No cross-plane impact.

**What I was NOT sure about:**
The discussion isn't pinned — GitHub's GraphQL API has no `pinDiscussion` mutation (only `pinIssue` exists), so this can only be done from the Discussions tab UI. Left as a manual 10-second follow-up rather than blocking on it; discoverability is instead handled via the new README section and the discovery-draft.md link.

## Test plan

- [x] `pre-commit run` — passed (markdown lint, gitleaks)
- [x] Confirmed discussion #242 is live and publicly readable
- [x] Confirmed README and discovery-draft.md links resolve to the discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)