### PR TITLE
docs: mark LB-05 and LB-06 done in Path to Late Beta

### DIFF
--- a/docs/PATH_TO_LATE_BETA.md
+++ b/docs/PATH_TO_LATE_BETA.md
@@ -57,8 +57,8 @@ Concretely, late beta requires:
 | LB-02 | Restrict Loki/Tempo/Prometheus/Alertmanager ports to localhost by default | [#180](https://github.com/paruff/uFawkesObs/issues/180) | 🔲 PENDING |
 | LB-03 | Add a tested Slack notification channel for Alertmanager | [#181](https://github.com/paruff/uFawkesObs/issues/181) | 🔲 PENDING |
 | LB-04 | Run and document a live rollback drill | [#182](https://github.com/paruff/uFawkesObs/issues/182) | 🔲 PENDING (runbook ready) |
-| LB-05 | Investigate GitOps Reconciliation Deploy transient failure | [#183](https://github.com/paruff/uFawkesObs/issues/183) | 🔲 PENDING |
-| LB-06 | Add a beta feedback channel | [#184](https://github.com/paruff/uFawkesObs/issues/184) | 🔲 PENDING |
+| LB-05 | Investigate GitOps Reconciliation Deploy transient failure | [#183](https://github.com/paruff/uFawkesObs/issues/183) | ✅ DONE — root cause was a dead `push` trigger (deploy secrets unavailable in that context, 100% failure rate); removed in PR #196. 55/55 `workflow_run`-triggered deploys since have succeeded. |
+| LB-06 | Add a beta feedback channel | [#184](https://github.com/paruff/uFawkesObs/issues/184) | ✅ DONE — [discussion #242](https://github.com/paruff/uFawkesObs/discussions/242) posted, linked from README (PR #243, merged) |
 | LB-07 | Reconcile `docs/plan.md` status drift against real issue state | [#185](https://github.com/paruff/uFawkesObs/issues/185) | 🟡 IN PROGRESS (plan.md reconciled 2026-08-12; superseded issues #51–#54, #80–#83 closed) |
 
 All issues are labeled `late-beta` for tracking:


### PR DESCRIPTION
## Summary

Updates `docs/PATH_TO_LATE_BETA.md`'s exit-criteria table to match reality:

- **LB-05 (#183):** closed with evidence — the fix was already merged (PR #196) but the issue and this tracker were never updated. Root cause: `deploy.yml` had a dead `push` trigger whose runs deterministically failed (deploy secrets unavailable in that context), producing confusing red runs alongside the working `workflow_run`-gated path. Confirmed via 60-run history: 55/55 `workflow_run`-triggered deploys since the fix succeeded; the only 2 failures in the sample are both pre-fix `push`-triggered runs.
- **LB-06 (#184):** closed via merged PR #243 (beta feedback discussion + README link).

Only 3 items remain open on the Path to Late Beta gate: LB-02, LB-03, LB-04.

## AI-Assisted Review Block

**What does this PR do?**
Updates two status-table rows in a tracking doc from PENDING to DONE, matching already-verified/already-merged work.

**What could go wrong?**
Nothing — pure documentation status update, no functional change.

**What tests cover this change?**
N/A — status table only.

**Architecture check:**
- Docs-only.
- No cross-plane impact.

**What I was NOT sure about:**
While investigating, I also noticed LB-02's row still says PENDING even though issue #180 is already closed and `compose.yaml` already has the `127.0.0.1:` localhost-only bindings — but that's out of scope for this PR since it wasn't part of what I was asked to verify here. Flagging for a possible follow-up.

## Test plan

- [x] `pre-commit run` — passed
- [x] Verified LB-05 root cause and fix against actual run history (`gh run list`) and merged commit ancestry
- [x] Verified LB-06 via merged PR #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)