### PR TITLE
fix(dora): dedupe event_queue writes on identical payload

### DIFF
--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -63,6 +63,28 @@ Also enable service-level auth where available (for example `auth_enabled: true`
 
 ---
 
+### No Authentication on DORA Ingestion API by Default
+
+**Limitation:** `dora-api`'s `/event` and `/event/batch` endpoints only enforce
+the `Authorization: Bearer <DORA_API_KEY>` header when `DORA_API_KEY` is set in
+`.env` — unset (the default) leaves ingestion open to anything that can reach
+`http://localhost:8088` (see `dora/ingestion/api/auth.py`). Mitigated by the
+same localhost-only binding as the other backends (`127.0.0.1:8088:8088` in
+`compose.yaml`), but it's a real gap if that port is ever re-exposed the way
+the section above describes for Loki/Tempo/Prometheus/Alertmanager.
+
+**Impact:** On a shared host, or if the port is re-exposed, anyone who can
+reach it can submit fabricated deployment/incident/PR/rework events, skewing
+DORA metrics.
+
+**Workaround / Opt-out path:** Set `DORA_API_KEY` in `.env` — it's supported
+today, just not required. There is no fail-fast check enforcing it (unlike
+`GRAFANA_ADMIN_PASSWORD`, which `scripts/check-env.sh` refuses to start
+without); making it required-by-default would be a breaking change for
+existing deployments and hasn't been made yet.
+
+---
+
 ## Data Storage
 
 ### Local Filesystem Storage Only

--- a/dora/database/migrations/004-add-payload-hash-idempotency.sql
+++ b/dora/database/migrations/004-add-payload-hash-idempotency.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- Migration 004: Add payload_hash idempotency key to event_queue
+-- ----------------------------------------------------------------------------
+-- event_queue had no dedup key, so a retried webhook/API submission (client
+-- timeout, network retry — same payload resent) inserted a second row and
+-- silently double-counted DORA metrics downstream. Adds a SHA-256 hash of
+-- the canonical payload as a partial unique index (NULL-safe for any rows
+-- written before this migration) so enqueue_event can detect and no-op on
+-- an exact-duplicate resubmission instead of enqueueing it again.
+-- (production-audit finding, 2026-08-21)
+-- ============================================================================
+
+ALTER TABLE event_queue
+    ADD COLUMN IF NOT EXISTS payload_hash VARCHAR(64);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_event_queue_payload_hash
+    ON event_queue (payload_hash)
+    WHERE payload_hash IS NOT NULL;
+
+-- Record this migration
+INSERT INTO _schema_migrations (version, description, checksum)
+VALUES (
+    4,
+    'Add payload_hash idempotency key to event_queue',
+    'sha256-004-add-payload-hash-idempotency'
+)
+ON CONFLICT (version) DO NOTHING;

--- a/dora/ingestion/api/idempotency.py
+++ b/dora/ingestion/api/idempotency.py
@@ -1,0 +1,20 @@
+"""Shared idempotency-key computation for event_queue writes.
+
+Used by both queue_sqlite.py and queue_postgres.py so a retried submission
+hashes identically regardless of backend — the whole point is that a client
+retry (same payload, resent after a timeout) dedupes instead of
+double-counting DORA metrics.
+"""
+
+import hashlib
+import json
+
+
+def payload_hash(payload: dict) -> str:
+    """Return a stable SHA-256 hex digest of a validated event payload.
+
+    Uses a canonical JSON encoding (sorted keys, no whitespace) so the same
+    logical payload always hashes the same way regardless of field order.
+    """
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/dora/ingestion/api/queue_postgres.py
+++ b/dora/ingestion/api/queue_postgres.py
@@ -10,6 +10,8 @@ import json
 
 import asyncpg
 
+from .idempotency import payload_hash as _payload_hash
+
 # ── Connection pool ────────────────────────────────────────────────────────────
 
 _pool: asyncpg.Pool | None = None
@@ -50,38 +52,50 @@ async def close_pool():
 async def enqueue_event(payload: dict) -> int:
     """Insert an event into the event_queue and return its id.
 
+    Idempotent: a payload identical to one already enqueued returns the
+    existing row's id instead of inserting a duplicate (production-audit
+    finding — a client retry must not double-count DORA metrics). The
+    ``DO UPDATE ... EXCLUDED`` no-op is a standard Postgres upsert idiom to
+    still get ``RETURNING id`` back on a conflict, which plain
+    ``DO NOTHING`` would not return.
+
     Args:
         payload: The validated event payload (dict).
 
     Returns:
-        The id of the newly inserted event_queue row.
+        The id of the newly inserted (or pre-existing, deduped) row.
     """
     pool = await get_pool()
     event_type: str = payload.get("event_type", "unknown")
     source: str = payload.get("repo", "unknown")
+    p_hash = _payload_hash(payload)
 
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            INSERT INTO event_queue (event_type, source, payload)
-            VALUES ($1, $2, $3::jsonb)
+            INSERT INTO event_queue (event_type, source, payload, payload_hash)
+            VALUES ($1, $2, $3::jsonb, $4)
+            ON CONFLICT (payload_hash) DO UPDATE
+                SET payload_hash = EXCLUDED.payload_hash
             RETURNING id
             """,
             event_type,
             source,
             json.dumps(payload),
+            p_hash,
         )
         return row["id"]
 
 
 async def enqueue_events(payloads: list[dict]) -> list[int]:
-    """Insert multiple events in a single transaction.
+    """Insert multiple events in a single transaction, deduping each against
+    payload_hash the same way enqueue_event does.
 
     Args:
         payloads: List of validated event payloads.
 
     Returns:
-        List of ids for the newly inserted rows.
+        List of ids for the newly inserted (or pre-existing, deduped) rows.
     """
     pool = await get_pool()
     ids: list[int] = []
@@ -90,15 +104,19 @@ async def enqueue_events(payloads: list[dict]) -> list[int]:
         for payload in payloads:
             event_type: str = payload.get("event_type", "unknown")
             source: str = payload.get("repo", "unknown")
+            p_hash = _payload_hash(payload)
             row = await conn.fetchrow(
                 """
-                    INSERT INTO event_queue (event_type, source, payload)
-                    VALUES ($1, $2, $3::jsonb)
+                    INSERT INTO event_queue (event_type, source, payload, payload_hash)
+                    VALUES ($1, $2, $3::jsonb, $4)
+                    ON CONFLICT (payload_hash) DO UPDATE
+                        SET payload_hash = EXCLUDED.payload_hash
                     RETURNING id
                     """,
                 event_type,
                 source,
                 json.dumps(payload),
+                p_hash,
             )
             ids.append(row["id"])
 

--- a/dora/ingestion/api/queue_sqlite.py
+++ b/dora/ingestion/api/queue_sqlite.py
@@ -14,12 +14,15 @@ from contextlib import asynccontextmanager
 
 import aiosqlite
 
+from .idempotency import payload_hash as _payload_hash
+
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS event_queue (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     event_type      TEXT    NOT NULL,
     source          TEXT    NOT NULL,
     payload         TEXT    NOT NULL,
+    payload_hash    TEXT,
     status          TEXT    NOT NULL DEFAULT 'pending',
     attempts        INTEGER NOT NULL DEFAULT 0,
     received_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -81,7 +84,34 @@ async def get_pool(
         _pool = await aiosqlite.connect(_sqlite_path(dsn))
         await _pool.executescript(_SCHEMA)
         await _pool.commit()
+        await _ensure_payload_hash_column(_pool)
     return _pool
+
+
+async def _ensure_payload_hash_column(conn: aiosqlite.Connection) -> None:
+    """Add payload_hash to event_queue if this database predates it, and
+    ensure its unique index exists either way.
+
+    ``CREATE TABLE IF NOT EXISTS`` in _SCHEMA only applies to brand-new
+    databases — an existing event_queue table (e.g. one already running the
+    dora profile before this fix) never gets the column added just by
+    changing the schema string. The index can't live in _SCHEMA's
+    executescript either: on a legacy database that script would try to
+    index a column that doesn't exist yet, failing before this function
+    ever runs. So both column and index are created here, unconditionally
+    safe to re-run (IF NOT EXISTS / column-presence check) on every
+    connect. Existing rows get payload_hash = NULL, which the partial
+    unique index excludes, so nothing conflicts.
+    """
+    cursor = await conn.execute("PRAGMA table_info(event_queue)")
+    columns = {row[1] for row in await cursor.fetchall()}
+    if "payload_hash" not in columns:
+        await conn.execute("ALTER TABLE event_queue ADD COLUMN payload_hash TEXT")
+    await conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_event_queue_payload_hash "
+        "ON event_queue (payload_hash) WHERE payload_hash IS NOT NULL"
+    )
+    await conn.commit()
 
 
 async def close_pool():
@@ -108,33 +138,60 @@ async def _connect():
 
 
 async def enqueue_event(payload: dict) -> int:
-    """Insert an event into the event_queue and return its id."""
+    """Insert an event into the event_queue and return its id.
+
+    Idempotent: a payload identical to one already enqueued returns the
+    existing row's id instead of inserting a duplicate (production-audit
+    finding — a client retry must not double-count DORA metrics).
+    """
     event_type: str = payload.get("event_type", "unknown")
     source: str = payload.get("repo", "unknown")
+    p_hash = _payload_hash(payload)
 
     async with _connect() as conn:
         cursor = await conn.execute(
-            "INSERT INTO event_queue (event_type, source, payload) VALUES (?, ?, ?)",
-            (event_type, source, json.dumps(payload)),
+            "INSERT INTO event_queue (event_type, source, payload, payload_hash) "
+            "VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(payload_hash) WHERE payload_hash IS NOT NULL DO NOTHING",
+            (event_type, source, json.dumps(payload), p_hash),
         )
+        if cursor.rowcount == 0:
+            row = await (
+                await conn.execute(
+                    "SELECT id FROM event_queue WHERE payload_hash = ?", (p_hash,)
+                )
+            ).fetchone()
+            return row[0]
         return cursor.lastrowid
 
 
 async def enqueue_events(payloads: list[dict]) -> list[int]:
-    """Insert multiple events. SQLite has no cross-statement RETURNING, so
-    ids are read back from lastrowid, which is safe here since writes are
+    """Insert multiple events, deduping each against payload_hash the same
+    way enqueue_event does. SQLite has no cross-statement RETURNING, so ids
+    are read back from lastrowid, which is safe here since writes are
     serialized through the single shared connection."""
     ids: list[int] = []
     async with _connect() as conn:
         for payload in payloads:
             event_type: str = payload.get("event_type", "unknown")
             source: str = payload.get("repo", "unknown")
+            p_hash = _payload_hash(payload)
             cursor = await conn.execute(
-                "INSERT INTO event_queue (event_type, source, payload) "
-                "VALUES (?, ?, ?)",
-                (event_type, source, json.dumps(payload)),
+                "INSERT INTO event_queue (event_type, source, payload, payload_hash) "
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(payload_hash) WHERE payload_hash IS NOT NULL DO NOTHING",
+                (event_type, source, json.dumps(payload), p_hash),
             )
-            ids.append(cursor.lastrowid)
+            if cursor.rowcount == 0:
+                row = await (
+                    await conn.execute(
+                        "SELECT id FROM event_queue WHERE payload_hash = ?",
+                        (p_hash,),
+                    )
+                ).fetchone()
+                ids.append(row[0])
+            else:
+                ids.append(cursor.lastrowid)
     return ids
 
 

--- a/tests/unit/test_dora_queue_postgres.py
+++ b/tests/unit/test_dora_queue_postgres.py
@@ -174,6 +174,27 @@ class TestEnqueueEvent:
         assert event_id == 42
         mock_conn.fetchrow.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_enqueue_event_uses_payload_hash_conflict_upsert(self):
+        """Production-audit finding: retried submissions must dedupe via
+        payload_hash instead of inserting a duplicate row."""
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value={"id": 7})
+
+        mock_pool = MagicMock()
+        mock_pool.is_closing.return_value = False
+        mock_pool.acquire.return_value = _mock_async_context_manager(mock_conn)
+
+        import dora.ingestion.api.queue_postgres as q
+
+        q._pool = mock_pool
+
+        await enqueue_event({"event_type": "deployment", "repo": "myapp"})
+
+        query = mock_conn.fetchrow.await_args.args[0]
+        assert "payload_hash" in query
+        assert "ON CONFLICT" in query
+
 
 class TestEnqueueEvents:
     """Cover enqueue_events()."""

--- a/tests/unit/test_dora_queue_sqlite.py
+++ b/tests/unit/test_dora_queue_sqlite.py
@@ -8,8 +8,10 @@ per test — see queue_sqlite.get_pool(dsn=...).
 
 import json
 import sys
+import tempfile
 from pathlib import Path
 
+import aiosqlite
 import pytest
 import pytest_asyncio
 
@@ -34,14 +36,40 @@ async def _conn():
 async def test_enqueue_event_returns_incrementing_id():
     await _conn()
     first_id = await queue.enqueue_event({"event_type": "deployment", "repo": "a"})
-    second_id = await queue.enqueue_event({"event_type": "deployment", "repo": "a"})
+    second_id = await queue.enqueue_event({"event_type": "deployment", "repo": "b"})
     assert second_id == first_id + 1
+
+
+async def test_enqueue_event_is_idempotent_for_identical_payload():
+    """A resent (retried) payload must not double-enqueue (production-audit
+    finding: event_queue had no dedup key, so a client retry silently
+    double-counted DORA metrics)."""
+    await _conn()
+    payload = {"event_type": "deployment", "repo": "a", "commit_sha": "x" * 40}
+
+    first_id = await queue.enqueue_event(payload)
+    second_id = await queue.enqueue_event(payload)
+
+    assert second_id == first_id
+    assert await queue.get_queue_depth() == 1
+
+
+async def test_enqueue_event_distinguishes_different_payloads_with_same_repo():
+    await _conn()
+    first_id = await queue.enqueue_event(
+        {"event_type": "deployment", "repo": "a", "commit_sha": "a" * 40}
+    )
+    second_id = await queue.enqueue_event(
+        {"event_type": "deployment", "repo": "a", "commit_sha": "b" * 40}
+    )
+    assert second_id != first_id
+    assert await queue.get_queue_depth() == 2
 
 
 async def test_get_queue_depth_counts_only_pending():
     await _conn()
     await queue.enqueue_event({"event_type": "deployment", "repo": "a"})
-    await queue.enqueue_event({"event_type": "deployment", "repo": "a"})
+    await queue.enqueue_event({"event_type": "deployment", "repo": "b"})
     assert await queue.get_queue_depth() == 2
 
 
@@ -144,3 +172,49 @@ async def test_enqueue_events_batch_inserts_all_and_returns_ids():
     )
     assert len(ids) == 2
     assert await queue.get_queue_depth() == 2
+
+
+async def test_get_pool_adds_payload_hash_to_pre_existing_database():
+    """Regression guard: a database created before the idempotency fix (no
+    payload_hash column) must self-heal on next connect, not break enqueue.
+
+    Discovered live against the real dora-api SQLite file, which had been
+    running for two days before this fix and had no payload_hash column —
+    CREATE TABLE IF NOT EXISTS alone does not add it to an existing table.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "legacy.db"
+
+        # Simulate the pre-fix schema: event_queue with no payload_hash column.
+        legacy_conn = await aiosqlite.connect(str(db_path))
+        await legacy_conn.executescript(
+            """
+            CREATE TABLE event_queue (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type      TEXT    NOT NULL,
+                source          TEXT    NOT NULL,
+                payload         TEXT    NOT NULL,
+                status          TEXT    NOT NULL DEFAULT 'pending',
+                attempts        INTEGER NOT NULL DEFAULT 0,
+                received_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                processed_at    TIMESTAMP
+            );
+            """
+        )
+        await legacy_conn.execute(
+            "INSERT INTO event_queue (event_type, source, payload) "
+            "VALUES ('deployment', 'a', '{}')"
+        )
+        await legacy_conn.commit()
+        await legacy_conn.close()
+
+        # Reconnect via the real get_pool() — this must self-heal the schema.
+        await queue.get_pool(dsn=f"sqlite:///{db_path}")
+
+        # Old row survives, untouched, with payload_hash = NULL.
+        assert await queue.get_queue_depth() == 1
+
+        # New enqueue must work against the now-healed schema.
+        new_id = await queue.enqueue_event({"event_type": "deployment", "repo": "b"})
+        assert new_id == 2
+        assert await queue.get_queue_depth() == 2


### PR DESCRIPTION
## Summary

Resolves the DORA ingestion idempotency gap flagged in the 2026-08-21 production audit ("High-value fixes"): `event_queue` had no dedup key, so a retried client submission (network timeout, resend) silently double-counted DORA metrics.

Adds a SHA-256 hash of the canonical payload (`payload_hash`) with a partial unique index (NULL-safe for pre-existing rows) to both backends:

- **SQLite** (`queue_sqlite.py`): `INSERT ... ON CONFLICT(payload_hash) WHERE payload_hash IS NOT NULL DO NOTHING`, falling back to a `SELECT` for the existing row's id on conflict.
- **Postgres** (`queue_postgres.py`): `INSERT ... ON CONFLICT (payload_hash) DO UPDATE SET payload_hash = EXCLUDED.payload_hash` — the standard idiom to still get `RETURNING id` on a conflict.
- New migration `dora/database/migrations/004-add-payload-hash-idempotency.sql` for the Postgres/resource-plane backend.

**A real bug caught by live verification, not just unit tests:** `get_pool()` now self-heals pre-existing SQLite databases that predate this column — `CREATE TABLE IF NOT EXISTS` alone doesn't add a column to an existing table. I found this by rebuilding and restarting the actual local `dora-api` container against its real 2-day-old database (backed up first) rather than trusting only the in-memory-SQLite unit tests, which always start fresh and would never have caught it. Also live-verified the actual fix: posting an identical event twice through the real running API returned the same `id` both times and only enqueued one row; a genuinely different payload still enqueued normally. Test data cleaned up from the live database afterward.

Also documents the related, deliberately-*unfixed* gap in `docs/KNOWN_LIMITATIONS.md`: `DORA_API_KEY` auth is optional by default (mitigated by the existing `127.0.0.1`-only port binding on `dora-api`). Making it required-by-default would be a breaking change for existing deployments — flagged, not silently changed.

## AI-Assisted Review Block

**What does this PR do?**
Adds an idempotency key to DORA event ingestion so retried/duplicate submissions don't double-count metrics, across both the SQLite (self-contained `dora` profile) and Postgres (resource-plane) backends, plus a migration and a self-healing schema check for databases that predate this change.

**What could go wrong?**
- The dedup key is an exact-payload hash — it catches true duplicate resubmissions (the common retry case) but won't catch two *semantically* identical events with a differing timestamp or other field. That's a deliberate, documented scope limit, not a bug.
- SQLite's `ON CONFLICT` target had to exactly match the partial index's `WHERE` predicate or SQLite rejects the query outright — caught this during implementation via the unit tests, fixed before it ever reached the live container.
- Live-tested the schema self-heal against a real, currently-in-use database (backed up first, restored to its exact prior row count afterward) rather than only a synthetic fixture.

**What tests cover this change?**
`tests/unit/test_dora_queue_sqlite.py` (idempotent-enqueue, distinct-payloads-still-separate, and a dedicated legacy-database migration regression test using a real temp SQLite file, not `:memory:`) and `tests/unit/test_dora_queue_postgres.py` (asserts the new query shape via the existing asyncpg-mock pattern). Two pre-existing tests that submitted the identical payload twice and expected two separate rows were updated to use distinct payloads, since that assumption is exactly what this PR intentionally changes. Full suite: 708/708 passing.

**Architecture check:**
- Only `dora/ingestion/api/` (application layer) and `dora/database/migrations/` (Postgres schema) touched — no cross-plane impact, no compose.yaml changes.
- Config/data layer per AGENTS.md §4: migration is additive and backward-compatible (nullable column, partial index), no destructive changes.

**What I was NOT sure about:**
Whether to also make `DORA_API_KEY` required-by-default while I was in this area — decided against it (documented in KNOWN_LIMITATIONS.md instead) since it's a breaking behavior change for existing deployments that deserves its own explicit decision, not a drive-by default flip bundled into an idempotency fix.

## Test plan

- [x] `pytest tests/unit/` — 708/708 passing
- [x] `pre-commit run` — passed on all changed files
- [x] Live-verified against the real running `dora-api` container: rebuilt image, restarted service, confirmed schema self-heal on the real (backed-up) database, POSTed an identical event twice via curl and confirmed single enqueue + same `id`, POSTed a distinct event and confirmed normal separate enqueue, cleaned up test rows and restored the database to its exact prior row count

🤖 Generated with [Claude Code](https://claude.com/claude-code)