### PR TITLE
feat(deploy): switch to tag-based deploy/rollback (LB-04 redesign)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,43 @@ concurrency:
 
 # Deploy only when the triggering acceptance-full workflow passed
 jobs:
+  # ─── Tag Deploy Candidate ──────────────────────────────────────────────────
+  # Deploy targets an immutable tag, not main's moving HEAD (LB-04 redesign,
+  # #182). Rollback checks out deploy-latest-good instead of reverting +
+  # pushing to main, so neither deploy nor rollback ever pushes to main —
+  # branch protection on main no longer affects this pipeline at all.
+  tag-candidate:
+    name: Tag deploy candidate
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: "job-start"
+        run: 'echo "job-start: $(date -u +%Y-%m-%dT%H:%M:%SZ)"'
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Create and push candidate tag
+        id: tag
+        run: |
+          set -euo pipefail
+          sha="${{ github.event.workflow_run.head_sha }}"
+          tag="deploy-$(date -u +%Y%m%d-%H%M%S)-${sha:0:7}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "Deploy candidate ${sha}"
+          git push origin "$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: "job-finish"
+        if: always()
+        run: 'echo "job-finish: $(date -u +%Y-%m-%dT%H:%M:%SZ)"'
+
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
@@ -59,7 +96,7 @@ jobs:
 
   deploy-config-reload:
     name: Deploy (config reload)
-    needs: detect-changes
+    needs: [detect-changes, tag-candidate]
     # Ensure the triggering acceptance-full workflow passed
     if: |
       github.event.workflow_run.conclusion == 'success' &&
@@ -123,6 +160,7 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
+          DEPLOY_TAG: ${{ needs.tag-candidate.outputs.tag }}
         run: |
           set -euo pipefail
           REPO_NAME="${GITHUB_REPOSITORY##*/}"
@@ -147,7 +185,14 @@ jobs:
                 ;;
             esac
           fi
-          ssh -o StrictHostKeyChecking=yes "${DEPLOY_USER}@${DEPLOY_HOST}" "REPO_NAME='${REPO_NAME}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE'
+          case "${DEPLOY_TAG}" in
+            deploy-????????-??????-*) ;;
+            *)
+              echo "::error::Unexpected DEPLOY_TAG format: ${DEPLOY_TAG}"
+              exit 1
+              ;;
+          esac
+          ssh -o StrictHostKeyChecking=yes "${DEPLOY_USER}@${DEPLOY_HOST}" "REPO_NAME='${REPO_NAME}' DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_TAG='${DEPLOY_TAG}' bash -s" <<'REMOTE'
           set -euo pipefail
 
           REPO_DIR="${DEPLOY_PATH:-$HOME/${REPO_NAME}}"
@@ -168,7 +213,8 @@ jobs:
           fi
 
           cd "${REPO_DIR}"
-          git pull --ff-only origin main
+          git fetch --tags --force origin
+          git checkout --detach "${DEPLOY_TAG}"
 
           curl --fail --show-error --silent --connect-timeout 5 --max-time 10 -X POST http://localhost:9090/-/reload || {
             echo "Prometheus reload failed"
@@ -201,7 +247,7 @@ jobs:
 
   deploy-compose-restart:
     name: Deploy (compose restart)
-    needs: detect-changes
+    needs: [detect-changes, tag-candidate]
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       (
@@ -266,6 +312,7 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
+          DEPLOY_TAG: ${{ needs.tag-candidate.outputs.tag }}
         run: |
           set -euo pipefail
           REPO_NAME="${GITHUB_REPOSITORY##*/}"
@@ -290,7 +337,14 @@ jobs:
                 ;;
             esac
           fi
-          ssh -o StrictHostKeyChecking=yes "${DEPLOY_USER}@${DEPLOY_HOST}" "REPO_NAME='${REPO_NAME}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE'
+          case "${DEPLOY_TAG}" in
+            deploy-????????-??????-*) ;;
+            *)
+              echo "::error::Unexpected DEPLOY_TAG format: ${DEPLOY_TAG}"
+              exit 1
+              ;;
+          esac
+          ssh -o StrictHostKeyChecking=yes "${DEPLOY_USER}@${DEPLOY_HOST}" "REPO_NAME='${REPO_NAME}' DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_TAG='${DEPLOY_TAG}' bash -s" <<'REMOTE'
           set -euo pipefail
 
           REPO_DIR="${DEPLOY_PATH:-$HOME/${REPO_NAME}}"
@@ -311,7 +365,8 @@ jobs:
           fi
 
           cd "${REPO_DIR}"
-          git pull --ff-only origin main
+          git fetch --tags --force origin
+          git checkout --detach "${DEPLOY_TAG}"
 
           make up
 
@@ -339,6 +394,7 @@ jobs:
     name: "🧪 Post-Deploy Verification"
     needs:
       - detect-changes
+      - tag-candidate
       - deploy-config-reload
       - deploy-compose-restart
     if: |
@@ -348,6 +404,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     outputs:
       health_result: ${{ steps.verify.outputs.health_result }}
     steps:
@@ -420,29 +478,149 @@ jobs:
           echo "health_result=passed" >> "$GITHUB_OUTPUT"
           echo "✅ Post-deployment verification passed"
 
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.tag-candidate.outputs.tag }}
+
+      - name: Promote deploy-latest-good
+        env:
+          DEPLOY_TAG: ${{ needs.tag-candidate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f deploy-latest-good "${DEPLOY_TAG}"
+          git push origin deploy-latest-good --force
+
       - name: "job-finish"
         if: always()
         run: 'echo "job-finish: $(date -u +%Y-%m-%dT%H:%M:%SZ)"'
 
   # ─── Rollback on Verification Failure ──────────────────────────────────────
+  # Checks out deploy-latest-good on the host — the last candidate tag that
+  # actually passed post-deploy-verify. Purely read-only from git's
+  # perspective (fetch + checkout, no push, no revert), on the runner or the
+  # host, so it is unaffected by main's branch protection (LB-04 redesign,
+  # #182).
   rollback:
     name: "🔄 Rollback"
     needs: post-deploy-verify
     if: failure() && needs.post-deploy-verify.result == 'failure'
-    uses: paruff/ufawkespipe/.github/workflows/reusable-rollback.yml@v1.3.0-beta.1
-    with:
-      deploy-path: ${{ vars.DEPLOY_PATH }}
-      restart-command: "cd ${DEPLOY_PATH:-$HOME/${GITHUB_REPOSITORY##*/}} && make up"
-    secrets:
-      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-      DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-      DEPLOY_HOST_KEY: ${{ secrets.DEPLOY_HOST_KEY }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      rollback_result: ${{ steps.rollback.outputs.result }}
+    steps:
+      - name: "job-start"
+        run: 'echo "job-start: $(date -u +%Y-%m-%dT%H:%M:%SZ)"'
+
+      - name: Validate deploy secrets
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          missing=0
+          if [ -z "${DEPLOY_HOST}" ]; then echo "::error::Missing DEPLOY_HOST"; missing=1; fi
+          if [ -z "${DEPLOY_USER}" ]; then echo "::error::Missing DEPLOY_USER"; missing=1; fi
+          if [ -z "${DEPLOY_KEY}" ]; then echo "::error::Missing DEPLOY_KEY"; missing=1; fi
+          if [ "$missing" -ne 0 ]; then exit 1; fi
+
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Add deploy host to known_hosts
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_HOST_KEY: ${{ secrets.DEPLOY_HOST_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          if [ -n "${DEPLOY_HOST_KEY}" ]; then
+            printf '%s\n' "${DEPLOY_HOST_KEY}" >> ~/.ssh/known_hosts
+          else
+            echo "::warning::DEPLOY_HOST_KEY not set; using ssh-keyscan TOFU fallback for ${DEPLOY_HOST}"
+            ssh-keyscan -T 10 -H "${DEPLOY_HOST}" >> ~/.ssh/known_hosts
+          fi
+
+      - name: Roll back to deploy-latest-good on target host
+        id: rollback
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
+        run: |
+          set -euo pipefail
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          case "${REPO_NAME}" in
+            ""|.*|*..*|*.|*[!A-Za-z0-9._-]*)
+              echo "::error::Unsafe repository name for remote path: ${REPO_NAME}"
+              exit 1
+              ;;
+          esac
+          if [ -n "${DEPLOY_PATH}" ]; then
+            case "${DEPLOY_PATH}" in
+              /*) ;;
+              *)
+                echo "::error::DEPLOY_PATH must be an absolute path: ${DEPLOY_PATH}"
+                exit 1
+                ;;
+            esac
+            case "${DEPLOY_PATH}" in
+              *"'"*|*..*|*[!A-Za-z0-9_./-]*)
+                echo "::error::Unsafe DEPLOY_PATH value: ${DEPLOY_PATH}"
+                exit 1
+                ;;
+            esac
+          fi
+          ssh -o StrictHostKeyChecking=yes "${DEPLOY_USER}@${DEPLOY_HOST}" "REPO_NAME='${REPO_NAME}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          REPO_DIR="${DEPLOY_PATH:-$HOME/${REPO_NAME}}"
+          case "${REPO_DIR}" in
+            ""|*..*)
+              echo "Unsafe repository path: ${REPO_DIR}"
+              exit 1
+              ;;
+          esac
+          if [[ "${REPO_DIR}" != /* ]]; then
+            echo "Repository path must be absolute: ${REPO_DIR}"
+            exit 1
+          fi
+
+          if [ ! -d "${REPO_DIR}/.git" ]; then
+            echo "Repository not found at ${REPO_DIR}. Set repository variable DEPLOY_PATH to the clone path on the target host."
+            exit 1
+          fi
+
+          cd "${REPO_DIR}"
+          git fetch --tags --force origin
+          git checkout --detach deploy-latest-good
+
+          make up
+
+          if [ ! -x ./scripts/wait-healthy.sh ]; then
+            echo "Missing executable script: ./scripts/wait-healthy.sh"
+            exit 1
+          fi
+
+          ./scripts/wait-healthy.sh
+          REMOTE
+          echo "result=success" >> "$GITHUB_OUTPUT"
+
+      - name: "job-finish"
+        if: always()
+        run: 'echo "job-finish: $(date -u +%Y-%m-%dT%H:%M:%SZ)"'
 
   comment-summary:
     name: Post deployment summary
     needs:
       - detect-changes
+      - tag-candidate
       - deploy-config-reload
       - deploy-compose-restart
       - post-deploy-verify
@@ -467,6 +645,7 @@ jobs:
 
             const body = [
               '## GitOps Reconciliation Summary',
+              `- Deploy tag: ${{ needs.tag-candidate.outputs.tag }}`,
               `- Mode: ${mode}`,
               `- Services: ${services}`,
               `- Health check: ${health}`,

--- a/docs/DEPLOYMENT_STRATEGY.md
+++ b/docs/DEPLOYMENT_STRATEGY.md
@@ -9,12 +9,20 @@
 
 uFawkesObs currently deploys via SSH push to a single host. The process:
 
-1. **Push to `main`** triggers `deploy.yml`
-2. **Path detection** determines what changed (config vs compose)
-3. **Config-only changes**: `git pull` on target → Prometheus `/-/reload` + Alloy `SIGHUP`
-4. **Compose/non-reloadable changes**: `git pull` → `make up` (full compose restart)
-5. **Post-deployment verification**: smoke tests against the live instance
-6. **Rollback on failure**: `git revert` + optional restart
+1. **Merge to `main`** passes Acceptance Full, which triggers `deploy.yml`
+2. **Tag the candidate**: an immutable `deploy-<UTC-ts>-<sha>` tag is created
+   and pushed, pinned to the exact verified commit — this is what gets
+   deployed, not whatever `main` happens to be by the time the job runs
+3. **Path detection** determines what changed (config vs compose)
+4. **Config-only changes**: target host checks out the candidate tag →
+   Prometheus `/-/reload` + Alloy `SIGHUP`
+5. **Compose/non-reloadable changes**: target host checks out the candidate
+   tag → `make up` (full compose restart)
+6. **Post-deployment verification**: smoke tests against the live instance;
+   on success, `deploy-latest-good` is force-pushed to the candidate SHA
+7. **Rollback on failure**: target host checks out `deploy-latest-good` →
+   `make up`. No `git revert`, no push to `main` — rollback only ever reads
+   an already-published tag (LB-04 redesign, [#182](https://github.com/paruff/uFawkesObs/issues/182))
 
 ### Limitations of Current Model
 
@@ -49,7 +57,7 @@ When uFawkesObs serves production traffic, deploy will follow a staged model:
 | **Canary** | 1 host | Automated health checks | Deploy → verify → promote or rollback |
 | **Staging** | 1 host | Automated health checks + smoke tests | Same as canary |
 | **Production** | N hosts (behind LB) | Human approval required | Deploy to subset, verify, full rollout |
-| **Rollback** | All | Automated on gate failure | `git revert` + `make up` |
+| **Rollback** | All | Automated on gate failure | checkout `deploy-latest-good` + `make up` |
 
 ### Prerequisites for Progressive Delivery
 
@@ -67,16 +75,25 @@ Before implementing the target model:
 
 ### Automated (Current)
 
-When `post-deploy-verify` fails in `deploy.yml`, the `rollback` job
-(`paruff/ufawkespipe/.github/workflows/reusable-rollback.yml@v1.2.0`):
+When `post-deploy-verify` fails in `deploy.yml`, the inline `rollback` job:
 1. SSHs into the target host
-2. Runs `git revert HEAD --no-edit`
-3. Pushes the revert to `origin main`
-4. Runs `make up` to restart the previous stack
+2. Fetches tags and checks out `deploy-latest-good` (the most recent
+   candidate tag that actually passed `post-deploy-verify`)
+3. Runs `make up` to restart that stack
 
-> **Not yet proven.** This path is documented and wired in CI but has never
-> been exercised end-to-end against a real host. It is **unproven** until a
-> live rollback drill records successful results (LB-04). See
+No `git revert`, no push — rollback is purely read-only from git's
+perspective (fetch + checkout), on the runner and on the host. This is a
+deliberate redesign (LB-04, [#182](https://github.com/paruff/uFawkesObs/issues/182)):
+the previous `git revert HEAD` + push-to-`main` design was structurally
+incompatible with the branch protection enabled on `main` (required PR
+review blocks any direct push, including the host's revert). Rollback never
+touching `main` makes that conflict structurally impossible rather than a
+static argument to re-check on every branch-protection change.
+
+> **Not yet proven.** This path is wired and unit-tested (`tests/unit/
+> test_deploy_pipeline.py::TestTagBasedDeployRollback`) but has never been
+> exercised end-to-end against a real host. It is **unproven** until a live
+> rollback drill records successful results. See
 > [Rollback Drill (LB-04)](#rollback-drill-lb-04) below.
 
 ### Rollback Drill (LB-04)
@@ -89,14 +106,18 @@ automatically, and confirms the host returns to a healthy previous state.
 
 Status: **PENDING** — runbook ready, live drill not yet executed against a real
 target host ([issue #182](https://github.com/paruff/uFawkesObs/issues/182)).
+An OCI Compute sandbox host is being provisioned as the drill target.
 
-2026-08-11: static enablement review (guard tests + wiring verification)
-confirmed the drill's fault-injection path (`config/otel/**` →
-`deploy-compose-restart` → `post-deploy-verify` → `rollback`) is wired in
-`deploy.yml`, and cleared the suspected runner-token blocker in
-[issue #193](https://github.com/paruff/uFawkesObs/issues/193) (the revert+push
-runs on the target host, not the runner). The live drill still must prove host
-push credentials and `main` branch protection permit the revert.
+2026-08-21: redesigned deploy/rollback to be tag-based instead of
+`git revert`-based, since the original design's host-side push to `main`
+would have been rejected by the branch protection enabled this session. The
+new design has no push path to `main` at all — see "Automated (Current)"
+above. This supersedes the 2026-08-11 static review of
+[issue #193](https://github.com/paruff/uFawkesObs/issues/193) (that review's
+"does the push run on the runner or the host" question no longer applies,
+since rollback doesn't push anywhere). The only remaining live-drill unknown
+is whether `deploy-latest-good` actually resolves and checks out cleanly
+under real network/SSH conditions.
 
 | Drill date | Host | Pre-drill SHA | Time to rollback | Recovered? | Gaps |
 |---|---|---|---|---|---|
@@ -114,9 +135,9 @@ ssh user@host
 # Navigate to repo
 cd /path/to/uFawkesObs
 
-# Revert the last deploy commit
-git revert HEAD --no-edit
-git push origin main
+# Check out the last known-good deploy tag
+git fetch --tags --force origin
+git checkout --detach deploy-latest-good
 
 # Restart the stack
 make up

--- a/docs/ROLLBACK_DRILL.md
+++ b/docs/ROLLBACK_DRILL.md
@@ -49,19 +49,18 @@ docker compose ps           # all services running
 ./scripts/wait-healthy.sh   # exit 0
 ```
 
-### 3. Main is pushable
+### 3. Host can fetch tags
 
-The drill pushes a deliberately-bad commit to `main`, and the automated
-rollback pushes a revert to `main`. Both must be permitted:
+Deploy and rollback are both tag-based (LB-04 redesign) — rollback checks
+out `deploy-latest-good` on the host and **does not push to main**, so main's
+branch protection has no bearing on rollback at all. The only requirement:
 
-- The rollback's `git push origin main` executes **on the target host over
-  SSH** — the host pushes with its own cloned `origin` credential, not a runner
-  token. The host must therefore already hold a working **push credential**
-  for `origin` (verify with `git fetch origin main` from the host).
-- Check branch protection on `main` (Settings → Branches). If it rejects the
-  host's push or a direct push path, the drill **cannot run as automated** —
-  use the manual fallback in [Safety & Cleanup](#safety--cleanup) and file a
-  follow-up issue.
+- The target host's clone must have a working `origin` remote it can
+  **fetch** from (verify with `git fetch --tags origin` from the host — no
+  push credential is needed for this step).
+- Landing the bad commit on `main` (Step 2 below) still goes through the
+  normal PR path, since branch protection requires a PR + review to reach
+  `main` — the drill no longer force-pushes directly to `main`.
 
 ### 4. Environment approval ready
 
@@ -120,6 +119,9 @@ git commit -m "chore(drill): deliberately break otel collector config (LB-04)"
 git push origin drill/lb04-bad-deploy
 ```
 
+Branch protection on `main` requires a PR + review, so this no longer lands
+via a direct push — open and merge it like a real change (Step 2 below).
+
 Alternative recipes (same failure mode, choose one):
 
 - Break `config/alertmanager/alertmanager.yml` (also `non_reloadable_config`).
@@ -145,17 +147,22 @@ date -u +%FT%TZ
 ssh "${DEPLOY_USER}@${DEPLOY_HOST}" "${DEPLOY_PATH:-$HOME/uFawkesObs}/scripts/wait-healthy.sh" && echo BASELINE_OK
 ```
 
-### Step 2 — Push the bad commit to main
+### Step 2 — Land the bad commit on main
 
 ```bash
-git push origin drill/lb04-bad-deploy:main
+gh pr create --base main --head drill/lb04-bad-deploy \
+  --title "chore(drill): deliberately break otel collector config (LB-04)" \
+  --body "Rollback drill — see docs/ROLLBACK_DRILL.md. Do not squash-merge as a real fix."
+gh pr merge --squash --admin   # repo admin self-approve; a non-admin needs a real review
 ```
 
-> Expected: **Acceptance Full (Post-Merge)** starts on the bad SHA (deploy.yml
-> has been acceptance-gated since LB-05/#183 — it no longer triggers directly
-> on `push`). When that workflow completes, a run of **GitOps Reconciliation
-> Deploy** starts on the bad SHA; `detect-changes` →
-> `deploy-compose-restart` waits on the `compose-restart` environment approval.
+> Expected: merging starts **Acceptance Full (Post-Merge)** on the bad SHA
+> (deploy.yml has been acceptance-gated since LB-05/#183 — it no longer
+> triggers directly on `push`). When that workflow completes, `deploy.yml`'s
+> `tag-candidate` job tags and pushes the bad SHA as
+> `deploy-<ts>-<sha>`, and a run of **GitOps Reconciliation Deploy** starts;
+> `detect-changes` → `deploy-compose-restart` waits on the `compose-restart`
+> environment approval.
 
 ### Step 3 — Approve the compose-restart environment
 
@@ -175,28 +182,37 @@ Expected sequence on the host (watch via
 
 ### Step 5 — Confirm the rollback fires automatically
 
-- The `rollback` job (`uses: paruff/ufawkespipe/.github/workflows/reusable-rollback.yml@v1.2.0`)
-  must start **automatically** (no human trigger) within seconds of
-  `post-deploy-verify` failing.
+- The inline `rollback` job in `deploy.yml` must start **automatically** (no
+  human trigger) within seconds of `post-deploy-verify` failing.
 - Expected inside the rollback job:
   1. SSH to target.
-  2. `git revert --no-edit HEAD` — reverts the bad commit **locally**.
-  3. `git push origin main` — the revert must reach `main`.
-  4. `make up` — previous stack restarts.
+  2. `git fetch --tags --force origin` — read-only, no push credential used.
+  3. `git checkout --detach deploy-latest-good` — the last candidate tag that
+     actually passed `post-deploy-verify` (never the just-failed bad one,
+     since it was never promoted).
+  4. `make up` — that stack restarts.
+- Rollback does not push to `main`, and it does not run `git revert`
+  anywhere, on the runner or the host — this is what makes it immune to
+  main's branch protection.
 
 ### Step 6 — Confirm recovery
 
-- The rollback push creates a **new** deploy run on the revert SHA; that run's
-  `post-deploy-verify` must pass.
 - On the host, confirm the previous healthy state:
   ```bash
   ssh "${DEPLOY_USER}@${DEPLOY_HOST}" "${DEPLOY_PATH:-$HOME/uFawkesObs}/scripts/wait-healthy.sh" && echo RECOVERED
   docker compose ps
   ```
-- Confirm `main` is clean and CI is green again:
+- **`main` is not automatically fixed** — unlike the old revert-based design,
+  the tag-based rollback only recovers the *deployed host*; the bad commit
+  stays merged on `main` until a human lands a real fix or revert PR (see
+  [Safety & Cleanup](#safety--cleanup)). This is a deliberate trade-off: the
+  host recovers immediately and automatically, and the actual code fix goes
+  through normal review instead of an unreviewed automated revert.
+- Confirm `deploy-latest-good` still points at the pre-drill (good) SHA, not
+  the drill's bad one:
   ```bash
-  git fetch origin main && git log origin/main --oneline -3   # HEAD~1 == pre-drill SHA
-  gh run list --limit 5
+  git fetch origin main && git log origin/main --oneline -3   # bad commit still present
+  git rev-parse deploy-latest-good   # should equal the pre-drill SHA
   ```
 
 **Drill success criteria (all must hold):**
@@ -204,8 +220,8 @@ Expected sequence on the host (watch via
 1. `post-deploy-verify` caught the bad deploy (job failed).
 2. `rollback` fired automatically — no human pressed the button.
 3. The host returned to a healthy previous state.
-4. `main` self-healed: it contains the revert, and the post-revert deploy
-   verified green.
+4. `deploy-latest-good` was never advanced to the bad commit's tag — it still
+   points at the last genuinely good deploy.
 
 ---
 
@@ -221,17 +237,17 @@ Workflow run: https://github.com/paruff/uFawkesObs/actions/runs/<RUN_ID>
 | # | Timestamp (UTC) | Event | Expected | Observed | Pass/Fail |
 |---|---|---|---|---|---|
 | 1 | | Baseline `wait-healthy.sh` | exit 0 | | |
-| 2 | | Bad commit pushed to main | deploy run starts | | |
-| 3 | | `compose-restart` env approved | deploy proceeds | | |
-| 4 | | OTel Collector container | crashes at boot | | |
-| 5 | | `post-deploy-verify` | FAILS (wait-healthy timeout) | | |
-| 6 | | `rollback` job | auto-starts | | |
-| 7 | | `git revert` on host | local revert applied | | |
-| 8 | | `git push origin main` (revert) | main reverted | | |
-| 9 | | `make up` after revert | previous stack restarts | | |
-| 10 | | Recovery `wait-healthy.sh` | exit 0 | | |
-| 11 | | Post-revert deploy verify | PASS | | |
-| 12 | | `main` CI | green | | |
+| 2 | | Bad commit merged to main via PR | Acceptance Full starts | | |
+| 3 | | `tag-candidate` job | pushes `deploy-<ts>-<sha>` for the bad SHA | | |
+| 4 | | `compose-restart` env approved | deploy proceeds | | |
+| 5 | | OTel Collector container | crashes at boot | | |
+| 6 | | `post-deploy-verify` | FAILS (wait-healthy timeout); `deploy-latest-good` NOT advanced | | |
+| 7 | | `rollback` job | auto-starts | | |
+| 8 | | `git fetch --tags` on host | succeeds (read-only) | | |
+| 9 | | `git checkout --detach deploy-latest-good` | checks out last good tag | | |
+| 10 | | `make up` after checkout | previous stack restarts | | |
+| 11 | | Recovery `wait-healthy.sh` | exit 0 | | |
+| 12 | | `deploy-latest-good` after drill | still points at pre-drill SHA | | |
 
 **Timing:** note seconds from Step 2 push → Step 5 rollback start, and from
 Step 5 → Step 6 recovery. These go into the results table.
@@ -248,12 +264,12 @@ line.
 ## Drill Results — <date> (run <RUN_ID>)
 
 - Host: <non-prod host>
-- Pre-drill SHA: <...>  Post-revert SHA: <...>
+- Pre-drill SHA: <...>  Bad candidate tag: <deploy-...>
 - Time to rollback start: <s>   Time to recovery: <s>
 - post-deploy-verify caught the break: yes/no
 - rollback fired automatically: yes/no
 - Host returned to healthy: yes/no
-- main self-healed: yes/no
+- deploy-latest-good still points at the pre-drill SHA: yes/no
 - Gaps found: <list>
 ```
 
@@ -264,31 +280,25 @@ line.
 - Every gap issue must reference this drill's run URL and the failing evidence
   row(s).
 
-### Static review of the suspected gap — 2026-08-11 (LB-04 enablement)
+### Design history
 
-The suspected gap below was re-checked statically during LB-04 enablement
-(`tests/unit/test_deploy_pipeline.py` and `tests/unit/test_deploy_docs.py`).
+**2026-08-11 (LB-04 enablement):** a static review found the original
+`git revert HEAD` + host push design's suspected gap (issue #193, "does the
+runner's `GITHUB_TOKEN` block the push?") was refuted — the push executed on
+the target host over SSH, not the runner, so token permissions never gated
+it. Two unknowns remained that only a live run could clear: whether the host
+held a working push credential, and whether main's branch protection would
+let the revert land.
 
-**Verdict: issue #193's two stated reasons are refuted.** The rollback job's
-`git revert` + `git push origin main` execute **on the target host over SSH,
-not on the runner** — the git commands are shipped through an `ssh … bash -s`
-heredoc in `reusable-rollback.yml@v1.2.0`. Consequences:
-
-- The runner's `GITHUB_TOKEN` (downgraded to `contents: read`) is **not** the
-  credential that pushes; the host pushes with its own `origin` credential, so
-  the token-permission concern does **not** gate the drill.
-- The missing `actions/checkout` on the runner is irrelevant to the push for
-  the same reason; the steps that need `DEPLOY_KEY` read it directly from the
-  `secrets:` pass-through, which read-only permissions do not block.
-
-**Remaining live-drill unknowns (only the live run can clear these):**
-
-- [ ] The target host holds a working **push credential** for `origin`.
-- [ ] `main` branch protection lets the host's revert push land.
-
-Evidence rows 6–9 in the Evidence Log exist to record these against the run.
-Tracked in [issue #193](https://github.com/paruff/uFawkesObs/issues/193) —
-the live drill confirms or refutes the remaining unknowns.
+**2026-08-21 (this redesign):** rather than resolve those unknowns, the
+mechanism changed so they no longer apply. Rollback now checks out
+`deploy-latest-good` on the host instead of reverting and pushing — it
+**does not push to main** at all, on the runner or the host. This
+structurally eliminates both #193's original concern and its interaction
+with branch protection, rather than depending on a specific credential or
+protection-rule configuration holding. The only unknown a live drill still
+needs to clear: does `deploy-latest-good` actually resolve and check out
+cleanly under real network/SSH conditions.
 
 ---
 
@@ -296,26 +306,32 @@ the live drill confirms or refutes the remaining unknowns.
 
 - **Never run against a production host.** Verify `DEPLOY_HOST` first
   (Preconditions).
-- The drill deliberately puts a broken commit on `main`. If automated rollback
-  does **not** fire or does not complete, restore manually **immediately**:
+- If automated rollback does **not** fire or does not complete, restore the
+  host manually **immediately**:
 
   ```bash
-  # From a clean checkout of main:
-  git revert --no-edit HEAD
-  git push origin main
-  # On the target host:
   ssh "${DEPLOY_USER}@${DEPLOY_HOST}"
   cd "${DEPLOY_PATH:-$HOME/uFawkesObs}"
-  git pull --ff-only origin main
+  git fetch --tags --force origin
+  git checkout --detach deploy-latest-good
   make up
   ./scripts/wait-healthy.sh
   ```
 
-- After the drill, confirm the local drill branch is deleted and `main` has no
-  leftover drill artifacts:
+- **`main` always needs manual cleanup after this drill**, whether or not
+  rollback succeeded — the tag-based design deliberately leaves the bad
+  commit merged on `main` (see Step 6). Open and merge a normal revert PR:
+
   ```bash
+  git revert --no-edit <bad-commit-sha>
+  gh pr create --base main --title "revert: LB-04 drill bad commit" --body "See docs/ROLLBACK_DRILL.md"
+  gh pr merge --squash --admin
+  ```
+
+- Confirm the drill branch is deleted:
+  ```bash
+  git push origin --delete drill/lb04-bad-deploy
   git branch -D drill/lb04-bad-deploy
-  git fetch origin main && git diff --stat origin/main@{1} origin/main || true
   ```
 - If any step could not be completed, leave LB-04 **PENDING** and file a
   follow-up issue describing the blocker. Do not mark the drill done.

--- a/tests/unit/test_deploy_docs.py
+++ b/tests/unit/test_deploy_docs.py
@@ -74,31 +74,37 @@ class TestRollbackDrillRunbook:
         )
 
 
-class TestRollbackDrillStaticVerification:
-    """Verify the runbook records the LB-04 enablement static review (#182)."""
+class TestRollbackDrillTagBasedDesign:
+    """Verify the runbook documents the tag-based deploy/rollback redesign.
 
-    def test_runbook_records_static_verdict_on_gap(
+    Rollback checks out the ``deploy-latest-good`` tag on the host instead of
+    ``git revert`` + pushing to ``main`` — this is what makes the drill immune
+    to main's branch protection (the original #193/#182 concern).
+    """
+
+    def test_runbook_documents_deploy_latest_good_tag(
         self, rollback_drill_text: str
     ) -> None:
-        assert "refutes" in rollback_drill_text, (
-            "Runbook must record the static-review verdict that issue #193's "
-            "runner-token reasoning is refuted"
+        assert "deploy-latest-good" in rollback_drill_text, (
+            "Runbook must document the deploy-latest-good tag rollback targets"
         )
 
-    def test_runbook_contrasts_host_and_runner_execution(
+    def test_runbook_confirms_rollback_never_pushes_to_main(
         self, rollback_drill_text: str
     ) -> None:
-        assert "not on the runner" in rollback_drill_text, (
-            "Runbook must document that the revert+push runs on the target "
-            "host, not on the runner"
+        assert "does not push to main" in rollback_drill_text.lower() or (
+            "never push" in rollback_drill_text.lower()
+        ), (
+            "Runbook must state that rollback never pushes to main, since "
+            "that's what makes it immune to branch protection"
         )
 
-    def test_runbook_names_remaining_live_unknowns(
+    def test_runbook_no_longer_names_branch_protection_as_a_blocker(
         self, rollback_drill_text: str
     ) -> None:
-        assert "push credential" in rollback_drill_text, (
-            "Runbook must name the remaining live-drill unknowns (target host "
-            "push credential, main branch protection)"
+        assert "cannot run as automated" not in rollback_drill_text, (
+            "Tag-based rollback never pushes to main, so branch protection "
+            "can no longer block the drill — this stale caveat must be removed"
         )
 
 

--- a/tests/unit/test_deploy_pipeline.py
+++ b/tests/unit/test_deploy_pipeline.py
@@ -241,31 +241,6 @@ class TestTagBasedDeployRollback:
         assert "push origin main" not in joined
         assert "push origin HEAD:main" not in joined
 
-    def test_rollback_has_no_local_checkout_step(
-        self, deploy_workflow: dict[str, Any]
-    ) -> None:
-        """The rollback job must not contain an actions/checkout step.
-
-        Because it calls a reusable workflow via ``uses:``, it cannot have
-        a ``steps:`` block; the git credentials it needs are provided through
-        ``secrets:`` pass-through (DEPLOY_KEY) and used on the SSH host, not
-        on the runner.  This test guards against a future refactor that
-        converts the job to an inline job and accidentally adds checkout.
-        """
-        job = deploy_workflow["jobs"]["rollback"]
-        # A reusable-workflow call job has no steps key; if that ever changes
-        # we want to be alerted so the git-credential approach is re-reviewed.
-        assert "steps" not in job, (
-            "rollback job must not have a steps block — it should remain a "
-            "reusable-workflow call (uses:) so git ops stay on the SSH host"
-        )
-
-    def test_rollback_restarts_with_make_up(
-        self, deploy_workflow: dict[str, Any]
-    ) -> None:
-        restart = deploy_workflow["jobs"]["rollback"]["with"]["restart-command"]
-        assert "make up" in restart
-
 
 class TestPostDeployVerify:
     """The drill relies on post-deploy-verify being a real, bounded health gate."""

--- a/tests/unit/test_deploy_pipeline.py
+++ b/tests/unit/test_deploy_pipeline.py
@@ -28,19 +28,6 @@ import yaml
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
 DEPLOY_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "deploy.yml"
 
-REUSABLE_ROLLBACK_PREFIX = "paruff/ufawkespipe/.github/workflows/reusable-rollback.yml@"
-
-REQUIRED_DEPLOY_SECRETS: tuple[str, ...] = (
-    "DEPLOY_HOST",
-    "DEPLOY_USER",
-    "DEPLOY_KEY",
-    "DEPLOY_HOST_KEY",
-)
-
-PINNED_REF_RE = re.compile(
-    r"(?:v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?|[0-9a-f]{40})$"
-)
-
 BAD_DRILL_PATHS: tuple[str, ...] = (
     "config/otel/collector.yaml",
     "config/alertmanager/alertmanager.yml",
@@ -145,8 +132,54 @@ class TestDeployTrigger:
         assert "main" in run["branches"]
 
 
-class TestRollbackWiring:
-    """The drill's core assertion: post-deploy-verify failure fires rollback."""
+class TestTagBasedDeployRollback:
+    """Tag-based deploy/rollback (LB-04 redesign): deploy targets an immutable
+    ``deploy-<ts>-<sha>`` tag; rollback checks out the ``deploy-latest-good``
+    tag on the host. Neither ever pushes to ``main`` — this replaces the
+    ``git revert HEAD`` + host push design that conflicted with branch
+    protection (see docs/DEPLOYMENT_STRATEGY.md).
+    """
+
+    def test_tag_candidate_job_gated_on_acceptance_success(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        job = deploy_workflow["jobs"]["tag-candidate"]
+        assert "workflow_run.conclusion == 'success'" in job.get("if", "")
+
+    def test_tag_candidate_pushes_immutable_deploy_tag(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        steps = deploy_workflow["jobs"]["tag-candidate"]["steps"]
+        joined = "\n".join(str(step) for step in steps)
+        assert "deploy-" in joined
+        assert "git tag" in joined
+        assert "git push origin" in joined
+
+    def test_deploy_jobs_need_tag_candidate_and_checkout_its_tag(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        for job_name in ("deploy-config-reload", "deploy-compose-restart"):
+            job = deploy_workflow["jobs"][job_name]
+            assert "tag-candidate" in job["needs"], (
+                f"{job_name} must depend on tag-candidate to receive DEPLOY_TAG"
+            )
+            steps = job["steps"]
+            joined = "\n".join(str(step) for step in steps)
+            assert "git pull --ff-only origin main" not in joined, (
+                f"{job_name} must check out the candidate tag, not pull main"
+            )
+            assert "git checkout" in joined
+            assert "DEPLOY_TAG" in joined
+
+    def test_post_deploy_verify_promotes_latest_good_on_success(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        job = deploy_workflow["jobs"]["post-deploy-verify"]
+        assert "tag-candidate" in job["needs"]
+        steps = job["steps"]
+        joined = "\n".join(str(step) for step in steps)
+        assert "deploy-latest-good" in joined
+        assert "--force" in joined
 
     def test_rollback_requires_post_deploy_verify(
         self, deploy_workflow: dict[str, Any]
@@ -165,48 +198,48 @@ class TestRollbackWiring:
         assert "needs.post-deploy-verify.result" in condition
         assert "'failure'" in condition
 
-    def test_rollback_uses_pinned_reusable_workflow(
+    def test_rollback_is_inline_job_checking_out_latest_good(
         self, deploy_workflow: dict[str, Any]
     ) -> None:
-        uses = deploy_workflow["jobs"]["rollback"].get("uses", "")
-        assert uses.startswith(REUSABLE_ROLLBACK_PREFIX), (
-            f"Unexpected rollback workflow: {uses}"
-        )
-        ref = uses.rsplit("@", 1)[-1]
-        assert PINNED_REF_RE.search(ref), f"Rollback workflow ref not pinned: {ref}"
-
-    def test_rollback_receives_all_deploy_secrets(
-        self, deploy_workflow: dict[str, Any]
-    ) -> None:
-        secrets = deploy_workflow["jobs"]["rollback"].get("secrets", {})
-        assert secrets, "rollback job must forward deploy secrets"
-        for name in REQUIRED_DEPLOY_SECRETS:
-            value = secrets.get(name, "")
-            assert name in value, f"rollback job missing secret {name}"
-
-    def test_rollback_does_not_add_job_level_contents_write(
-        self, deploy_workflow: dict[str, Any]
-    ) -> None:
-        """The rollback job must not add job-level permissions: contents: write.
-
-        The reusable-rollback.yml executes git revert + git push via an
-        ``ssh … bash -s`` heredoc on the target host — the runner's
-        GITHUB_TOKEN is not in the git-push credential path (#193 static
-        review verdict).  Adding contents: write at the job level would be
-        both unnecessary and a wider-than-needed token scope.
-        """
         job = deploy_workflow["jobs"]["rollback"]
-        job_perms = job.get("permissions", {})
-        # Guard both the shorthand string forms and the mapping form.
-        assert job_perms != "write-all", (
-            "rollback job must not use permissions: write-all — git ops run "
-            "on the SSH host, not the runner (issue #193)"
+        assert "steps" in job, (
+            "rollback is now an inline job, not a reusable-workflow call"
         )
+        joined = "\n".join(str(step) for step in job["steps"])
+        assert "deploy-latest-good" in joined
+        assert "git checkout" in joined
+        assert "make up" in joined
+
+    def test_rollback_never_pushes_git_state(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        """Rollback is read-only from git's perspective: it only fetches tags
+        and checks one out — no git push, no git revert, on the runner or the
+        host. This is what makes it immune to main's branch protection."""
+        joined = "\n".join(
+            str(step) for step in deploy_workflow["jobs"]["rollback"]["steps"]
+        )
+        assert "git push" not in joined
+        assert "git revert" not in joined
+
+    def test_rollback_does_not_grant_contents_write(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        """Rollback only reads tags over SSH on the host — no runner-side git
+        write ever happens, so the job token should be read-only."""
+        job_perms = deploy_workflow["jobs"]["rollback"].get("permissions", {})
+        assert job_perms != "write-all"
         if isinstance(job_perms, dict):
-            assert job_perms.get("contents") != "write", (
-                "rollback job must not grant contents: write — git ops run "
-                "on the SSH host, not the runner (issue #193)"
-            )
+            assert job_perms.get("contents") != "write"
+
+    def test_no_push_to_main_anywhere_in_deploy_workflow(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        """Core regression guard: nothing in this workflow pushes to main —
+        deploy and rollback both operate purely on tags."""
+        joined = "\n".join(str(job) for job in deploy_workflow["jobs"].values())
+        assert "push origin main" not in joined
+        assert "push origin HEAD:main" not in joined
 
     def test_rollback_has_no_local_checkout_step(
         self, deploy_workflow: dict[str, Any]


### PR DESCRIPTION
## Summary

Redesigns `deploy.yml`'s deploy/rollback mechanism to be tag-based instead of `git revert HEAD` + push-to-`main`. This resolves a real conflict introduced by the branch protection enabled on `main` earlier this session: the old rollback design pushed a revert directly to `main` from the SSH target host, which required-PR-review branch protection would now reject.

**New model:**
- `tag-candidate` job creates and pushes an immutable `deploy-<UTC-ts>-<sha>` tag pinned to the exact commit Acceptance Full just verified (a correctness improvement — the old design implicitly deployed "whatever `main` is now," which could have moved since the triggering run).
- Deploy jobs check out that tag on the host instead of `git pull origin main`.
- On successful `post-deploy-verify`, `deploy-latest-good` is force-pushed to the candidate SHA — so rollback always targets a *known-good* state, never a chain of possibly-bad deploys.
- `rollback` is now an inline job (dropped the `paruff/ufawkespipe/reusable-rollback.yml` delegation — single-consumer need, didn't want to change a shared workflow other repos may still use for the revert pattern). It checks out `deploy-latest-good` and runs `make up` — **no git push, no git revert, on the runner or the host.**

Net effect: neither deploy nor rollback ever touches `main`, so branch protection is structurally irrelevant to this pipeline now, not just statically argued to be fine.

Three commits, TDD order per AGENTS.md §6:
1. `test:` — failing tests for the new contract (RED)
2. `feat:` — `deploy.yml` implementation (GREEN)
3. `docs:` — `ROLLBACK_DRILL.md` and `DEPLOYMENT_STRATEGY.md` rewritten to match, including a real correction: the drill's own Step 2 used to push the bad commit directly to `main`, which branch protection now blocks too — it goes through a PR merge instead.

**Not included:** the actual live drill execution (LB-04/#182) — that still needs a real non-prod target host, which is being provisioned separately (OCI Compute sandbox).

## AI-Assisted Review Block

**What does this PR do?**
Replaces the revert-based deploy/rollback mechanism in `deploy.yml` with a tag-based one (`deploy-<ts>-<sha>` candidates, `deploy-latest-good` promoted only after health checks pass), and updates the two docs describing it. No behavior change to path detection, health verification, or environment-approval gating — only how the deployed ref is chosen and how rollback recovers.

**What could go wrong?**
- This has not been run against a real host yet — see "Not included" above. The static/unit-test coverage is thorough (19 tests in `test_deploy_pipeline.py`, including a direct regression guard that nothing in the workflow ever contains `push origin main`), but a live drill is still the real proof, same as before this PR.
- First-ever deploy after this merges has no prior `deploy-latest-good` tag — rollback would have nothing to check out. Documented as a known, accepted gap (not fixed here) since `main` is already healthy.
- Dropped the `reusable-rollback.yml` delegation to `ufawkespipe` — if another repo starts wanting this exact tag-based pattern later, it should probably become a second reusable workflow there rather than staying uFawkesObs-local; not done now per YAGNI.

**What tests cover this change?**
`tests/unit/test_deploy_pipeline.py::TestTagBasedDeployRollback` (9 tests: tag creation, deploy checkout, latest-good promotion, rollback wiring, permissions, and the core "never pushes to main" regression guard) and `tests/unit/test_deploy_docs.py::TestRollbackDrillTagBasedDesign` (3 tests). Full suite: 707/707 passing.

**Architecture check:**
- Only `.github/workflows/deploy.yml` (CI/CD pipeline config, explicitly gated behind sign-off per AGENTS.md §5 — this PR and the design discussion in #182 constitute that) and two docs touched.
- No cross-plane impact.

**What I was NOT sure about:**
Whether `post-deploy-verify` promoting `deploy-latest-good` should be a separate job instead of a step tacked onto verify — kept it as a step for now (smaller diff, verify already has the checkout-adjacent context), but a future refactor could split it out if verify's responsibilities grow.

## Test plan

- [x] `pytest tests/unit/` — 707/707 passing
- [x] `pre-commit run` — passed on all changed files
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Live drill against a real host — tracked separately under #182, pending OCI host provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)