### PR TITLE
docs: relocate pr-review-block skill to .agents/skills/

### DIFF
--- a/.agents/skills/pr-review-block/SKILL.md
+++ b/.agents/skills/pr-review-block/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: pr-review-block
+description: Use when opening a pull request in uFawkesObs — provides the required "AI-Assisted Review Block" template every agent-opened PR description must include (AGENTS.md §7).
+---
+
+# AI-Assisted Review Block
+
+Every PR opened by an agent in this repo must include this block in its description. `review.md` checks for this literal structure — if you change the headings, update `review.md`'s check to match.
+
+```markdown
+## AI-Assisted Review Block
+
+**What does this PR do?**
+[...]
+
+**What could go wrong?**
+[...]
+
+**What tests cover this change?**
+[...]
+
+**Architecture check:**
+- What layer(s) were touched and are they correct per §4?
+- Any cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDevX)?
+
+**What I was NOT sure about:**
+[...]
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,27 +173,8 @@ Commit message format: `feat(scope):`, `fix(scope):`, `test(scope):`,
 
 Every PR opened by an agent must include this block in its description.
 `review.md` checks for this literal structure — if you change the
-headings, update `review.md`'s check to match.
-
-```markdown
-## AI-Assisted Review Block
-
-**What does this PR do?**
-[...]
-
-**What could go wrong?**
-[...]
-
-**What tests cover this change?**
-[...]
-
-**Architecture check:**
-- What layer(s) were touched and are they correct per §4?
-- Any cross-plane impact (uFawkesPipe, uFawkesRes, uFawkesDevX)?
-
-**What I was NOT sure about:**
-[...]
-```
+headings, update `review.md`'s check to match. See skill: `pr-review-block`
+for the exact template.
 
 ## 8. GitOps / Trunk-Based Delivery Contract
 


### PR DESCRIPTION
## Summary

A prior session created `.claude/skills/pr-review-block/SKILL.md` and updated `AGENTS.md` §7 to point to it, but `.claude/skills/` isn't this repo's actual skill convention — `.agents/skills/` is, with 14 other skills already there (obs-stack, dora-metrics, promql, etc.), per AGENTS.md §2. Moves the file to the right home and lands the already-drafted AGENTS.md §7 pointer that had no real target until now.

## AI-Assisted Review Block

**What does this PR do?**
Moves one skill file from `.claude/skills/pr-review-block/` to `.agents/skills/pr-review-block/` and commits the matching AGENTS.md §7 edit (replacing the inline PR-review-block template with a pointer to the skill) that was already sitting uncommitted from a prior session.

**What could go wrong?**
Nothing — no other file in the repo referenced `.claude/skills` (verified via grep). This is a pure relocation.

**What tests cover this change?**
Manual — no automated test exists for skill file location. `pre-commit run` passed.

**Architecture check:**
- Docs/tooling-only change — no AGENTS.md §4 layer touched.
- No cross-plane impact.

**What I was NOT sure about:**
Nothing notable.

## Test plan

- [x] `pre-commit run` — passed
- [x] Verified no remaining references to `.claude/skills` anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)