### PR TITLE
fix(ci): allow external_directory writes for opencode

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": "allow"
+  }
+}


### PR DESCRIPTION
## Summary
Ported from `paruff/fawkes` (#1622 there): `external_directory` permission defaults to `"ask"` when unset, which blocks forever in headless CI — there's no human present to answer the confirmation prompt — if opencode ever needs to write outside the checkout (e.g. self-installing a tool). Confirmed this exact hang in fawkes, where it burned a full 30-minute workflow timeout on a Terraform self-install attempt.

Scoped down from the full set of fawkes fixes after checking this repo specifically:
- **Terraform/TFLint pre-install**: not applicable, no `.tf` files in this repo.
- **Commit-msg hook**: already present (`scripts/commit-msg.sh` via `.pre-commit-config.yaml`), nothing to add.
- **This permission fix**: the one genuinely applicable item — preventive, no known trigger has hit it here yet, but the failure mode is silent and expensive (a full timeout) when it does happen.

Did not touch the existing nim-proxy / provider-fallback workflow logic — added a new `.opencode/opencode.json` since none existed, only setting the one `permission` key.

## Test plan
- [x] pre-commit hooks pass locally, including this repo's own conventional-commit-msg hook
- [ ] No direct test available without triggering a real `/oc` run that needs external-directory access

🤖 Generated with [Claude Code](https://claude.com/claude-code)